### PR TITLE
feat: add variation SKU search for configured products

### DIFF
--- a/web/src/app/[locale]/search/page.tsx
+++ b/web/src/app/[locale]/search/page.tsx
@@ -70,11 +70,16 @@ async function searchProducts(query: string) {
           slug
         }
       }
+      variations(first: 100) {
+        nodes {
+          sku
+        }
+      }
     }
   `;
 
-  // Run both queries in parallel: name/description search + SKU search
-  const [nameSearchResponse, skuSearchResponse] = await Promise.all([
+  // Run three queries in parallel: name/description search + product SKU search + variation SKU search
+  const [nameSearchResponse, skuSearchResponse, variationSearchResponse] = await Promise.all([
     // Query 1: Search product name/description
     fetch(GRAPHQL_ENDPOINT, {
       method: 'POST',
@@ -93,7 +98,7 @@ async function searchProducts(query: string) {
       }),
       next: { revalidate: 3600 },
     }),
-    // Query 2: Search by SKU (exact match)
+    // Query 2: Search by product SKU (exact match)
     fetch(GRAPHQL_ENDPOINT, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -111,44 +116,84 @@ async function searchProducts(query: string) {
       }),
       next: { revalidate: 3600 },
     }),
+    // Query 3: Search variable products with variations for SKU matching
+    fetch(GRAPHQL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: `
+          query SearchVariationsBySKU {
+            products(where: { type: VARIABLE, visibility: VISIBLE }, first: 50) {
+              nodes {
+                ${productFields}
+              }
+            }
+          }
+        `,
+      }),
+      next: { revalidate: 3600 },
+    }),
   ]);
 
   // Check for HTTP errors
-  if (!nameSearchResponse.ok || !skuSearchResponse.ok) {
+  if (!nameSearchResponse.ok || !skuSearchResponse.ok || !variationSearchResponse.ok) {
     console.error('WordPress GraphQL search failed', {
       nameStatus: nameSearchResponse.status,
       skuStatus: skuSearchResponse.status,
+      variationStatus: variationSearchResponse.status,
     });
     return [];
   }
 
-  const [nameData, skuData] = await Promise.all([
+  const [nameData, skuData, variationData] = await Promise.all([
     nameSearchResponse.json(),
     skuSearchResponse.json(),
+    variationSearchResponse.json(),
   ]);
 
   // Check for GraphQL errors
-  if (nameData.errors || skuData.errors) {
+  if (nameData.errors || skuData.errors || variationData.errors) {
     console.error('GraphQL search query failed', {
       nameErrors: nameData.errors,
       skuErrors: skuData.errors,
+      variationErrors: variationData.errors,
     });
     return [];
   }
 
-  // Merge results from both queries, removing duplicates by ID
+  // Merge results from all three queries, removing duplicates by ID
   const nameResults = nameData.data?.products?.nodes || [];
   const skuResults = skuData.data?.products?.nodes || [];
+  const variationProducts = variationData.data?.products?.nodes || [];
 
-  // Create a Map to deduplicate by product ID
-  const resultsMap = new Map();
-
-  // Add SKU results first (higher priority for exact SKU matches)
-  skuResults.forEach((product: { id: string }) => {
-    resultsMap.set(product.id, product);
+  // Filter variation products to only those with matching variation SKUs
+  const normalizedQuery = query.trim().toLowerCase();
+  const variationResults = variationProducts.filter((product: any) => {
+    if (!product.variations?.nodes) return false;
+    return product.variations.nodes.some((variation: any) => 
+      variation.sku?.toLowerCase() === normalizedQuery
+    );
   });
 
-  // Add name search results (won't override if already exists)
+  // Create a Map to deduplicate by product ID
+  // Priority order: Variation SKU > Product SKU > Name search
+  const resultsMap = new Map();
+
+  // Add variation SKU matches first (highest priority - exact configured product match)
+  variationResults.forEach((product: any) => {
+    // Remove variations from response to keep payload clean
+    const { variations, ...productWithoutVariations } = product;
+    resultsMap.set(product.id, productWithoutVariations);
+  });
+
+  // Add product SKU results (second priority - parent product SKU match)
+  skuResults.forEach((product: { id: string }) => {
+    if (!resultsMap.has(product.id)) {
+      resultsMap.set(product.id, product);
+    }
+  });
+
+  // Add name search results (lowest priority - fuzzy name match)
   nameResults.forEach((product: { id: string }) => {
     if (!resultsMap.has(product.id)) {
       resultsMap.set(product.id, product);

--- a/web/src/app/[locale]/search/page.tsx
+++ b/web/src/app/[locale]/search/page.tsx
@@ -1,209 +1,131 @@
-import { sanitizeWordPressContent } from '@/lib/sanitizeDescription';
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import { Link } from '@/lib/navigation';
-import Image from 'next/image';
-import { SearchIcon, ArrowLeftIcon } from '@/lib/icons';
+import { SearchIcon } from '@/lib/icons';
 import { getTranslations } from 'next-intl/server';
 import Breadcrumbs from '@/components/products/ProductPage/Breadcrumbs';
 import { getSearchBreadcrumbs, breadcrumbsToSchemaOrg } from '@/lib/navigation/breadcrumbs';
 import SearchResults from '@/components/search/SearchResults';
+import { getGraphQLClient } from '@/lib/graphql/client';
+import { getSdk } from '@/lib/graphql/generated';
+import logger from '@/lib/logger';
 
 interface SearchPageProps {
   params: Promise<{ locale: string }>;
   searchParams: Promise<{ q?: string }>;
 }
 
-async function searchProducts(query: string) {
-  const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL?.trim();
-
-  if (!GRAPHQL_ENDPOINT) {
-    console.error(
-      'searchProducts: NEXT_PUBLIC_WORDPRESS_GRAPHQL is not configured. Returning empty search results.',
-    );
-    return [];
-  }
-
-  const productFields = `
-    id
-    databaseId
-    name
-    slug
-    ... on SimpleProduct {
-      sku
-      partNumber
-      price
-      shortDescription
-      image {
-        id
-        sourceUrl
-        altText
-        mediaDetails {
-          height
-          width
-        }
-      }
-      productCategories {
-        nodes {
-          name
-          slug
-        }
-      }
-    }
-    ... on VariableProduct {
-      sku
-      partNumber
-      price
-      shortDescription
-      image {
-        id
-        sourceUrl
-        altText
-        mediaDetails {
-          height
-          width
-        }
-      }
-      productCategories {
-        nodes {
-          name
-          slug
-        }
-      }
-      variations(first: 100) {
-        nodes {
-          sku
-        }
-      }
-    }
-  `;
-
-  // Run three queries in parallel: name/description search + product SKU search + variation SKU search
-  const [nameSearchResponse, skuSearchResponse, variationSearchResponse] = await Promise.all([
-    // Query 1: Search product name/description
-    fetch(GRAPHQL_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: `
-          query SearchProducts($search: String!) {
-            products(where: { search: $search, visibility: VISIBLE }, first: 24) {
-              nodes {
-                ${productFields}
-              }
-            }
-          }
-        `,
-        variables: { search: query },
-      }),
-      next: { revalidate: 3600 },
-    }),
-    // Query 2: Search by product SKU (exact match)
-    fetch(GRAPHQL_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: `
-          query SearchProductsBySKU($sku: String!) {
-            products(where: { sku: $sku, visibility: VISIBLE }, first: 24) {
-              nodes {
-                ${productFields}
-              }
-            }
-          }
-        `,
-        variables: { sku: query },
-      }),
-      next: { revalidate: 3600 },
-    }),
-    // Query 3: Search variable products with variations for SKU matching
-    fetch(GRAPHQL_ENDPOINT, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        query: `
-          query SearchVariationsBySKU {
-            products(where: { type: VARIABLE, visibility: VISIBLE }, first: 50) {
-              nodes {
-                ${productFields}
-              }
-            }
-          }
-        `,
-      }),
-      next: { revalidate: 3600 },
-    }),
-  ]);
-
-  // Check for HTTP errors
-  if (!nameSearchResponse.ok || !skuSearchResponse.ok || !variationSearchResponse.ok) {
-    console.error('WordPress GraphQL search failed', {
-      nameStatus: nameSearchResponse.status,
-      skuStatus: skuSearchResponse.status,
-      variationStatus: variationSearchResponse.status,
-    });
-    return [];
-  }
-
-  const [nameData, skuData, variationData] = await Promise.all([
-    nameSearchResponse.json(),
-    skuSearchResponse.json(),
-    variationSearchResponse.json(),
-  ]);
-
-  // Check for GraphQL errors
-  if (nameData.errors || skuData.errors || variationData.errors) {
-    console.error('GraphQL search query failed', {
-      nameErrors: nameData.errors,
-      skuErrors: skuData.errors,
-      variationErrors: variationData.errors,
-    });
-    return [];
-  }
-
-  // Merge results from all three queries, removing duplicates by ID
-  const nameResults = nameData.data?.products?.nodes || [];
-  const skuResults = skuData.data?.products?.nodes || [];
-  const variationProducts = variationData.data?.products?.nodes || [];
-
-  // Filter variation products to only those with matching variation SKUs
-  const normalizedQuery = query.trim().toLowerCase();
-  const variationResults = variationProducts.filter((product: any) => {
-    if (!product.variations?.nodes) return false;
-    return product.variations.nodes.some((variation: any) => 
-      variation.sku?.toLowerCase() === normalizedQuery
-    );
-  });
-
-  // Create a Map to deduplicate by product ID
-  // Priority order: Variation SKU > Product SKU > Name search
-  const resultsMap = new Map();
-
-  // Add variation SKU matches first (highest priority - exact configured product match)
-  variationResults.forEach((product: any) => {
-    // Remove variations from response to keep payload clean
-    const { variations, ...productWithoutVariations } = product;
-    resultsMap.set(product.id, productWithoutVariations);
-  });
-
-  // Add product SKU results (second priority - parent product SKU match)
-  skuResults.forEach((product: { id: string }) => {
-    if (!resultsMap.has(product.id)) {
-      resultsMap.set(product.id, product);
-    }
-  });
-
-  // Add name search results (lowest priority - fuzzy name match)
-  nameResults.forEach((product: { id: string }) => {
-    if (!resultsMap.has(product.id)) {
-      resultsMap.set(product.id, product);
-    }
-  });
-
-  // Convert Map back to array and limit to 24 results
-  return Array.from(resultsMap.values()).slice(0, 24);
+/**
+ * SKU pattern detector - helps optimize by only running variation query when needed
+ * Typical SKU format: letters, numbers, hyphens (e.g., "TEMP-SENSOR-1000-024")
+ * 
+ * @param query - Search query string to test
+ * @returns True if query matches SKU pattern (alphanumeric with dashes/underscores)
+ */
+function looksLikeSku(query: string): boolean {
+  // Match patterns with alphanumeric + dash/underscore (common SKU formats)
+  // At least one letter and one number, may contain dashes/underscores
+  return /^[A-Za-z0-9\-_]+$/.test(query) && /[A-Za-z]/.test(query) && /[0-9]/.test(query);
 }
 
+/**
+ * Server-side search function with variation SKU support
+ * 
+ * Executes parallel GraphQL queries with priority ordering:
+ * 1. Variation SKU (exact configured product match)
+ * 2. Product SKU (parent product match)
+ * 3. Name search (fuzzy match)
+ * 
+ * @param query - Search query string
+ * @returns Array of up to 24 matching products
+ */
+async function searchProducts(query: string) {
+  try {
+    // Use GraphQL client with GET method for CDN caching
+    const client = getGraphQLClient(['search'], true);
+    const sdk = getSdk(client);
+
+    const normalizedQuery = query.trim().toLowerCase();
+    const shouldCheckVariations = looksLikeSku(query);
+
+    // Build query array conditionally - only add variation query if input looks like a SKU
+    const queryPromises = [
+      // Query 1: Search product name/description (fuzzy match)
+      sdk.SearchProducts({ search: query, first: 24 }),
+      // Query 2: Search by product SKU (exact match)
+      sdk.SearchProductsBySKU({ sku: query, first: 24 }),
+    ];
+
+    // Query 3: Only search variable product variations if query looks like a SKU pattern
+    // This avoids fetching 50 products × 100 variations (5,000 SKUs) for non-SKU searches
+    if (shouldCheckVariations) {
+      queryPromises.push(sdk.ListVariableProductsWithVariationSkus({ first: 50 }));
+    }
+
+    const results = await Promise.all(queryPromises);
+    const [nameData, skuData, variationData] = results;
+
+    // Extract products from GraphQL responses
+    const nameResults = nameData.products?.nodes || [];
+    const skuResults = skuData.products?.nodes || [];
+
+    // Filter variation products to only those with matching variation SKUs (if query ran)
+    const variationResults: typeof nameResults = [];
+    if (shouldCheckVariations && variationData) {
+      const variationProducts = variationData.products?.nodes || [];
+
+      variationProducts.forEach((product) => {
+        // Type guard: only VariableProduct has variations
+        if (product.__typename === 'VariableProduct') {
+          // Safe to cast after typename check - GraphQL unions make type narrowing complex
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const variableProduct = product as any;
+          if (variableProduct.variations?.nodes) {
+            // Check if any variation SKU matches the search query exactly
+            const hasMatch = variableProduct.variations.nodes.some((variation: { sku?: string | null }) => 
+              variation.sku?.toLowerCase() === normalizedQuery
+            );
+            if (hasMatch) {
+              variationResults.push(product);
+            }
+          }
+        }
+      });
+    }
+
+    // Create a Map to deduplicate by product ID with priority ordering
+    // Priority: Variation SKU (exact configured match) > Product SKU (parent match) > Name (fuzzy)
+    const resultsMap = new Map();
+
+    // Add variation SKU matches first (highest priority - exact configured product match)
+    variationResults.forEach((product) => {
+      resultsMap.set(product.id, product);
+    });
+
+    // Add product SKU results (second priority - parent product SKU match)
+    skuResults.forEach((product) => {
+      if (!resultsMap.has(product.id)) {
+        resultsMap.set(product.id, product);
+      }
+    });
+
+    // Add name search results (lowest priority - fuzzy name match)
+    nameResults.forEach((product) => {
+      if (!resultsMap.has(product.id)) {
+        resultsMap.set(product.id, product);
+      }
+    });
+
+    // Convert Map back to array and limit to 24 results for search page
+    return Array.from(resultsMap.values()).slice(0, 24);
+  } catch (error) {
+    logger.error('Search products error', error, { query });
+    return [];
+  }
+}
+
+/**
+ * Generate metadata for search results page
+ */
 export async function generateMetadata({
   params,
   searchParams,
@@ -219,6 +141,11 @@ export async function generateMetadata({
   };
 }
 
+/**
+ * Search results page component
+ * 
+ * Server-rendered page showing search results with breadcrumbs and schema.org markup
+ */
 export default async function SearchPage({ params, searchParams }: SearchPageProps) {
   const { locale } = await params;
   const queryParams = await searchParams;

--- a/web/src/app/api/search/route.ts
+++ b/web/src/app/api/search/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import logger from '@/lib/logger';
+import { getGraphQLClient } from '@/lib/graphql/client';
+import { getSdk } from '@/lib/graphql/generated';
 
 // Type for search product response
 interface SearchProduct {
@@ -26,166 +28,28 @@ interface SearchProduct {
       slug: string;
     }>;
   } | null;
-  variations?: {
-    nodes: Array<{
-      sku?: string | null;
-    }>;
-  } | null;
 }
 
-// Search by product name/description
-const SEARCH_QUERY = `
-  query SearchProducts($search: String!) {
-    products(where: { search: $search, visibility: VISIBLE }, first: 8) {
-      nodes {
-        id
-        databaseId
-        name
-        slug
-        ... on SimpleProduct {
-          sku
-          partNumber
-          price
-          shortDescription
-          image {
-            id
-            sourceUrl
-            altText
-            mediaDetails {
-              height
-              width
-            }
-          }
-          productCategories {
-            nodes {
-              name
-              slug
-            }
-          }
-        }
-        ... on VariableProduct {
-          sku
-          partNumber
-          price
-          shortDescription
-          image {
-            id
-            sourceUrl
-            altText
-            mediaDetails {
-              height
-              width
-            }
-          }
-          productCategories {
-            nodes {
-              name
-              slug
-            }
-          }
-        }
-      }
-    }
-  }
-`;
+/**
+ * SKU pattern detector - helps optimize by only running variation query when needed
+ * Typical SKU format: letters, numbers, hyphens (e.g., "TEMP-SENSOR-1000-024")
+ * 
+ * @param query - Search query string to test
+ * @returns True if query matches SKU pattern (alphanumeric with dashes/underscores)
+ */
+function looksLikeSku(query: string): boolean {
+  // Match patterns with alphanumeric + dash/underscore (common SKU formats)
+  // At least one letter and one number, may contain dashes/underscores
+  return /^[A-Za-z0-9\-_]+$/.test(query) && /[A-Za-z]/.test(query) && /[0-9]/.test(query);
+}
 
-// Search by SKU (exact match)
-const SKU_SEARCH_QUERY = `
-  query SearchProductsBySKU($sku: String!) {
-    products(where: { sku: $sku, visibility: VISIBLE }, first: 8) {
-      nodes {
-        id
-        databaseId
-        name
-        slug
-        ... on SimpleProduct {
-          sku
-          partNumber
-          price
-          shortDescription
-          image {
-            id
-            sourceUrl
-            altText
-            mediaDetails {
-              height
-              width
-            }
-          }
-          productCategories {
-            nodes {
-              name
-              slug
-            }
-          }
-        }
-        ... on VariableProduct {
-          sku
-          partNumber
-          price
-          shortDescription
-          image {
-            id
-            sourceUrl
-            altText
-            mediaDetails {
-              height
-              width
-            }
-          }
-          productCategories {
-            nodes {
-              name
-              slug
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
-// Search variable products with variations for SKU matching
-// Limit to recent products to avoid performance issues
-const VARIATION_SKU_SEARCH_QUERY = `
-  query SearchVariationsBySKU {
-    products(where: { type: VARIABLE, visibility: VISIBLE }, first: 50) {
-      nodes {
-        id
-        databaseId
-        name
-        slug
-        ... on VariableProduct {
-          sku
-          partNumber
-          price
-          shortDescription
-          image {
-            id
-            sourceUrl
-            altText
-            mediaDetails {
-              height
-              width
-            }
-          }
-          productCategories {
-            nodes {
-              name
-              slug
-            }
-          }
-          variations(first: 100) {
-            nodes {
-              sku
-            }
-          }
-        }
-      }
-    }
-  }
-`;
-
+/**
+ * Search API route - handles product search with variation SKU support
+ * 
+ * Priority order: Variation SKU > Product SKU > Name search
+ * Uses GraphQL client with GET method for CDN caching
+ * Conditionally runs variation query only for SKU-like patterns
+ */
 export async function POST(request: NextRequest) {
   try {
     const { query } = await request.json();
@@ -194,101 +58,64 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ products: { nodes: [] } });
     }
 
-    const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL;
+    // Use GraphQL client with GET method for CDN caching
+    const client = getGraphQLClient(['search'], true);
+    const sdk = getSdk(client);
 
-    if (!GRAPHQL_ENDPOINT) {
-      logger.error('NEXT_PUBLIC_WORDPRESS_GRAPHQL not configured');
-      return NextResponse.json({ error: 'GraphQL endpoint not configured' }, { status: 500 });
-    }
-
-    // Run three queries in parallel: name/description search + product SKU search + variation SKU search
-    const [nameSearchResponse, skuSearchResponse, variationSearchResponse] = await Promise.all([
-      // Query 1: Search product name/description
-      fetch(GRAPHQL_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query: SEARCH_QUERY,
-          variables: { search: query },
-        }),
-        next: { revalidate: 0 },
-      }),
-      // Query 2: Search by product SKU (exact match)
-      fetch(GRAPHQL_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query: SKU_SEARCH_QUERY,
-          variables: { sku: query },
-        }),
-        next: { revalidate: 0 },
-      }),
-      // Query 3: Search variable products with variations
-      fetch(GRAPHQL_ENDPOINT, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          query: VARIATION_SKU_SEARCH_QUERY,
-        }),
-        next: { revalidate: 0 },
-      }),
-    ]);
-
-    if (!nameSearchResponse.ok || !skuSearchResponse.ok || !variationSearchResponse.ok) {
-      logger.error('WordPress GraphQL search failed', {
-        nameStatus: nameSearchResponse.status,
-        skuStatus: skuSearchResponse.status,
-        variationStatus: variationSearchResponse.status,
-      });
-      return NextResponse.json(
-        { error: 'Failed to fetch search results' },
-        { status: nameSearchResponse.ok 
-            ? (skuSearchResponse.ok ? variationSearchResponse.status : skuSearchResponse.status)
-            : nameSearchResponse.status }
-      );
-    }
-
-    const [nameData, skuData, variationData] = await Promise.all([
-      nameSearchResponse.json(),
-      skuSearchResponse.json(),
-      variationSearchResponse.json(),
-    ]);
-
-    if (nameData.errors || skuData.errors || variationData.errors) {
-      logger.error('GraphQL search query failed', {
-        nameErrors: nameData.errors,
-        skuErrors: skuData.errors,
-        variationErrors: variationData.errors,
-      });
-      return NextResponse.json(
-        { error: 'GraphQL query failed', details: nameData.errors || skuData.errors || variationData.errors },
-        { status: 500 }
-      );
-    }
-
-    // Merge results from all three queries, removing duplicates by ID
-    const nameResults: SearchProduct[] = nameData.data?.products?.nodes || [];
-    const skuResults: SearchProduct[] = skuData.data?.products?.nodes || [];
-    const variationProducts: SearchProduct[] = variationData.data?.products?.nodes || [];
-
-    // Filter variation products to only those with matching variation SKUs
     const normalizedQuery = query.trim().toLowerCase();
