### PR TITLE
fix: Handle WPGraphQL Model user object in customer group resolvers

### DIFF
--- a/cms/files/wpgraphql-customer-groups.php
+++ b/cms/files/wpgraphql-customer-groups.php
@@ -135,7 +135,7 @@ add_action('graphql_register_types', function() {
         'type' => 'String',
         'description' => __('Primary customer group from ACF field or user meta', 'bapi'),
         'resolve' => function($user) {
-            // Debug: Check user object structure
+            // Handle both WP_User and WPGraphQL\Model\User objects
             $user_id = null;
             if (isset($user->ID)) {
                 $user_id = $user->ID;
@@ -147,8 +147,6 @@ add_action('graphql_register_types', function() {
                 $user_id = $user->databaseId;
             }
             
-            error_log("DEBUG customerGroup1: user_type=" . gettype($user) . " user_class=" . get_class($user) . " user_id=" . ($user_id ?? 'NULL') . " props=" . implode(',', array_keys(get_object_vars($user))));
-            
             if (!$user_id) {
                 return null;
             }
@@ -156,18 +154,14 @@ add_action('graphql_register_types', function() {
             // Try ACF first if available
             if (function_exists('get_field')) {
                 $value = get_field('customer_group1', 'user_' . $user_id);
-                error_log("DEBUG ACF get_field result: " . var_export($value, true));
                 if ($value && is_string($value)) {
-                    error_log("DEBUG customerGroup1 RETURNING from ACF: " . $value);
                     return $value;
                 }
             }
+            
             // Fallback to direct user meta read
             $value = get_user_meta($user_id, 'customer_group1', true);
-            error_log("DEBUG get_user_meta result: " . var_export($value, true));
-            $return_value = (is_string($value) && !empty($value)) ? $value : null;
-            error_log("DEBUG customerGroup1 FINAL RETURN: " . var_export($return_value, true));
-            return $return_value;
+            return (is_string($value) && !empty($value)) ? $value : null;
         },
     ]);
 
@@ -175,13 +169,20 @@ add_action('graphql_register_types', function() {
         'type' => 'String',
         'description' => __('Secondary customer group from ACF field or user meta', 'bapi'),
         'resolve' => function($user) {
+            // Handle both WP_User and WPGraphQL\Model\User objects
+            $user_id = $user->databaseId ?? $user->userId ?? $user->data->ID ?? $user->ID ?? null;
+            if (!$user_id) {
+                return null;
+            }
+            
             if (function_exists('get_field')) {
-                $value = get_field('customer_group2', 'user_' . $user->ID);
+                $value = get_field('customer_group2', 'user_' . $user_id);
                 if ($value && is_string($value)) {
                     return $value;
                 }
             }
-            $value = get_user_meta($user->ID, 'customer_group2', true);
+            
+            $value = get_user_meta($user_id, 'customer_group2', true);
             return (is_string($value) && !empty($value)) ? $value : null;
         },
     ]);
@@ -190,13 +191,20 @@ add_action('graphql_register_types', function() {
         'type' => 'String',
         'description' => __('Tertiary customer group from ACF field or user meta', 'bapi'),
         'resolve' => function($user) {
+            // Handle both WP_User and WPGraphQL\Model\User objects
+            $user_id = $user->databaseId ?? $user->userId ?? $user->data->ID ?? $user->ID ?? null;
+            if (!$user_id) {
+                return null;
+            }
+            
             if (function_exists('get_field')) {
-                $value = get_field('customer_group3', 'user_' . $user->ID);
+                $value = get_field('customer_group3', 'user_' . $user_id);
                 if ($value && is_string($value)) {
                     return $value;
                 }
             }
-            $value = get_user_meta($user->ID, 'customer_group3', true);
+            
+            $value = get_user_meta($user_id, 'customer_group3', true);
             return (is_string($value) && !empty($value)) ? $value : null;
         },
     ]);

--- a/cms/files/wpgraphql-customer-groups.php
+++ b/cms/files/wpgraphql-customer-groups.php
@@ -170,7 +170,17 @@ add_action('graphql_register_types', function() {
         'description' => __('Secondary customer group from ACF field or user meta', 'bapi'),
         'resolve' => function($user) {
             // Handle both WP_User and WPGraphQL\Model\User objects
-            $user_id = $user->databaseId ?? $user->userId ?? $user->data->ID ?? $user->ID ?? null;
+            $user_id = null;
+            if (isset($user->ID)) {
+                $user_id = $user->ID;
+            } elseif (isset($user->data->ID)) {
+                $user_id = $user->data->ID;
+            } elseif (isset($user->userId)) {
+                $user_id = $user->userId;
+            } elseif (isset($user->databaseId)) {
+                $user_id = $user->databaseId;
+            }
+            
             if (!$user_id) {
                 return null;
             }
@@ -192,7 +202,17 @@ add_action('graphql_register_types', function() {
         'description' => __('Tertiary customer group from ACF field or user meta', 'bapi'),
         'resolve' => function($user) {
             // Handle both WP_User and WPGraphQL\Model\User objects
-            $user_id = $user->databaseId ?? $user->userId ?? $user->data->ID ?? $user->ID ?? null;
+            $user_id = null;
+            if (isset($user->ID)) {
+                $user_id = $user->ID;
+            } elseif (isset($user->data->ID)) {
+                $user_id = $user->data->ID;
+            } elseif (isset($user->userId)) {
+                $user_id = $user->userId;
+            } elseif (isset($user->databaseId)) {
+                $user_id = $user->databaseId;
+            }
+            
             if (!$user_id) {
                 return null;
             }

--- a/scripts/fix-test-users-acf.sh
+++ b/scripts/fix-test-users-acf.sh
@@ -15,7 +15,7 @@ NC='\033[0m'
 SSH_HOST="35.224.70.159"
 SSH_PORT="17338"
 SSH_USER="bapiheadlessstaging"
-WP_PATH="~/public"
+WP_PATH="/www/bapiheadlessstaging_582/public"
 
 echo -e "${YELLOW}========================================${NC}"
 echo -e "${YELLOW}Fix Test Users - ACF Field Names${NC}"
@@ -25,7 +25,6 @@ echo -e "${YELLOW}========================================${NC}"
 update_user_group() {
   local email=$1
   local group=$2
-  local display_name=$3
   
   echo -e "\n${GREEN}→ Processing: $email${NC}"
   
@@ -54,10 +53,10 @@ update_user_group() {
 }
 
 # Update all test users
-update_user_group "test-alc@bapihvac.com" "ALC" "Test User - ALC"
-update_user_group "test-acs@bapihvac.com" "ACS" "Test User - ACS"
-update_user_group "test-emc@bapihvac.com" "EMC" "Test User - EMC"
-update_user_group "test-ccg@bapihvac.com" "CCG" "Test User - CCG"
+update_user_group "test-alc@bapihvac.com" "ALC"
+update_user_group "test-acs@bapihvac.com" "ACS"
+update_user_group "test-emc@bapihvac.com" "EMC"
+update_user_group "test-ccg@bapihvac.com" "CCG"
 update_user_group "test-ccga@bapihvac.com" "CCGA" "Test User - CCGA"
 update_user_group "test-standard@bapihvac.com" "" "Test User - Standard"
 

--- a/scripts/fix-test-users-acf.sh
+++ b/scripts/fix-test-users-acf.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Fix test users - Update customer group fields to use ACF field names
+# Problem: Old script set 'customer_group' but auth reads 'customer_group1/2/3'
+# Solution: Update user meta to use correct ACF field names
+
+set -e
+
+# Colors
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Kinsta staging SSH details
+SSH_HOST="35.224.70.159"
+SSH_PORT="17338"
+SSH_USER="bapiheadlessstaging"
+WP_PATH="~/public"
+
+echo -e "${YELLOW}========================================${NC}"
+echo -e "${YELLOW}Fix Test Users - ACF Field Names${NC}"
+echo -e "${YELLOW}========================================${NC}"
+
+# Function to update user customer group
+update_user_group() {
+  local email=$1
+  local group=$2
+  local display_name=$3
+  
+  echo -e "\n${GREEN}→ Processing: $email${NC}"
+  
+  # Get user ID
+  USER_ID=$(ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "wp user get $email --field=ID --path=$WP_PATH 2>/dev/null || echo ''")
+  
+  if [ -z "$USER_ID" ]; then
+    echo -e "${RED}  ✗ User not found: $email${NC}"
+    return 1
+  fi
+  
+  echo "  User ID: $USER_ID"
+  
+  # Update customer_group1 ACF field (primary group)
+  if [ -n "$group" ]; then
+    ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "wp user meta update $USER_ID customer_group1 '$group' --path=$WP_PATH"
+    echo -e "${GREEN}  ✓ Set customer_group1 = '$group'${NC}"
+  else
+    # Clear customer_group1 for standard user
+    ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "wp user meta delete $USER_ID customer_group1 --path=$WP_PATH 2>/dev/null || true"
+    echo -e "${GREEN}  ✓ Cleared customer_group1 (standard user)${NC}"
+  fi
+  
+  # Clear old incorrect field name if exists
+  ssh -p $SSH_PORT $SSH_USER@$SSH_HOST "wp user meta delete $USER_ID customer_group --path=$WP_PATH 2>/dev/null || true"
+}
+
+# Update all test users
+update_user_group "test-alc@bapihvac.com" "ALC" "Test User - ALC"
+update_user_group "test-acs@bapihvac.com" "ACS" "Test User - ACS"
+update_user_group "test-emc@bapihvac.com" "EMC" "Test User - EMC"
+update_user_group "test-ccg@bapihvac.com" "CCG" "Test User - CCG"
+update_user_group "test-ccga@bapihvac.com" "CCGA" "Test User - CCGA"
+update_user_group "test-standard@bapihvac.com" "" "Test User - Standard"
+
+echo -e "\n${GREEN}========================================${NC}"
+echo -e "${GREEN}All test users updated successfully!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo -e "\n${YELLOW}Next steps:${NC}"
+echo "1. Refresh your browser at staging site"
+echo "2. Run: fetch('/api/auth/me').then(r => r.json()).then(console.log)"
+echo "3. Verify customerGroups: ['alc'] (not ['end-user'])"
+echo "4. Check Button Sensor category - should see ALC products"

--- a/scripts/update-test-users.sh
+++ b/scripts/update-test-users.sh
@@ -1,39 +1,41 @@
 #!/bin/bash
 # Update remaining test user customer groups
 
+WP_PATH="${WP_PATH:-/www/bapiheadlessstaging_582/public}"
+
 echo "Finding and updating test users..."
 
 # Find user IDs and update customer_group1 field
-wp user list --search='test-acs@bapihvac.com' --field=ID | while read user_id; do
+wp --path="$WP_PATH" user list --search='test-acs@bapihvac.com' --field=ID | while read user_id; do
     echo "Setting ACS for user $user_id"
-    wp user meta update "$user_id" customer_group1 'ACS'
+    wp --path="$WP_PATH" user meta update "$user_id" customer_group1 'ACS'
 done
 
-wp user list --search='test-emc@bapihvac.com' --field=ID | while read user_id; do
+wp --path="$WP_PATH" user list --search='test-emc@bapihvac.com' --field=ID | while read user_id; do
     echo "Setting EMC for user $user_id"
-    wp user meta update "$user_id" customer_group1 'EMC'
+    wp --path="$WP_PATH" user meta update "$user_id" customer_group1 'EMC'
 done
 
-wp user list --search='test-ccg@bapihvac.com' --field=ID | while read user_id; do
+wp --path="$WP_PATH" user list --search='test-ccg@bapihvac.com' --field=ID | while read user_id; do
     echo "Setting CCG for user $user_id"
-    wp user meta update "$user_id" customer_group1 'CCG'
+    wp --path="$WP_PATH" user meta update "$user_id" customer_group1 'CCG'
 done
 
-wp user list --search='test-ccga@bapihvac.com' --field=ID | while read user_id; do
+wp --path="$WP_PATH" user list --search='test-ccga@bapihvac.com' --field=ID | while read user_id; do
     echo "Setting CCGA for user $user_id"
-    wp user meta update "$user_id" customer_group1 'CCGA'
+    wp --path="$WP_PATH" user meta update "$user_id" customer_group1 'CCGA'
 done
 
 echo ""
 echo "Verification:"
 for email in test-alc@bapihvac.com test-acs@bapihvac.com test-emc@bapihvac.com test-ccg@bapihvac.com test-ccga@bapihvac.com; do
-    user_id=$(wp user list --search="$email" --field=ID)
+    user_id=$(wp --path="$WP_PATH" user list --search="$email" --field=ID)
     if [ -n "$user_id" ]; then
-        group=$(wp user meta get "$user_id" customer_group1 2>/dev/null || echo "NOT SET")
+        group=$(wp --path="$WP_PATH" user meta get "$user_id" customer_group1 2>/dev/null || echo "NOT SET")
         echo "$email (ID: $user_id) -> customer_group1 = $group"
     fi
 done
 
 echo ""
 echo "Clearing WordPress cache..."
-wp cache flush
+wp --path="$WP_PATH" cache flush

--- a/scripts/update-test-users.sh
+++ b/scripts/update-test-users.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Update remaining test user customer groups
+
+echo "Finding and updating test users..."
+
+# Find user IDs and update customer_group1 field
+wp user list --search='test-acs@bapihvac.com' --field=ID | while read user_id; do
+    echo "Setting ACS for user $user_id"
+    wp user meta update "$user_id" customer_group1 'ACS'
+done
+
+wp user list --search='test-emc@bapihvac.com' --field=ID | while read user_id; do
+    echo "Setting EMC for user $user_id"
+    wp user meta update "$user_id" customer_group1 'EMC'
+done
+
+wp user list --search='test-ccg@bapihvac.com' --field=ID | while read user_id; do
+    echo "Setting CCG for user $user_id"
+    wp user meta update "$user_id" customer_group1 'CCG'
+done
+
+wp user list --search='test-ccga@bapihvac.com' --field=ID | while read user_id; do
+    echo "Setting CCGA for user $user_id"
+    wp user meta update "$user_id" customer_group1 'CCGA'
+done
+
+echo ""
+echo "Verification:"
+for email in test-alc@bapihvac.com test-acs@bapihvac.com test-emc@bapihvac.com test-ccg@bapihvac.com test-ccga@bapihvac.com; do
+    user_id=$(wp user list --search="$email" --field=ID)
+    if [ -n "$user_id" ]; then
+        group=$(wp user meta get "$user_id" customer_group1 2>/dev/null || echo "NOT SET")
+        echo "$email (ID: $user_id) -> customer_group1 = $group"
+    fi
+done
+
+echo ""
+echo "Clearing WordPress cache..."
+wp cache flush

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -47,14 +47,6 @@ export async function GET(request: NextRequest) {
     }
 
     const { viewer } = data;
-    
-    // DEBUG: Log raw viewer response to see what WordPress sends
-    console.log('[DEBUG /api/auth/me] Raw viewer response:', JSON.stringify({
-      customerGroup1: viewer.customerGroup1,
-      customerGroup2: viewer.customerGroup2,
-      customerGroup3: viewer.customerGroup3,
-      databaseId: viewer.databaseId,
-    }, null, 2));
 
     // Extract role names from the GraphQL response
     const roles = viewer.roles?.nodes?.map((role: { name: string }) => role.name) || [];


### PR DESCRIPTION
- Fix WPGraphQL returning WPGraphQL\Model\User instead of WP_User
- Extract user ID from model object via databaseId/userId properties
- Apply fix to all three customerGroup1/2/3 resolvers
- Update all test users with correct customer_group1 values
- Remove debug logging from production code

Fixes customer group filtering for authenticated users on staging. Verified: test-alc user now returns customerGroups: ['alc'] instead of ['end-user']

