### PR TITLE
feat(wam): add all remaining WAM installation and dashboard photos

### DIFF
--- a/docs/DAILY-LOG.md
+++ b/docs/DAILY-LOG.md
@@ -1,11 +1,55 @@
 # BAPI Headless Development Log
 
+## January 26, 2026 - Phase 14B: Add Remaining WAM Installation Photos 🏪
+
+### Phase 14B: Complete WAM Photo Gallery - **IN PROGRESS** 🚧
+
+**Branch:** `feat/phase14b-wam-remaining-photos`  
+**Goal:** Add all remaining WAM installation and dashboard images to `/wam` page  
+**Time Actual:** TBD
+
+**User Request:** "Proceed with 14 b"
+
+**Images Added:**
+- **Walk-In Coolers:** +3 images (now 7 total displayed)
+  - Cooler_Case_1.webp, Cooler_Slim_2.webp, Cooler_Slim_3.webp
+  
+- **Walk-In Freezers:** +5 images (now 13 total displayed)
+  - Freezer_Buffer_2.webp, Freezer_Door_3.webp, Freezer_Slim_3.webp
+  - Freezer_Slim_5.webp, Freezer_Buffer_2_Edited.webp
+  
+- **Deli Cases & Prepared Foods:** +2 images (now 5 total displayed)
+  - Deli_Cases_All_2.webp, Deli_Cases_All_3.webp
+  
+- **Convenience Stores & Mini-Marts:** +5 images (now 9 total displayed)
+  - Mini-Mart_Overhead_2.webp, Mini-Mart_Overhead_3.webp
+  - DoorSwitch_1_Blue.webp, DoorSwitch_2.webp, DoorSwitch_3.webp
+  
+- **WAM Dashboards:** +4 images (now 7 total displayed)
+  - WAM_Graphic2.webp, WAM_Graphic3.webp
+  - Trays_2.webp, Serving_Tray_Trend2.webp
+
+**Total Images on /wam Page:**
+- Phase 14A: 22 images (19 installations + 3 dashboards)
+- Phase 14B: +19 images (15 installations + 4 dashboards)
+- **Grand Total: 41 images** (all available WAM photos from Phase 13B)
+
+**Build Status:** ✅ Passing (Next.js 16.1.2, compiled in 3.5s, 62/62 pages generated)
+
+**Remaining Tasks:**
+- [ ] Commit changes
+- [ ] Push branch and create PR
+- [ ] Staging review
+- [ ] Merge and deploy to production
+
+---
+
 ## January 26, 2026 - Phase 14A: Complete WAM Product Pages 🏪
 
-### Phase 14A: WAM Product Page Enhancement - **85% COMPLETE** ✅
+### Phase 14A: WAM Product Page Enhancement - **COMPLETE** ✅
 
-**Branch:** `feat/phase14a-wam-product-pages`  
-**Goal:** Complete WAM product page with remaining installation photos, dashboards, and real-world use cases  
+**Branch:** `feat/phase14a-wam-product-pages` (merged to main)  
+**Goal:** Complete WAM product page with installation photos, dashboards, and real-world use cases  
 **Time Actual:** 1.5 hours (gallery + dashboard showcase)
 
 **User Request:** "Proceed with Phase 14a"

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -2,7 +2,19 @@
 
 ## 🔄 In Progress
 
-### Phase 14A: Complete WAM Product Pages (Jan 26, 2026) ✅ 85% COMPLETE
+### Phase 14B: Add Remaining WAM Installation Photos (Jan 26, 2026) 🚧 IN PROGRESS
+- [x] Create feature branch `feat/phase14b-wam-remaining-photos`
+- [x] Add remaining cooler images (3 more - now 7 total displayed)
+- [x] Add remaining freezer images (5 more - now 13 total displayed)
+- [x] Add remaining deli case images (2 more - now 5 total displayed)
+- [x] Add remaining convenience store images (5 more - now 9 total displayed)
+- [x] Add remaining WAM dashboard images (4 more - now 7 total displayed)
+- [x] Test build with all 41 images (build passing)
+- [ ] Commit changes to feature branch
+- [ ] Push branch and create PR
+- [ ] Merge to main and deploy to production
+
+### Phase 14A: Complete WAM Product Pages (Jan 26, 2026) ✅ **COMPLETE**
 - [x] Review existing `/wam` page structure
 - [x] Create WAM installations gallery section with 19 photos (coolers, freezers, deli, convenience)
 - [x] Add software dashboard screenshots (3 primary dashboards)
@@ -10,9 +22,8 @@
 - [x] All images already optimized to WebP format (Phase 13B)
 - [x] Test responsive design and image loading (build passing)
 - [x] Commit initial work to feature branch `feat/phase14a-wam-product-pages`
-- [ ] Push branch and create PR
-- [ ] Merge to main and deploy to production
-- [ ] Optional future: Hero background image, use cases section, testimonials
+- [x] Push branch and create PR
+- [x] Merge to main and deploy to production
 
 ### Phase 13B: WAM Retail Installation Images (Jan 26, 2026) ✅ **COMPLETE**
 - [x] Extract 41 WAM convenience store installation images

--- a/web/src/app/wam/page.tsx
+++ b/web/src/app/wam/page.tsx
@@ -426,6 +426,21 @@ export default function WAMPage() {
                   alt: 'Multi-zone cooler monitoring',
                   title: 'Multi-Zone Monitoring',
                 },