-    const variationResults = variationProducts.filter((product) => {
-      if (!product.variations?.nodes) return false;
-      return product.variations.nodes.some((variation) => 
-        variation.sku?.toLowerCase() === normalizedQuery
-      );
-    });
+    const shouldCheckVariations = looksLikeSku(query);
 
-    // Create a Map to deduplicate by product ID
-    // Priority order: Variation SKU > Product SKU > Name search
+    // Build query array conditionally - only add variation query if input looks like a SKU
+    const queryPromises = [
+      // Query 1: Search product name/description (fuzzy match)
+      sdk.SearchProducts({ search: query, first: 8 }),
+      // Query 2: Search by product SKU (exact match)
+      sdk.SearchProductsBySKU({ sku: query, first: 8 }),
+    ];
+
+    // Query 3: Only search variable product variations if query looks like a SKU pattern
+    // This avoids fetching 50 products × 100 variations (5,000 SKUs) for non-SKU searches
+    if (shouldCheckVariations) {
+      queryPromises.push(sdk.ListVariableProductsWithVariationSkus({ first: 50 }));
+    }
+
+    const results = await Promise.all(queryPromises);
+    const [nameData, skuData, variationData] = results;
+
+    // Extract products from GraphQL responses
+    const nameResults = (nameData.products?.nodes || []) as SearchProduct[];
+    const skuResults = (skuData.products?.nodes || []) as SearchProduct[];
+    
+    // Filter variation products to only those with matching variation SKUs (if query ran)
+    let variationResults: SearchProduct[] = [];
+    if (shouldCheckVariations && variationData) {
+      const variationProducts = (variationData.products?.nodes || []);
+      
+      variationResults = variationProducts.filter((product) => {
+        // Type guard: only VariableProduct has variations
+        if (product.__typename !== 'VariableProduct') {
+          return false;
+        }
+        // Safe to cast after typename check - GraphQL unions make type narrowing complex
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const variableProduct = product as any;
+        if (!variableProduct.variations?.nodes) {
+          return false;
+        }
+        // Check if any variation SKU matches the search query exactly
+        return variableProduct.variations.nodes.some((variation: { sku?: string | null }) => 
+          variation.sku?.toLowerCase() === normalizedQuery
+        );
+      }) as SearchProduct[];
+    }
+
+    // Create a Map to deduplicate by product ID with priority ordering
+    // Priority: Variation SKU (exact configured match) > Product SKU (parent match) > Name (fuzzy)
     const resultsMap = new Map<string, SearchProduct>();
     
     // Add variation SKU matches first (highest priority - exact configured product match)
     variationResults.forEach((product) => {
-      // Remove variations from response to keep payload clean
-      const { variations, ...productWithoutVariations } = product;
-      resultsMap.set(product.id, productWithoutVariations);
+      resultsMap.set(product.id, product);
     });
     
     // Add product SKU results (second priority - parent product SKU match)
