### PR TITLE
refactor: remove redundant closing backtick cleanup

### DIFF
--- a/web/scripts/translate-vietnamese-products.js
+++ b/web/scripts/translate-vietnamese-products.js
@@ -138,8 +138,8 @@ ${sourceText}`,
     console.log('✅ Translation complete!\n');
 
     // Remove markdown code blocks if present (Claude sometimes wraps responses)
-    translatedText = translatedText.replace(/^```json\s*\n?/gm, '').replace(/\n```$/g, '');
-    translatedText = translatedText.replace(/^```\s*\n?/gm, '').replace(/\n```$/g, '');
+    translatedText = translatedText.replace(/^```json\s*\n?/gm, '');
+    translatedText = translatedText.replace(/^```\s*\n?/gm, '');
     translatedText = translatedText.trim();
 
     console.log(translatedText);


### PR DESCRIPTION
Remove .replace(/\n\`\`\`$/g, '') calls as .trim() already handles
trailing backticks. Now fully matches pattern in sync-footer-translations.js
and sync-home-translations.js.

Addresses final PR feedback for complete consistency."