+                {
+                  src: '/images/applications/retail/coolers/Cooler_Case_1.webp',
+                  alt: 'Cooler case temperature monitoring',
+                  title: 'Display Case Monitoring',
+                },
+                {
+                  src: '/images/applications/retail/coolers/Cooler_Slim_2.webp',
+                  alt: 'Slim profile cooler sensor',
+                  title: 'Slim Profile Installation',
+                },
+                {
+                  src: '/images/applications/retail/coolers/Cooler_Slim_3.webp',
+                  alt: 'Compact cooler sensor installation',
+                  title: 'Compact Installation',
+                },
               ].map((image, idx) => (
                 <div
                   key={idx}
@@ -502,6 +517,31 @@ export default function WAMPage() {
                   alt: 'Freezer slim sensor placement',
                   title: 'Space-Saving Sensors',
                 },
+                {
+                  src: '/images/applications/retail/freezers/Freezer_Buffer_2.webp',
+                  alt: 'Freezer buffer area sensor',
+                  title: 'Additional Buffer Zone',
+                },
+                {
+                  src: '/images/applications/retail/freezers/Freezer_Door_3.webp',
+                  alt: 'Freezer door sensor configuration',
+                  title: 'Door Sensor Configuration',
+                },
+                {
+                  src: '/images/applications/retail/freezers/Freezer_Slim_3.webp',
+                  alt: 'Slim profile freezer sensor',
+                  title: 'Low-Profile Installation',
+                },
+                {
+                  src: '/images/applications/retail/freezers/Freezer_Slim_5.webp',
+                  alt: 'Freezer slim sensor variant',
+                  title: 'Flexible Sensor Placement',
+                },
+                {
+                  src: '/images/applications/retail/freezers/Freezer_Buffer_2_Edited.webp',
+                  alt: 'Freezer buffer monitoring system',
+                  title: 'Complete Buffer System',
+                },
               ].map((image, idx) => (
                 <div
                   key={idx}
@@ -552,6 +592,16 @@ export default function WAMPage() {
                   src: '/images/applications/retail/deli-cases/Deli_Case_1.webp',
                   alt: 'Single deli case sensor',
                   title: 'Individual Case Monitoring',
+                },
+                {
+                  src: '/images/applications/retail/deli-cases/Deli_Cases_All_2.webp',
+                  alt: 'Deli display case monitoring',
+                  title: 'Display Case Array',
+                },
+                {
+                  src: '/images/applications/retail/deli-cases/Deli_Cases_All_3.webp',
+                  alt: 'Prepared foods temperature control',
+                  title: 'Prepared Foods Safety',
                 },
               ].map((image, idx) => (
                 <div
@@ -608,6 +658,31 @@ export default function WAMPage() {
                   src: '/images/applications/retail/convenience/Mini-Mart_Overhead_1.webp',
                   alt: 'Mini-mart sensor deployment',
                   title: 'Multi-Zone Store Monitoring',
+                },
+                {
+                  src: '/images/applications/retail/convenience/Mini-Mart_Overhead_2.webp',
+                  alt: 'Convenience store overhead view',
+                  title: 'Comprehensive Coverage',
+                },
+                {
+                  src: '/images/applications/retail/convenience/Mini-Mart_Overhead_3.webp',
+                  alt: 'Mini-mart temperature zones',
+                  title: 'Zone-Based Monitoring',
+                },
+                {
+                  src: '/images/applications/retail/convenience/DoorSwitch_1_Blue.webp',
+                  alt: 'Blue door sensor installation',
+                  title: 'Door Alert System',
+                },
+                {
+                  src: '/images/applications/retail/convenience/DoorSwitch_2.webp',
+                  alt: 'Door switch variant installation',
+                  title: 'Alternate Door Sensor',
+                },
+                {
+                  src: '/images/applications/retail/convenience/DoorSwitch_3.webp',
+                  alt: 'Door monitoring configuration',
+                  title: 'Advanced Door Control',
                 },
               ].map((image, idx) => (
                 <div
@@ -679,6 +754,30 @@ export default function WAMPage() {
                 alt: 'Temperature trend graph',
                 title: 'Historical Trending',
                 description: 'Analyze patterns and prove compliance with detailed reports',
+              },
+              {
+                src: '/images/wam/dashboards/WAM_Graphic2.webp',
+                alt: 'WAM system overview dashboard',
+                title: 'System Overview',
+                description: 'Monitor entire facility status from a single screen',
+              },
+              {
+                src: '/images/wam/dashboards/WAM_Graphic3.webp',
+                alt: 'WAM alert management interface',
+                title: 'Alert Management',
+                description: 'Configure and manage temperature alerts and notifications',
+              },
+              {
+                src: '/images/wam/dashboards/Trays_2.webp',
+                alt: 'Multiple serving tray monitoring',
+                title: 'Zone Comparison',
+                description: 'Compare temperatures across different zones or assets',
+              },
+              {
+                src: '/images/wam/dashboards/Serving_Tray_Trend2.webp',
+                alt: 'Extended temperature trend analysis',
+                title: 'Long-Term Trends',
+                description: 'Track performance over days, weeks, or months',
               },
             ].map((dashboard, idx) => (
               <div


### PR DESCRIPTION
- Walk-In Coolers: +3 images (now 7 total)
- Walk-In Freezers: +5 images (now 13 total)
- Deli Cases: +2 images (now 5 total)
- Convenience Stores: +5 images (now 9 total)
- WAM Dashboards: +4 images (now 7 total)

Total: 41 images displayed on /wam page (all available from Phase 13B) All images already WebP optimized (94.2% savings)
Build tested and passing (Next.js 16.1.2)