@@ -305,7 +132,7 @@ export async function POST(request: NextRequest) {
       }
     });
 
-    // Convert Map back to array and limit to 8 results
+    // Convert Map back to array and limit to 8 results for dropdown
     const mergedResults = Array.from(resultsMap.values()).slice(0, 8);
 
     return NextResponse.json({ products: { nodes: mergedResults } });

--- a/web/src/app/api/search/route.ts
+++ b/web/src/app/api/search/route.ts
@@ -26,6 +26,11 @@ interface SearchProduct {
       slug: string;
     }>;
   } | null;
+  variations?: {
+    nodes: Array<{
+      sku?: string | null;
+    }>;
+  } | null;
 }
 
 // Search by product name/description
@@ -140,6 +145,47 @@ const SKU_SEARCH_QUERY = `
   }
 `;
 
+// Search variable products with variations for SKU matching
+// Limit to recent products to avoid performance issues
+const VARIATION_SKU_SEARCH_QUERY = `
+  query SearchVariationsBySKU {
+    products(where: { type: VARIABLE, visibility: VISIBLE }, first: 50) {
+      nodes {
+        id
+        databaseId
+        name
+        slug
+        ... on VariableProduct {
+          sku
+          partNumber
+          price
+          shortDescription
+          image {
+            id
+            sourceUrl
+            altText
+            mediaDetails {
+              height
+              width
+            }
+          }
+          productCategories {
+            nodes {
+              name
+              slug
+            }
+          }
+          variations(first: 100) {
+            nodes {
+              sku
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
 export async function POST(request: NextRequest) {
   try {
     const { query } = await request.json();
@@ -155,8 +201,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'GraphQL endpoint not configured' }, { status: 500 });
     }
 
-    // Run both queries in parallel: name/description search + SKU search
-    const [nameSearchResponse, skuSearchResponse] = await Promise.all([
+    // Run three queries in parallel: name/description search + product SKU search + variation SKU search
+    const [nameSearchResponse, skuSearchResponse, variationSearchResponse] = await Promise.all([
       // Query 1: Search product name/description
       fetch(GRAPHQL_ENDPOINT, {
         method: 'POST',
@@ -167,7 +213,7 @@ export async function POST(request: NextRequest) {
         }),
         next: { revalidate: 0 },
       }),
-      // Query 2: Search by SKU (exact match)
+      // Query 2: Search by product SKU (exact match)
       fetch(GRAPHQL_ENDPOINT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -177,48 +223,82 @@ export async function POST(request: NextRequest) {
         }),
         next: { revalidate: 0 },
       }),
+      // Query 3: Search variable products with variations
+      fetch(GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: VARIATION_SKU_SEARCH_QUERY,
+        }),
+        next: { revalidate: 0 },
+      }),
     ]);
 
-    if (!nameSearchResponse.ok || !skuSearchResponse.ok) {
+    if (!nameSearchResponse.ok || !skuSearchResponse.ok || !variationSearchResponse.ok) {
       logger.error('WordPress GraphQL search failed', {
         nameStatus: nameSearchResponse.status,
         skuStatus: skuSearchResponse.status,
+        variationStatus: variationSearchResponse.status,
       });
       return NextResponse.json(
         { error: 'Failed to fetch search results' },
-        { status: nameSearchResponse.ok ? skuSearchResponse.status : nameSearchResponse.status }
+        { status: nameSearchResponse.ok 
+            ? (skuSearchResponse.ok ? variationSearchResponse.status : skuSearchResponse.status)
+            : nameSearchResponse.status }
       );
     }
 
-    const [nameData, skuData] = await Promise.all([
+    const [nameData, skuData, variationData] = await Promise.all([
       nameSearchResponse.json(),
       skuSearchResponse.json(),
+      variationSearchResponse.json(),
     ]);
 
-    if (nameData.errors || skuData.errors) {
+    if (nameData.errors || skuData.errors || variationData.errors) {
       logger.error('GraphQL search query failed', {
         nameErrors: nameData.errors,
         skuErrors: skuData.errors,
+        variationErrors: variationData.errors,
       });
       return NextResponse.json(
-        { error: 'GraphQL query failed', details: nameData.errors || skuData.errors },
+        { error: 'GraphQL query failed', details: nameData.errors || skuData.errors || variationData.errors },
         { status: 500 }
       );
     }
 
-    // Merge results from both queries, removing duplicates by ID
+    // Merge results from all three queries, removing duplicates by ID
     const nameResults: SearchProduct[] = nameData.data?.products?.nodes || [];
     const skuResults: SearchProduct[] = skuData.data?.products?.nodes || [];
+    const variationProducts: SearchProduct[] = variationData.data?.products?.nodes || [];
 
-    // Create a Map to deduplicate by product ID
-    const resultsMap = new Map<string, SearchProduct>();
-    
-    // Add SKU results first (higher priority for exact SKU matches)
-    skuResults.forEach((product) => {
-      resultsMap.set(product.id, product);
+    // Filter variation products to only those with matching variation SKUs
+    const normalizedQuery = query.trim().toLowerCase();
+    const variationResults = variationProducts.filter((product) => {
+      if (!product.variations?.nodes) return false;
+      return product.variations.nodes.some((variation) => 
+        variation.sku?.toLowerCase() === normalizedQuery
+      );
     });
 
-    // Add name search results (won't override if already exists)
+    // Create a Map to deduplicate by product ID
+    // Priority order: Variation SKU > Product SKU > Name search
+    const resultsMap = new Map<string, SearchProduct>();
+    
+    // Add variation SKU matches first (highest priority - exact configured product match)
+    variationResults.forEach((product) => {
+      // Remove variations from response to keep payload clean
+      const { variations, ...productWithoutVariations } = product;
+      resultsMap.set(product.id, productWithoutVariations);
+    });
+    
+    // Add product SKU results (second priority - parent product SKU match)
+    skuResults.forEach((product) => {
+      if (!resultsMap.has(product.id)) {
+        resultsMap.set(product.id, product);
+      }
+    });
+
+    // Add name search results (lowest priority - fuzzy name match)
     nameResults.forEach((product) => {
       if (!resultsMap.has(product.id)) {
         resultsMap.set(product.id, product);

--- a/web/src/lib/graphql/generated.ts
+++ b/web/src/lib/graphql/generated.ts
@@ -39990,7 +39990,34 @@ export type SearchProductsQuery = { __typename?: 'RootQuery', products?: { __typ
       | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
       | { __typename?: 'SimpleProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
       | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
-      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
+      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
+    > } | null | undefined };
+
+export type SearchProductsBySkuQueryVariables = Exact<{
+  sku: Scalars['String']['input'];
+  first?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type SearchProductsBySkuQuery = { __typename?: 'RootQuery', products?: { __typename?: 'RootQueryToProductUnionConnection', nodes: Array<
+      | { __typename?: 'ExternalProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'SimpleProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
+      | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
+    > } | null | undefined };
+
+export type SearchVariationsBySkuQueryVariables = Exact<{
+  first?: InputMaybe<Scalars['Int']['input']>;
+}>;
+
+
+export type SearchVariationsBySkuQuery = { __typename?: 'RootQuery', products?: { __typename?: 'RootQueryToProductUnionConnection', nodes: Array<
+      | { __typename?: 'ExternalProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'SimpleProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
+      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
     > } | null | undefined };
 
 
@@ -42204,6 +42231,114 @@ export const SearchProductsDocument = gql`
             }
           }
         }
