### PR TITLE
fix: correct Hindi spelling for 'particulate'

### DIFF
--- a/web/messages/hi.json
+++ b/web/messages/hi.json
@@ -75,7 +75,7 @@
         "co2Desc": "कार्बन डाइऑक्साइड मॉनिटरिंग",
         "voc": "VOC सेंसर",
         "vocDesc": "उद्गमित कार्बनिक यौगिक",
-        "particulate": "कण्ण पदार्थ",
+        "particulate": "कण पदार्थ",
         "particulateDesc": "PM2.5 और PM10"
       },
       "wireless": {


### PR DESCRIPTION
Changed 'कण्ण पदार्थ' to 'कण पदार्थ' (removed double न). The correct Hindi word is कण (kaN) meaning particle.

Addresses PR feedback on spelling error in air quality section.

