### PR TITLE
fix: use logger.error instead of console.error in Edge API route

### DIFF
--- a/web/src/app/api/detect-region/route.ts
+++ b/web/src/app/api/detect-region/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { RegionCode, LanguageCode } from '@/types/region';
+import logger from '@/lib/logger';
 
 /**
  * Auto-detect user's region and language based on geo-location
@@ -130,7 +131,7 @@ export async function GET(request: NextRequest) {
   } catch (error) {
     // Fallback to US if detection fails
     // Log error for monitoring but don't expose details to client
-    console.error('Region detection error:', error);
+    logger.error('Region detection error', { error });
     
     return NextResponse.json({
       detected: false,


### PR DESCRIPTION
- Import logger utility at top of file
- Replace console.error with logger.error for consistency
- Matches pattern used in all other API routes (auth, chat, favorites, etc.)
- Logger is Edge runtime compatible and provides Sentry integration