+        variations(first: 100) {
+          nodes {
+            sku
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+export const SearchProductsBySkuDocument = gql`
+    query SearchProductsBySKU($sku: String!, $first: Int = 24) {
+  products(where: {sku: $sku, visibility: VISIBLE}, first: $first) {
+    nodes {
+      id
+      databaseId
+      name
+      slug
+      ... on SimpleProduct {
+        sku
+        partNumber
+        price
+        shortDescription
+        image {
+          sourceUrl
+          altText
+        }
+        productCategories {
+          nodes {
+            name
+            slug
+            parent {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+      }
+      ... on VariableProduct {
+        sku
+        partNumber
+        price
+        shortDescription
+        image {
+          sourceUrl
+          altText
+        }
+        productCategories {
+          nodes {
+            name
+            slug
+            parent {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+        variations(first: 100) {
+          nodes {
+            sku
+          }
+        }
+      }
+    }
+  }
+}
+    `;
+export const SearchVariationsBySkuDocument = gql`
+    query SearchVariationsBySKU($first: Int = 50) {
+  products(where: {type: VARIABLE, visibility: VISIBLE}, first: $first) {
+    nodes {
+      id
+      databaseId
+      name
+      slug
+      ... on VariableProduct {
+        sku
+        partNumber
+        price
+        shortDescription
+        image {
+          sourceUrl
+          altText
+        }
+        productCategories {
+          nodes {
+            name
+            slug
+            parent {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+        variations(first: 100) {
+          nodes {
+            sku
+          }
+        }
       }
     }
   }
@@ -42330,6 +42465,12 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     SearchProducts(variables: SearchProductsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SearchProductsQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<SearchProductsQuery>({ document: SearchProductsDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'SearchProducts', 'query', variables);
+    },
+    SearchProductsBySKU(variables: SearchProductsBySkuQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SearchProductsBySkuQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SearchProductsBySkuQuery>({ document: SearchProductsBySkuDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'SearchProductsBySKU', 'query', variables);
+    },
+    SearchVariationsBySKU(variables?: SearchVariationsBySkuQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SearchVariationsBySkuQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<SearchVariationsBySkuQuery>({ document: SearchVariationsBySkuDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'SearchVariationsBySKU', 'query', variables);
     }
   };
 }

--- a/web/src/lib/graphql/generated.ts
+++ b/web/src/lib/graphql/generated.ts
@@ -39990,7 +39990,7 @@ export type SearchProductsQuery = { __typename?: 'RootQuery', products?: { __typ
       | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
       | { __typename?: 'SimpleProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
       | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
-      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
+      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
     > } | null | undefined };
 
 export type SearchProductsBySkuQueryVariables = Exact<{
@@ -40004,15 +40004,15 @@ export type SearchProductsBySkuQuery = { __typename?: 'RootQuery', products?: { 
       | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
       | { __typename?: 'SimpleProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
       | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
-      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
+      | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
     > } | null | undefined };
 
-export type SearchVariationsBySkuQueryVariables = Exact<{
+export type ListVariableProductsWithVariationSkusQueryVariables = Exact<{
   first?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
 
-export type SearchVariationsBySkuQuery = { __typename?: 'RootQuery', products?: { __typename?: 'RootQueryToProductUnionConnection', nodes: Array<
+export type ListVariableProductsWithVariationSkusQuery = { __typename?: 'RootQuery', products?: { __typename?: 'RootQueryToProductUnionConnection', nodes: Array<
       | { __typename?: 'ExternalProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
       | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
       | { __typename?: 'SimpleProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
@@ -42231,11 +42231,6 @@ export const SearchProductsDocument = gql`
             }
           }
         }
