### PR TITLE
fix: optimize layout and text sizes for large screens

### DIFF
--- a/web/src/app/[locale]/contact/page.tsx
+++ b/web/src/app/[locale]/contact/page.tsx
@@ -269,7 +269,7 @@ export default function ContactPage() {
     <div className="min-h-screen bg-neutral-50">
       {/* Hero Section */}
       <section className="bg-gradient-to-br from-primary-700 via-primary-600 to-primary-500 text-white py-12 lg:py-16">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center">
             <h1 className="text-3xl lg:text-4xl font-bold mb-3">Contact Us</h1>
             <p className="text-lg text-primary-50 max-w-2xl mx-auto">
@@ -281,7 +281,7 @@ export default function ContactPage() {
 
       {/* Contact Form + Info Section */}
       <section className="py-12 lg:py-16 bg-neutral-50">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid lg:grid-cols-3 gap-8">
             {/* Contact Form */}
             <div className="lg:col-span-2">
@@ -467,7 +467,7 @@ export default function ContactPage() {
 
       {/* Sales Team Section */}
       <section className="py-12 lg:py-16 bg-white">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-10">
             <h2 className="text-2xl lg:text-3xl font-bold text-neutral-900 mb-2">
               Meet Our Global Sales Team
@@ -973,7 +973,7 @@ export default function ContactPage() {
 
       {/* Map Section */}
       <section className="py-12 lg:py-16 bg-neutral-50">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-8">
             <h2 className="text-2xl font-bold text-neutral-900 mb-2">Visit Our Facility</h2>
             <p className="text-base text-neutral-600">

--- a/web/src/app/[locale]/page.tsx
+++ b/web/src/app/[locale]/page.tsx
@@ -30,7 +30,7 @@ export default function Home() {
 
       {/* Quick Stats Bar */}
       <section className="bg-neutral-50 py-12 lg:py-16">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="relative bg-gradient-to-br from-primary-600 via-primary-500 to-primary-600 rounded-2xl p-8 shadow-2xl overflow-hidden">
             {/* Decorative background elements */}
             <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAiIGhlaWdodD0iNjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGRlZnM+PHBhdHRlcm4gaWQ9ImdyaWQiIHdpZHRoPSI2MCIgaGVpZ2h0PSI2MCIgcGF0dGVyblVuaXRzPSJ1c2VyU3BhY2VPblVzZSI+PHBhdGggZD0iTSAxMCAwIEwgMCAwIDAgMTAiIGZpbGw9Im5vbmUiIHN0cm9rZT0id2hpdGUiIHN0cm9rZS13aWR0aD0iMC41IiBvcGFjaXR5PSIwLjEiLz48L3BhdHRlcm4+PC9kZWZzPjxyZWN0IHdpZHRoPSIxMDAlIiBoZWlnaHQ9IjEwMCUiIGZpbGw9InVybCgjZ3JpZCkiLz48L3N2Zz4=')] opacity-20"></div>
@@ -86,7 +86,7 @@ export default function Home() {
 
       {/* Browse by Industry - 8 Industries */}
       <section className="bg-white py-12 lg:py-16">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-10">
             <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
               Innovative sensor solutions for the global market
@@ -193,7 +193,7 @@ export default function Home() {
 
       {/* Featured Products Section */}
       <section className="bg-neutral-50 py-12 lg:py-16">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-10">
             <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
               Popular Products
@@ -291,7 +291,7 @@ export default function Home() {
 
       {/* Why BAPI - 3 Key Differentiators */}
       <section className="bg-white py-12 lg:py-16">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-10">
             <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
               Why Choose BAPI?
@@ -355,7 +355,7 @@ export default function Home() {
 
       {/* Final CTA - Single Focus on Product Discovery */}
       <section className="bg-primary-500 py-12 lg:py-16">
-        <div className="max-w-content mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl lg:text-4xl font-bold text-white mb-4">
             Ready to Find Your Solution?
           </h2>

--- a/web/src/components/Hero/components/HeroContent.tsx
+++ b/web/src/components/Hero/components/HeroContent.tsx
@@ -9,19 +9,19 @@ interface HeroContentProps {
 
 const HeroContent: React.FC<HeroContentProps> = ({ title, subtitle, description }) => (
   <div className="text-center max-w-6xl mx-auto mb-14">
-    <h1 className="text-5xl sm:text-6xl lg:text-7xl xl:text-8xl font-extrabold text-gray-900 mb-10 leading-[1.1] tracking-tight animate-in fade-in slide-in-from-bottom-4 duration-700">
+    <h1 className="text-5xl sm:text-6xl lg:text-7xl font-extrabold text-gray-900 mb-10 leading-[1.1] tracking-tight animate-in fade-in slide-in-from-bottom-4 duration-700">
       {title}
     </h1>
     
     {/* Dynamic Tagline Rotator - back with style */}
     <div className="inline-block mb-12 animate-in fade-in slide-in-from-bottom-4 duration-700 delay-150">
-      <div className="text-3xl sm:text-4xl lg:text-5xl font-extrabold bg-gradient-to-r from-primary-700 via-primary-500 to-primary-700 bg-clip-text text-transparent mb-6 pb-2 px-4">
+      <div className="text-3xl sm:text-4xl lg:text-5xl max-w-4xl mx-auto font-extrabold bg-gradient-to-r from-primary-700 via-primary-500 to-primary-700 bg-clip-text text-transparent mb-6 pb-2 px-4">
         <TaglineRotator />
       </div>
       <div className="h-2 w-4/5 mx-auto bg-gradient-to-r from-transparent via-accent-500 to-transparent rounded-full shadow-lg shadow-accent-500/50" />
     </div>
     
-    <p className="text-xl sm:text-2xl lg:text-2xl text-gray-600 max-w-4xl mx-auto leading-relaxed font-normal mb-4 animate-in fade-in slide-in-from-bottom-4 duration-700 delay-300">
+    <p className="text-xl sm:text-2xl text-gray-600 max-w-3xl mx-auto leading-relaxed font-normal mb-4 animate-in fade-in slide-in-from-bottom-4 duration-700 delay-300">
       {description}
     </p>
   </div>

--- a/web/src/components/Hero/index.tsx
+++ b/web/src/components/Hero/index.tsx
@@ -91,13 +91,13 @@ export const Hero: React.FC<HeroProps> = ({ className }) => {
             <img
               src="/images/products/families/BAPI_Full_Family_11K_Wide_2025_noWAM_US.webp"
               alt="BAPI 2025 Complete Product Family - Temperature, Humidity, Pressure, Air Quality Sensors"
-              className="relative w-full h-auto rounded-xl shadow-lg"
+              className="relative w-full h-auto rounded-xl shadow-lg max-w-5xl mx-auto"
               loading="eager"
             />
             
             {/* Product family caption */}
-            <div className="mt-6 text-center">
-              <p className="text-base lg:text-lg font-bold text-neutral-900 tracking-wide">
+            <div className="mt-6 text-center max-w-3xl mx-auto">
+              <p className="text-base font-bold text-neutral-900 tracking-wide">
                 Complete sensor solutions for building automation systems
               </p>
               <p className="text-sm text-neutral-600 mt-2 font-medium">

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -83,7 +83,7 @@ const Footer: React.FC = () => {
     {/* Gradient Accent Line */}
     <div className="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-primary-500 via-accent-500 to-primary-500"></div>
     
-    <div className="max-w-container mx-auto px-4 sm:px-6 lg:px-8 xl:px-12 py-12 lg:py-16">
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-12 py-12 lg:py-16">
       {/* Main Footer Content */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-6 gap-8 lg:gap-12 pb-12 border-b border-neutral-200">
         {/* Brand & Mission - Takes 2 columns on large screens */}


### PR DESCRIPTION
- Standardize all content widths to max-w-7xl (1280px) to match header/footer
- Update homepage sections: stats, industries, products, why-bapi, cta
- Update contact page sections: hero, form, sales team, map
- Limit hero product image to max-w-5xl (1024px) to prevent excessive stretching
- Cap hero title at text-7xl (remove text-8xl for xl screens)
- Cap tagline at text-5xl with max-w-4xl container
- Reduce description to max-w-3xl and remove redundant lg sizing
- Keep product caption at base size with max-w-3xl

Addresses user feedback about pages being too wide on very large displays.