### PR TITLE
fix: replace bare next/link with locale-aware Link across all [locale…

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,6 +1,7 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
 import storybook from "eslint-plugin-storybook";
 import jsdoc from "eslint-plugin-jsdoc";
+import nextIntl from "eslint-plugin-next-intl";
 
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
@@ -45,6 +46,18 @@ const eslintConfig = defineConfig([...nextVitals, ...nextTs, {
   },
   plugins: {
     jsdoc: jsdoc,
+  },
+},
+// Enforce locale-aware Link from @/lib/navigation in [locale] routes and shared components.
+// Using next/link directly bypasses locale prefixing, causing 404s on client-side navigation
+// when localePrefix: 'always' is configured.
+// FIX: replace `import Link from 'next/link'` with `import { Link } from '@/lib/navigation'`
+// (not 'next-intl/link' as this rule suggests — this project wraps it via createNavigation)
+{
+  files: ['src/app/[locale]/**/*.{ts,tsx}', 'src/components/**/*.{ts,tsx}'],
+  plugins: { 'next-intl': nextIntl },
+  rules: {
+    'next-intl/use-next-intl-link-over-next-link': 'error',
   },
 },
 // Prevent duplicate <main> elements in page components

--- a/web/package.json
+++ b/web/package.json
@@ -117,6 +117,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.0.3",
     "eslint-plugin-jsdoc": "^61.4.1",
+    "eslint-plugin-next-intl": "^1.3.1",
     "eslint-plugin-storybook": "^10.2.1",
     "http-server": "^14.1.1",
     "husky": "^8.0.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       eslint-plugin-jsdoc:
         specifier: ^61.4.1
         version: 61.7.1(eslint@9.39.3(jiti@2.6.1))
+      eslint-plugin-next-intl:
+        specifier: ^1.3.1
+        version: 1.3.1(eslint@9.39.3(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^10.2.1
         version: 10.2.15(eslint@9.39.3(jiti@2.6.1))(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(typescript@5.9.3)
@@ -6112,6 +6115,11 @@ packages:
     engines: {node: '>=4.0'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+
+  eslint-plugin-next-intl@1.3.1:
+    resolution: {integrity: sha512-HKi85zXbW8PPYNKEJrSr2nbXDJJ6JQI4XoJpEKAVv9AcGAvKRNTlDs9CmUMOpdhFZIqLb28NJnv+YgrjXY6U0Q==}
+    peerDependencies:
+      eslint: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -17411,6 +17419,10 @@ snapshots:
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
+
+  eslint-plugin-next-intl@1.3.1(eslint@9.39.3(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.3(jiti@2.6.1)
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.3(jiti@2.6.1)):
     dependencies:

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import Hero from '@/components/Hero';
 import { GlobalPresence } from '@/components/company/GlobalPresence';
@@ -141,57 +141,49 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               {
                 name: t('categories.temperature.name'),
                 icon: '/images/icons/Temperature_Icon.webp',
-                href: '/products',
-                count: 119,
+                href: '/products/temperature-sensors',
                 description: t('categories.temperature.description'),
               },
               {
                 name: t('categories.humidity.name'),
                 icon: '/images/icons/Humidity_Icon.webp',
-                href: '/products',
-                count: 33,
+                href: '/products/humidity-sensors',
                 description: t('categories.humidity.description'),
               },
               {
                 name: t('categories.pressure.name'),
                 icon: '/images/icons/Pressure_Icon.webp',
-                href: '/products',
-                count: 39,
+                href: '/products/pressure-sensors',
                 description: t('categories.pressure.description'),
               },
               {
                 name: t('categories.airQuality.name'),
                 icon: '/images/icons/AirQuality_Icon.webp',
-                href: '/products',
-                count: 32,
+                href: '/products/air-quality-sensors',
                 description: t('categories.airQuality.description'),
               },
               {
                 name: t('categories.wireless.name'),
                 icon: '/images/icons/Wireless_Icon.webp',
-                href: '/products',
-                count: 24,
+                href: '/products/wireless-sensors',
                 description: t('categories.wireless.description'),
               },
               {
                 name: t('categories.accessories.name'),
                 icon: '/images/icons/Accessories_Icon.webp',
-                href: '/products',
-                count: 45,
+                href: '/products/accessories',
                 description: t('categories.accessories.description'),
               },
               {
                 name: t('categories.testInstruments.name'),
                 icon: '/images/icons/Test_Instruments_Icon.webp',
-                href: '/products',
-                count: 8,
+                href: '/products/test-instruments',
                 description: t('categories.testInstruments.description'),
               },
               {
                 name: t('categories.etaLine.name'),
                 icon: '/images/icons/Sensors_Icon.webp',
-                href: '/products',
-                count: 70,
+                href: '/products/eta-line',
                 description: t('categories.etaLine.description'),
               },
             ].map((category) => {
@@ -199,36 +191,37 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
                 <Link
                   key={category.name}
                   href={category.href}
-                  className="will-change-transform-safe group relative overflow-hidden rounded-2xl border-2 border-neutral-200 bg-white transition-all duration-300 ease-in-out hover:border-primary-500 hover:shadow-2xl focus:border-primary-500 focus:outline-none focus:ring-4 focus:ring-primary-500/50"
+                  className="will-change-transform-safe group relative overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm transition-all duration-300 ease-in-out hover:border-primary-300 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
                 >
-                  {/* Icon container - BAPI brand blue */}
-                  <div className="bg-linear-to-br relative flex h-48 items-center justify-center border-b-2 border-primary-700 from-[#044976] to-[#166fb9] p-8">
-                    <Image
-                      src={category.icon}
-                      alt={`${category.name} icon`}
-                      width={128}
-                      height={128}
-                      className="will-change-transform-safe h-full w-full object-contain drop-shadow-xl transition-transform duration-300 ease-in-out group-hover:scale-110"
-                    />
+                  {/* Icon container - BAPI brand blue, aspect-ratio responsive */}
+                  <div className="bg-linear-to-br relative aspect-[3/2] w-full overflow-hidden border-b-2 border-primary-700 from-[#044976] to-[#166fb9]">
+                    <div className="flex h-full items-center justify-center p-8">
+                      <Image
+                        src={category.icon}
+                        alt={`${category.name} icon`}
+                        width={128}
+                        height={128}
+                        className="will-change-transform-safe h-full w-full object-contain drop-shadow-xl transition-transform duration-300 ease-in-out group-hover:scale-110"
+                      />
+                    </div>
                   </div>
 
-                  <div className="p-6">
-                    {/* Category name */}
-                    <h3 className="mb-2 text-lg font-bold text-neutral-900 transition-colors group-hover:text-primary-600">
+                  <div className="p-4">
+                    {/* Category name with yellow underline on hover */}
+                    <h3 className="relative mb-2 text-lg font-bold text-neutral-900 transition-colors group-hover:text-primary-600">
                       {category.name}
+                      <span className="absolute -bottom-1 left-0 h-0.5 w-0 rounded bg-accent-500 transition-all duration-300 ease-in-out group-hover:w-full" />
                     </h3>
 
                     {/* Description */}
-                    <p className="mb-4 text-sm leading-relaxed text-neutral-700">
+                    <p className="mb-4 text-sm leading-relaxed text-neutral-600">
                       {category.description}
                     </p>
 
-                    {/* View Products CTA */}
-                    <div className="flex items-center justify-between">
-                      <span className="inline-flex items-center gap-1 text-sm font-bold text-primary-600 transition-all group-hover:gap-2">
-                        {t('categories.viewProducts')}
-                        <ArrowRightIcon className="h-4 w-4" />
-                      </span>
+                    {/* View Products CTA - animated border */}
+                    <div className="inline-flex items-center gap-2 border-b-2 border-transparent pb-0.5 text-sm font-semibold text-primary-600 transition-all duration-300 group-hover:gap-3 group-hover:border-primary-600">
+                      <span>{t('categories.viewProducts')}</span>
+                      <ArrowRightIcon className="h-4 w-4 transition-transform duration-300 group-hover:translate-x-1" />
                     </div>
                   </div>
                 </Link>

--- a/web/src/app/[locale]/accessories/page.tsx
+++ b/web/src/app/[locale]/accessories/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Metadata } from 'next';
 import {
   ArrowRightIcon,

--- a/web/src/app/[locale]/account/error.tsx
+++ b/web/src/app/[locale]/account/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/account/favorites/error.tsx
+++ b/web/src/app/[locale]/account/favorites/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/account/favorites/page.tsx
+++ b/web/src/app/[locale]/account/favorites/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter, useParams } from 'next/navigation';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import { ArrowLeftIcon, HeartIcon } from '@/lib/icons';
 import logger from '@/lib/logger';

--- a/web/src/app/[locale]/account/orders/error.tsx
+++ b/web/src/app/[locale]/account/orders/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/account/orders/loading.tsx
+++ b/web/src/app/[locale]/account/orders/loading.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ArrowLeftIcon } from '@/lib/icons';
 import { OrderCardSkeleton } from '@/components/skeletons';
 

--- a/web/src/app/[locale]/account/profile/error.tsx
+++ b/web/src/app/[locale]/account/profile/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/account/profile/loading.tsx
+++ b/web/src/app/[locale]/account/profile/loading.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ArrowLeftIcon } from '@/lib/icons';
 
 /**

--- a/web/src/app/[locale]/account/profile/page.tsx
+++ b/web/src/app/[locale]/account/profile/page.tsx
@@ -1,6 +1,6 @@
 import { getServerAuth } from '@/lib/auth/server';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ArrowLeftIcon, MailIcon, UserIcon, AtSignIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 

--- a/web/src/app/[locale]/account/quotes/error.tsx
+++ b/web/src/app/[locale]/account/quotes/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/account/quotes/loading.tsx
+++ b/web/src/app/[locale]/account/quotes/loading.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ArrowLeftIcon } from '@/lib/icons';
 
 /**

--- a/web/src/app/[locale]/account/settings/[[...rest]]/page.tsx
+++ b/web/src/app/[locale]/account/settings/[[...rest]]/page.tsx
@@ -1,6 +1,6 @@
 import { getServerAuth } from '@/lib/auth/server';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ArrowLeftIcon } from '@/lib/icons';
 import UserProfileClient from './UserProfileClient';
 import { getTranslations } from 'next-intl/server';

--- a/web/src/app/[locale]/air-quality/page.tsx
+++ b/web/src/app/[locale]/air-quality/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Metadata } from 'next';
 import {
   ArrowRightIcon,

--- a/web/src/app/[locale]/application-notes/[slug]/page.tsx
+++ b/web/src/app/[locale]/application-notes/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import {
   GetApplicationNoteBySlugQuery,

--- a/web/src/app/[locale]/applications/[category]/[subcategory]/page.tsx
+++ b/web/src/app/[locale]/applications/[category]/[subcategory]/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { notFound } from 'next/navigation';
 import {
   applicationCategories,

--- a/web/src/app/[locale]/applications/[category]/page.tsx
+++ b/web/src/app/[locale]/applications/[category]/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { notFound } from 'next/navigation';
 import { ChevronLeftIcon, ChevronRightIcon } from '@/lib/icons';
 import {

--- a/web/src/app/[locale]/applications/page.tsx
+++ b/web/src/app/[locale]/applications/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import {
   Building2Icon,
   FactoryIcon,

--- a/web/src/app/[locale]/catalogpricebook/page.tsx
+++ b/web/src/app/[locale]/catalogpricebook/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { DownloadIcon, FileTextIcon, PrinterIcon, MailIcon } from '@/lib/icons';
 
 export const metadata: Metadata = {

--- a/web/src/app/[locale]/company/careers/page.tsx
+++ b/web/src/app/[locale]/company/careers/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { getPageBySlug } from '@/lib/wordpress';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import {
   BriefcaseIcon,
   HeartIcon,

--- a/web/src/app/[locale]/company/contact-us/page.tsx
+++ b/web/src/app/[locale]/company/contact-us/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { getPageBySlug } from '@/lib/wordpress';
 import { GlobalPresence } from '@/components/company/GlobalPresence';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import {
   MailIcon,
   PhoneIcon,

--- a/web/src/app/[locale]/company/mission-values/page.tsx
+++ b/web/src/app/[locale]/company/mission-values/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { getPageBySlug } from '@/lib/wordpress';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { TargetIcon, EyeIcon, AwardIcon, UsersIcon, LightbulbIcon, ShieldIcon, HeartIcon, ArrowRightIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { locales } from '@/i18n';

--- a/web/src/app/[locale]/company/news/page.tsx
+++ b/web/src/app/[locale]/company/news/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { getTranslations } from 'next-intl/server';
 import { getPosts } from '@/lib/wordpress';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { NewspaperIcon, CalendarIcon, ArrowRightIcon, TrendingUpIcon } from '@/lib/icons';
 import Image from 'next/image';
 import { locales } from '@/i18n';

--- a/web/src/app/[locale]/company/page.tsx
+++ b/web/src/app/[locale]/company/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Building2Icon, UsersIcon, TargetIcon, AwardIcon, MapPinIcon, PhoneIcon, MailIcon } from '@/lib/icons';
 import PageContainer from '@/components/layout/PageContainer';
 import { GlobalPresence } from '@/components/company/GlobalPresence';

--- a/web/src/app/[locale]/company/why-bapi/page.tsx
+++ b/web/src/app/[locale]/company/why-bapi/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { getPageBySlug } from '@/lib/wordpress';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { StarIcon, AwardIcon, ShieldIcon, ClockIcon, UsersIcon, ZapIcon, CheckCircle2Icon, ArrowRightIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { locales } from '@/i18n';

--- a/web/src/app/[locale]/installations/page.tsx
+++ b/web/src/app/[locale]/installations/page.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 
 export const metadata: Metadata = {
   title: 'Real-World Installations | BAPI - Building Automation Products',

--- a/web/src/app/[locale]/product/[slug]/error.tsx
+++ b/web/src/app/[locale]/product/[slug]/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/product/[slug]/page.tsx
+++ b/web/src/app/[locale]/product/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense } from 'react';
 import Image from 'next/image';
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { getTranslations } from 'next-intl/server';
 import logger from '@/lib/logger';
 import {

--- a/web/src/app/[locale]/products/error.tsx
+++ b/web/src/app/[locale]/products/error.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import logger from '@/lib/logger';
 
 /**

--- a/web/src/app/[locale]/request-quote/page.tsx
+++ b/web/src/app/[locale]/request-quote/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ArrowLeftIcon, UploadIcon, XIcon, CheckCircleIcon, Loader2Icon } from '@/lib/icons';
 import { useAuth } from '@/hooks/useAuth';
 import { useRouter } from 'next/navigation';

--- a/web/src/app/[locale]/resources/case-studies/page.tsx
+++ b/web/src/app/[locale]/resources/case-studies/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { FileTextIcon, Building2Icon, AwardIcon, TrendingUpIcon, ArrowRightIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { generatePageMetadata } from '@/lib/metadata';

--- a/web/src/app/[locale]/resources/cross-reference/page.tsx
+++ b/web/src/app/[locale]/resources/cross-reference/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { RefreshCwIcon, SearchIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { generatePageMetadata } from '@/lib/metadata';

--- a/web/src/app/[locale]/resources/installation/page.tsx
+++ b/web/src/app/[locale]/resources/installation/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { WrenchIcon, FileTextIcon, DownloadIcon, SearchIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { generatePageMetadata } from '@/lib/metadata';

--- a/web/src/app/[locale]/resources/page.tsx
+++ b/web/src/app/[locale]/resources/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { BookOpenIcon } from '@/lib/icons';
 import { ResourceList } from '@/components/resources/ResourceList';
 import logger from '@/lib/logger';

--- a/web/src/app/[locale]/resources/selector/page.tsx
+++ b/web/src/app/[locale]/resources/selector/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { SearchIcon, CheckCircleIcon, ArrowRightIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { generatePageMetadata } from '@/lib/metadata';

--- a/web/src/app/[locale]/resources/videos/page.tsx
+++ b/web/src/app/[locale]/resources/videos/page.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { VideoIcon, PlayIcon, CalendarIcon, AlertCircleIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import { generatePageMetadata } from '@/lib/metadata';

--- a/web/src/app/[locale]/sensor-specs/page.tsx
+++ b/web/src/app/[locale]/sensor-specs/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ThermometerIcon, DropletsIcon, WindIcon, GaugeIcon, SearchIcon, DownloadIcon } from '@/lib/icons';
 import { LocalizedTemperatureSensorTable } from '@/components/sensors/LocalizedTemperatureSensorTable';
 

--- a/web/src/app/[locale]/sensors/page.tsx
+++ b/web/src/app/[locale]/sensors/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Metadata } from 'next';
 import {
   ArrowRightIcon,

--- a/web/src/app/[locale]/solutions/[slug]/page.tsx
+++ b/web/src/app/[locale]/solutions/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ActivityIcon, ServerIcon, BuildingIcon, FactoryIcon, CheckCircleIcon, ArrowRightIcon } from '@/lib/icons';
 
 // Solution data

--- a/web/src/app/[locale]/support/page.tsx
+++ b/web/src/app/[locale]/support/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { getTranslations } from 'next-intl/server';
 import {
   LifeBuoyIcon,

--- a/web/src/app/[locale]/test-instruments/page.tsx
+++ b/web/src/app/[locale]/test-instruments/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Metadata } from 'next';
 import {
   ArrowRightIcon,

--- a/web/src/app/[locale]/wam/page.tsx
+++ b/web/src/app/[locale]/wam/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import {
   RadioIcon,

--- a/web/src/app/[locale]/where-to-buy/page.tsx
+++ b/web/src/app/[locale]/where-to-buy/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { PhoneIcon, MailIcon, GlobeIcon, MapPinIcon, SearchIcon } from '@/lib/icons';
 
 export default function WhereToBuyPage() {

--- a/web/src/app/[locale]/wireless-site-verification/page.tsx
+++ b/web/src/app/[locale]/wireless-site-verification/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { RadioIcon, SignalIcon, MapPinIcon, CheckCircleIcon, AlertTriangleIcon, InfoIcon } from '@/lib/icons';
 
 export const metadata: Metadata = {

--- a/web/src/app/[locale]/wireless/page.tsx
+++ b/web/src/app/[locale]/wireless/page.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Metadata } from 'next';
 import {
   ArrowRightIcon,

--- a/web/src/components/application-notes/ApplicationNoteList.tsx
+++ b/web/src/components/application-notes/ApplicationNoteList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import {
   BookOpenIcon,

--- a/web/src/components/applications/ApplicationLandingPage.tsx
+++ b/web/src/components/applications/ApplicationLandingPage.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { Metadata } from 'next';
 import { CheckCircleIcon, ChevronRightIcon, PackageIcon, UsersIcon, HomeIcon } from '@/lib/icons';
 import type { ApplicationLandingPageData } from '@/types/applications';

--- a/web/src/components/category/CategoryHero.tsx
+++ b/web/src/components/category/CategoryHero.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { ChevronRightIcon } from '@/lib/icons';
 
 interface BreadcrumbItem {

--- a/web/src/components/company/GlobalPresence.tsx
+++ b/web/src/components/company/GlobalPresence.tsx
@@ -10,7 +10,7 @@ import {
 import type { Location, FacilityType } from '@/lib/constants/locations';
 import { Building2Icon, MapPinIcon } from '@/lib/icons';
 import { useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 
 const geoUrl = 'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json';
 

--- a/web/src/components/home/IndustryBrowse.tsx
+++ b/web/src/components/home/IndustryBrowse.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import {
   WindIcon,
   SproutIcon,

--- a/web/src/components/order-confirmation/OrderConfirmationClient.tsx
+++ b/web/src/components/order-confirmation/OrderConfirmationClient.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import { useRouter } from 'next/navigation';
 import { CheckCircleIcon, PackageIcon, TruckIcon, CreditCardIcon, HomeIcon, ArrowRightIcon, Loader2Icon } from '@/lib/icons';
 import { useToast } from '@/components/ui/Toast';

--- a/web/src/components/products/ProductPage/Breadcrumbs.tsx
+++ b/web/src/components/products/ProductPage/Breadcrumbs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import React from 'react';
 
 interface BreadcrumbsProps {

--- a/web/src/components/products/ProductPage/ContactInfo.tsx
+++ b/web/src/components/products/ProductPage/ContactInfo.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 
 export default function ContactInfo() {
   return (

--- a/web/src/components/products/RecentlyViewed.tsx
+++ b/web/src/components/products/RecentlyViewed.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRecentlyViewed } from '@/store/recentlyViewed';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import { XIcon, HistoryIcon, Trash2Icon } from '@/lib/icons';
 

--- a/web/src/components/search/SearchDropdown.tsx
+++ b/web/src/components/search/SearchDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useEffect, useState } from 'react';
-import Link from 'next/link';
+import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import { SearchIcon, XIcon, ArrowRightIcon, Loader2Icon } from '@/lib/icons';
 


### PR DESCRIPTION
- Fix homepage product catalog cards (all 8 hrefs were pointing to /products instead of /products/{slug}, causing 404s on client-side navigation)
- Replace 'import Link from next/link' with '{ Link } from @/lib/navigation' in 54 files under src/app/[locale] and src/components — bare next/link bypasses locale prefixing, causing silent 404s with localePrefix: always on client-side navigation
- Add eslint-plugin-next-intl with 'use-next-intl-link-over-next-link: error' rule scoped to [locale] routes and shared components to prevent regression
- Apply products page card UI to homepage: aspect-ratio icon area, yellow accent underline on hover, animated border CTA, refined border/shadow treatment