-        variations(first: 100) {
-          nodes {
-            sku
-          }
-        }
       }
     }
   }
@@ -42294,18 +42289,13 @@ export const SearchProductsBySkuDocument = gql`
             }
           }
         }
-        variations(first: 100) {
-          nodes {
-            sku
-          }
-        }
       }
     }
   }
 }
     `;
-export const SearchVariationsBySkuDocument = gql`
-    query SearchVariationsBySKU($first: Int = 50) {
+export const ListVariableProductsWithVariationSkusDocument = gql`
+    query ListVariableProductsWithVariationSkus($first: Int = 50) {
   products(where: {type: VARIABLE, visibility: VISIBLE}, first: $first) {
     nodes {
       id
@@ -42469,8 +42459,8 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     SearchProductsBySKU(variables: SearchProductsBySkuQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SearchProductsBySkuQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<SearchProductsBySkuQuery>({ document: SearchProductsBySkuDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'SearchProductsBySKU', 'query', variables);
     },
-    SearchVariationsBySKU(variables?: SearchVariationsBySkuQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<SearchVariationsBySkuQuery> {
-      return withWrapper((wrappedRequestHeaders) => client.request<SearchVariationsBySkuQuery>({ document: SearchVariationsBySkuDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'SearchVariationsBySKU', 'query', variables);
+    ListVariableProductsWithVariationSkus(variables?: ListVariableProductsWithVariationSkusQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<ListVariableProductsWithVariationSkusQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<ListVariableProductsWithVariationSkusQuery>({ document: ListVariableProductsWithVariationSkusDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'ListVariableProductsWithVariationSkus', 'query', variables);
     }
   };
 }

--- a/web/src/lib/graphql/queries/search.graphql
+++ b/web/src/lib/graphql/queries/search.graphql
@@ -50,11 +50,6 @@ query SearchProducts($search: String!, $first: Int = 20) {
             }
           }
         }
-        variations(first: 100) {
-          nodes {
-            sku
-          }
-        }
       }
     }
   }
@@ -112,17 +107,12 @@ query SearchProductsBySKU($sku: String!, $first: Int = 24) {
             }
           }
         }
