### PR TITLE
refactor: improve temperature accuracy conversion logic

### DIFF
--- a/web/src/lib/utils/locale.ts
+++ b/web/src/lib/utils/locale.ts
@@ -232,7 +232,7 @@ function fahrenheitToCelsius(fahrenheit: number): number {
 /**
  * Determine if region should use imperial units
  */
-function shouldUseImperial(language: LanguageCode, region?: RegionCode): boolean {
+export function shouldUseImperial(language: LanguageCode, region?: RegionCode): boolean {
   // If region explicitly provided, use it
   if (region) {
     return region === 'us';


### PR DESCRIPTION
Addresses GitHub Copilot review feedback from previous PR:

**1. Use shouldUseImperial() instead of string matching**
- Replace fragile '°C' string detection with shouldUseImperial() helper
- More reliable unit determination based on locale/region preference
- Export shouldUseImperial() from locale.ts for reusability

**2. Extract hardcoded fallback to named constant**
- Move 0.2 fallback to DEFAULT_ACCURACY_FAHRENHEIT constant
- Makes fallback value explicit and maintainable
- Aligns with sensor data structure

**3. Apply consistent locale-aware formatting**
- Use Intl.NumberFormat for both Fahrenheit AND Celsius values
- Previously only Celsius used locale formatting (inconsistent)
- Now respects decimal separators for all locales (1,234.5 vs 1.234,5)

**4. Improve error handling**
- Add explicit NaN check before formatting
- Fallback to original accuracy string if parsing fails
- More graceful degradation

**Before:**
- String matching: tempValue.includes('°C')
- Hardcoded fallback: parseFloat(...) || 0.2
- Inconsistent formatting: Fahrenheit used raw float

**After:**
- Locale check: shouldUseImperial(locale)
- Named constant: DEFAULT_ACCURACY_FAHRENHEIT
- Consistent formatting: Intl.NumberFormat for both units

Production build successful ✓

