### PR TITLE
chore: address Copilot PR review comments on eslint-plugin-next-intl

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -58,6 +58,21 @@ const eslintConfig = defineConfig([...nextVitals, ...nextTs, {
   plugins: { 'next-intl': nextIntl },
   rules: {
     'next-intl/use-next-intl-link-over-next-link': 'error',
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'next-intl/link',
+            message: "Use `@/lib/navigation` instead of importing from `next-intl/link` directly.",
+          },
+          {
+            name: 'next-intl/navigation',
+            message: "Use `@/lib/navigation` instead of importing from `next-intl/navigation` directly.",
+          },
+        ],
+      },
+    ],
   },
 },
 // Prevent duplicate <main> elements in page components

--- a/web/package.json
+++ b/web/package.json
@@ -143,6 +143,13 @@
   "volta": {
     "node": "20.20.0"
   },
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "eslint-plugin-next-intl>eslint": "^9"
+      }
+    }
+  },
   "msw": {
     "workerDirectory": [
       "public"


### PR DESCRIPTION
- Add no-restricted-imports for next-intl/link and next-intl/navigation in [locale] routes and src/components - matches documented convention of using @/lib/navigation exclusively (createNavigation wrapper)
- Add pnpm.peerDependencyRules to silence eslint-plugin-next-intl@1.3.1 peer dep warning on ESLint v9 (plugin works in practice, peer dep declaration has not been updated upstream)