-        variations(first: 100) {
-          nodes {
-            sku
-          }
-        }
       }
     }
   }
 }
 
-query SearchVariationsBySKU($first: Int = 50) {
+query ListVariableProductsWithVariationSkus($first: Int = 50) {
   products(where: { type: VARIABLE, visibility: VISIBLE }, first: $first) {
     nodes {
       id

--- a/web/src/lib/graphql/queries/search.graphql
+++ b/web/src/lib/graphql/queries/search.graphql
@@ -50,6 +50,112 @@ query SearchProducts($search: String!, $first: Int = 20) {
             }
           }
         }
+        variations(first: 100) {
+          nodes {
+            sku
+          }
+        }
+      }
+    }
+  }
+}
+
+query SearchProductsBySKU($sku: String!, $first: Int = 24) {
+  products(where: { sku: $sku, visibility: VISIBLE }, first: $first) {
+    nodes {
+      id
+      databaseId
+      name
+      slug
+      ... on SimpleProduct {
+        sku
+        partNumber
+        price
+        shortDescription
+        image {
+          sourceUrl
+          altText
+        }
+        productCategories {
+          nodes {
+            name
+            slug
+            parent {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+      }
+      ... on VariableProduct {
+        sku
+        partNumber
+        price
+        shortDescription
+        image {
+          sourceUrl
+          altText
+        }
+        productCategories {
+          nodes {
+            name
+            slug
+            parent {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+        variations(first: 100) {
+          nodes {
+            sku
+          }
+        }
+      }
+    }
+  }
+}
+
+query SearchVariationsBySKU($first: Int = 50) {
+  products(where: { type: VARIABLE, visibility: VISIBLE }, first: $first) {
+    nodes {
+      id
+      databaseId
+      name
+      slug
+      ... on VariableProduct {
+        sku
+        partNumber
+        price
+        shortDescription
+        image {
+          sourceUrl
+          altText
+        }
+        productCategories {
+          nodes {
+            name
+            slug
+            parent {
+              node {
+                id
+                name
+                slug
+              }
+            }
+          }
+        }
+        variations(first: 100) {
+          nodes {
+            sku
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
- Add triple-query search pattern: name + product SKU + variation SKU
- Enable B2B customers to search by configured variation SKUs (e.g., TEMP-SENSOR-1000-024)
- Server-side filter variable products by matching variation SKU
- Priority order: Variation SKU > Product SKU > Name search
- Limit variation query to 50 products with 100 variations each for performance
- Update GraphQL schema with SearchVariationsBySKU query
- Add variations field to VariableProduct queries
- Apply consistent logic across API route and search page
- Strip variations from response to keep payload clean

Solves: B2B reorder workflow for customers who need to search configured products by their variation SKUs


