### PR TITLE
fix: address all Copilot PR review feedback

### DIFF
--- a/cms/wp-content/mu-plugins/bapi-variation-sku-search.php
+++ b/cms/wp-content/mu-plugins/bapi-variation-sku-search.php
@@ -35,21 +35,24 @@ function bapi_index_variation_skus_search( $search, $query ) {
 			// Escape the search term for SQL LIKE
 			$like_term = '%' . $wpdb->esc_like( $search_term ) . '%';
 			
-			// Add variation SKU search to query
-			// This finds parent products where ANY variation SKU matches
-			$search .= " OR {$wpdb->posts}.ID IN (
-				SELECT DISTINCT p.post_parent
-				FROM {$wpdb->posts} p
-				INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
-				WHERE p.post_type = 'product_variation'
-				AND p.post_status = 'publish'
-				AND p.post_parent > 0
-				AND pm.meta_key = '_sku'
-				AND pm.meta_value LIKE %s
-			)";
+			// Prepare the variation SKU clause separately to avoid prepare() issues
+			// with existing % wildcards in $search from WordPress core
+			$variation_sku_clause = $wpdb->prepare(
+				" OR {$wpdb->posts}.ID IN (
+					SELECT DISTINCT p.post_parent
+					FROM {$wpdb->posts} p
+					INNER JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id
+					WHERE p.post_type = 'product_variation'
+					AND p.post_status = 'publish'
+					AND p.post_parent > 0
+					AND pm.meta_key = '_sku'
+					AND pm.meta_value LIKE %s
+				)",
+				$like_term
+			);
 			
-			// Prepare the query to prevent SQL injection
-			$search = $wpdb->prepare( $search, $like_term );
+			// Append the prepared clause to existing search
+			$search .= $variation_sku_clause;
 		}
 	}
 

--- a/docs/VARIATION-SKU-SEARCH-IMPLEMENTATION.md
+++ b/docs/VARIATION-SKU-SEARCH-IMPLEMENTATION.md
@@ -1,41 +1,61 @@
 # Variation SKU Search Implementation
 
-**Date:** April 15, 2026  
-**Branch:** `feat/variation-sku-search` (commit 080eb50)  
-**Investigation:** Legacy WordPress site analysis via SSH
+**Date:** April 16, 2026  
+**Branch:** `main` (merged from `feat/variation-sku-search`)  
+**Implementation:** Custom WPGraphQL resolver approach
 
 ---
 
 ## 🎯 TL;DR - Implementation Status
 
-✅ **Variation SKU search is ALREADY WORKING in headless Next.js**  
-❌ **WordPress mu-plugin approach does NOT work with WPGraphQL**  
-📖 **This document serves as investigation reference and architectural comparison**
+✅ **Variation SKU search implemented via WPGraphQL resolver-based fields**  
+📖 **This document serves as implementation reference, architectural comparison, and investigation history**  
+⚠️ **Notes below about mu-plugin and frontend triple-query approach are historical investigation findings**
 
-**Current Implementation:** Frontend triple-query approach in `web/src/app/api/search/route.ts`  
-**Legacy Reference:** Relevanssi Premium custom filter on `stage.bapihvac.com`
+**Current Implementation:** Resolver-based `searchProductsByVariationSku*` GraphQL approach  
+**Historical Reference:** Relevanssi Premium custom filter on `stage.bapihvac.com` and earlier headless/frontend investigation notes
 
 ---
 
-## 🚨 CRITICAL UPDATE: WPGraphQL Architecture
+## 📝 Current Implementation (April 16, 2026)
+
+### WPGraphQL Custom Resolver Approach
+
+**Location:** `cms/wp-content/mu-plugins/bapi-graphql-variation-search.php`
+
+**How It Works:**
+1. Custom WPGraphQL root fields: `searchProductsByVariationSku` and `searchProductsByVariationSkuPrefix`
+2. Direct SQL query to `wp_postmeta` for `_sku` meta_key on variation posts
+3. Returns parent variable products via WPGraphQL's `DataSource::resolve_post_object()`
+4. Zero external plugin dependencies
+
+**Frontend Integration:** `web/src/app/api/search/route.ts`
+- Uses custom resolver when query looks like SKU
+- Falls back to name/description search for non-SKU queries
+- Supports both GET (`?q=SKU`) and POST methods
+
+---
+
+## 📚 Historical Investigation Notes: WPGraphQL Architecture
 
 **Date:** April 15, 2026  
-**Status:** ⚠️ **mu-plugin approach NOT COMPATIBLE with WPGraphQL**
+**Status at time of investigation:** ⚠️ **Initial mu-plugin approach was not compatible with WPGraphQL**
 
 ### Discovery
 
-After deployment to Kinsta staging, testing revealed that **variation SKU search is ALREADY WORKING** in the headless Next.js frontend via a different approach.
+During staging investigation, testing showed that **variation SKU search could work in the headless Next.js frontend** via a fallback/search-composition approach before the resolver-based implementation.
 
-**The WordPress mu-plugin does NOT work with WPGraphQL** because:
+**The investigated WordPress mu-plugin approach did not work with WPGraphQL** because:
 - WPGraphQL uses custom resolvers that bypass WordPress's `posts_search` filter
-- Our `posts_search` hook is never triggered by GraphQL queries
+- The `posts_search` hook was never triggered by GraphQL queries
 - WPGraphQL for WooCommerce has its own query resolution system
 
-### Current Working Implementation
+### Historical Working Frontend Implementation
 
-**Location:** `web/src/app/api/search/route.ts`
+**Historical location:** `web/src/app/api/search/route.ts` (pre-resolver approach)  
+**Current location:** Resolver-based `searchProductsByVariationSku*` GraphQL implementation
 
-**Architecture:**
+**Historical architecture:**
 ```typescript
 // 1. Name/description search (fuzzy match)
 sdk.SearchProducts({ search: query, first: 8 })

--- a/scripts/deploy-variation-search.sh
+++ b/scripts/deploy-variation-search.sh
@@ -29,9 +29,9 @@ ENVIRONMENT=$1
 
 # Helper function to require environment variables
 require_env() {
-    VAR_NAME=$1
-    DEFAULT_VALUE=$2
-    VAR_VALUE="${!VAR_NAME}"
+    local VAR_NAME=$1
+    local DEFAULT_VALUE=$2
+    local VAR_VALUE="${!VAR_NAME}"
     
     if [ -z "$VAR_VALUE" ]; then
         if [ -n "$DEFAULT_VALUE" ]; then
@@ -109,8 +109,8 @@ echo ""
 # Create mu-plugins directory if it doesn't exist
 ssh -p "${SSH_PORT}" "${SSH_USER}@${SERVER}" "mkdir -p ${REMOTE_PATH}"
 
-# Copy file
-scp -P "${SSH_PORT}" "$PLUGIN_FILE" "${SSH_USER}@${SERVER}:${REMOTE_PATH}bapi-variation-sku-search.php"
+# Copy file (keep original filename)
+scp -P "${SSH_PORT}" "$PLUGIN_FILE" "${SSH_USER}@${SERVER}:${REMOTE_PATH}$(basename "$PLUGIN_FILE")"
 
 if [ $? -eq 0 ]; then
     echo ""

--- a/scripts/deploy-variation-search.sh
+++ b/scripts/deploy-variation-search.sh
@@ -27,20 +27,39 @@ fi
 
 ENVIRONMENT=$1
 
+# Helper function to require environment variables
+require_env() {
+    VAR_NAME=$1
+    DEFAULT_VALUE=$2
+    VAR_VALUE="${!VAR_NAME}"
+    
+    if [ -z "$VAR_VALUE" ]; then
+        if [ -n "$DEFAULT_VALUE" ]; then
+            echo "$DEFAULT_VALUE"
+        else
+            echo -e "${RED}Error: Required environment variable '$VAR_NAME' is not set${NC}" >&2
+            exit 1
+        fi
+    else
+        echo "$VAR_VALUE"
+    fi
+}
+
 # Set server details based on environment
 if [ "$ENVIRONMENT" == "staging" ]; then
     # Headless WordPress staging on Kinsta (bapiheadlessstaging.kinsta.cloud)
-    # SSH credentials from MyKinsta: Sites → bapiheadlessstaging → Info → SSH/SFTP
-    SERVER="35.224.70.159"
-    SSH_PORT="17338"
-    SSH_USER="bapiheadlessstaging"
+    # Prefer env vars, fall back to defaults (for local development)
+    SERVER=$(require_env "STAGING_SERVER" "35.224.70.159")
+    SSH_PORT=$(require_env "STAGING_SSH_PORT" "17338")
+    SSH_USER=$(require_env "STAGING_SSH_USER" "bapiheadlessstaging")
     REMOTE_PATH="~/public/wp-content/mu-plugins/"
     SITE_NAME="Headless WordPress Staging (Kinsta)"
 elif [ "$ENVIRONMENT" == "production" ]; then
     # Headless WordPress production on Kinsta
-    SERVER="TBD"  # TODO: Get from MyKinsta dashboard
-    SSH_PORT="TBD"
-    SSH_USER="TBD"
+    # Require env vars for production (no defaults)
+    SERVER=$(require_env "PRODUCTION_SERVER")
+    SSH_PORT=$(require_env "PRODUCTION_SSH_PORT")
+    SSH_USER=$(require_env "PRODUCTION_SSH_USER")
     REMOTE_PATH="~/public/wp-content/mu-plugins/"
     SITE_NAME="Headless WordPress Production (Kinsta)"
 else
@@ -53,8 +72,8 @@ echo -e "${YELLOW}Deploying to: ${ENVIRONMENT}${NC}"
 echo "Server: $SERVER"
 echo ""
 
-# Check if mu-plugin file exists
-PLUGIN_FILE="cms/wp-content/mu-plugins/bapi-variation-sku-search.php"
+# Check if mu-plugin file exists (GraphQL resolver version)
+PLUGIN_FILE="cms/wp-content/mu-plugins/bapi-graphql-variation-search.php"
 
 if [ ! -f "$PLUGIN_FILE" ]; then
     echo -e "${RED}Error: Plugin file not found${NC}"

--- a/scripts/test-variation-search.sh
+++ b/scripts/test-variation-search.sh
@@ -30,9 +30,9 @@ ENVIRONMENT=$1
 
 # Helper function to get environment variables with defaults
 get_env() {
-    VAR_NAME=$1
-    DEFAULT_VALUE=$2
-    VAR_VALUE="${!VAR_NAME}"
+    local VAR_NAME=$1
+    local DEFAULT_VALUE=$2
+    local VAR_VALUE="${!VAR_NAME}"
     
     if [ -z "$VAR_VALUE" ]; then
         echo "$DEFAULT_VALUE"
@@ -48,10 +48,16 @@ if [ "$ENVIRONMENT" == "staging" ]; then
     SSH_SERVER=$(get_env "STAGING_SSH_SERVER" "bapiheadlessstaging@35.224.70.159")
     SSH_PORT=$(get_env "STAGING_SSH_PORT" "17338")
 elif [ "$ENVIRONMENT" == "production" ]; then
-    # Headless WordPress production on Kinsta
+    # Headless WordPress production on Kinsta (require env vars)
     GRAPHQL_ENDPOINT=$(get_env "PRODUCTION_GRAPHQL_ENDPOINT" "")
     SSH_SERVER=$(get_env "PRODUCTION_SSH_SERVER" "")
     SSH_PORT=$(get_env "PRODUCTION_SSH_PORT" "")
+    
+    # Fail fast if production vars are missing
+    if [ -z "$GRAPHQL_ENDPOINT" ]; then
+        echo -e "${RED}Error: PRODUCTION_GRAPHQL_ENDPOINT environment variable is required for production${NC}" >&2
+        exit 1
+    fi
 elif [ "$ENVIRONMENT" == "local" ]; then
     GRAPHQL_ENDPOINT="http://localhost:8000/graphql"
     SSH_SERVER=""

--- a/scripts/test-variation-search.sh
+++ b/scripts/test-variation-search.sh
@@ -28,17 +28,30 @@ fi
 
 ENVIRONMENT=$1
 
+# Helper function to get environment variables with defaults
+get_env() {
+    VAR_NAME=$1
+    DEFAULT_VALUE=$2
+    VAR_VALUE="${!VAR_NAME}"
+    
+    if [ -z "$VAR_VALUE" ]; then
+        echo "$DEFAULT_VALUE"
+    else
+        echo "$VAR_VALUE"
+    fi
+}
+
 # Set server details based on environment
 if [ "$ENVIRONMENT" == "staging" ]; then
     # Headless WordPress staging on Kinsta
-    GRAPHQL_ENDPOINT="https://bapiheadlessstaging.kinsta.cloud/graphql"
-    SSH_SERVER="bapiheadlessstaging@35.224.70.159"
-    SSH_PORT="17338"
+    GRAPHQL_ENDPOINT=$(get_env "STAGING_GRAPHQL_ENDPOINT" "https://bapiheadlessstaging.kinsta.cloud/graphql")
+    SSH_SERVER=$(get_env "STAGING_SSH_SERVER" "bapiheadlessstaging@35.224.70.159")
+    SSH_PORT=$(get_env "STAGING_SSH_PORT" "17338")
 elif [ "$ENVIRONMENT" == "production" ]; then
     # Headless WordPress production on Kinsta
-    GRAPHQL_ENDPOINT="https://TBD/graphql"  # TODO: Update with production URL
-    SSH_SERVER="TBD@TBD"
-    SSH_PORT="TBD"
+    GRAPHQL_ENDPOINT=$(get_env "PRODUCTION_GRAPHQL_ENDPOINT" "")
+    SSH_SERVER=$(get_env "PRODUCTION_SSH_SERVER" "")
+    SSH_PORT=$(get_env "PRODUCTION_SSH_PORT" "")
 elif [ "$ENVIRONMENT" == "local" ]; then
     GRAPHQL_ENDPOINT="http://localhost:8000/graphql"
     SSH_SERVER=""
@@ -64,55 +77,53 @@ fi
 
 echo ""
 
-# Test Case 2: Search for known variation SKU
-echo -e "${BLUE}Test 2: Search for variation SKU (CCGA/10K-2-D-4\"-BB4)${NC}"
+# Test Case 2: Search for known variation SKU using custom resolver
+echo -e "${BLUE}Test 2: searchProductsByVariationSku (CCGA/10K-2-D-4\"-BB4)${NC}"
 echo "---------------------------------------"
 
 GRAPHQL_QUERY='
 query TestVariationSKU {
-  products(where: { search: "CCGA/10K-2-D-4\"-BB4" }, first: 5) {
-    nodes {
-      databaseId
-      name
-      sku
-    }
+  searchProductsByVariationSku(sku: "CCGA/10K-2-D-4\"-BB4") {
+    databaseId
+    name
+    sku
   }
 }
 '
 
-echo "Query: Search for 'CCGA/10K-2-D-4\"-BB4'"
+echo "Query: searchProductsByVariationSku(sku: 'CCGA/10K-2-D-4\"-BB4')"
 echo "Expected: Parent product 'CCGA/10K-2-D' (ID: 50116)"
 echo ""
 
-curl -s -X POST "$GRAPHQL_ENDPOINT" \
-  -H "Content-Type: application/json" \
-  -d "{\"query\": \"$GRAPHQL_QUERY\"}" | jq '.data.products.nodes'
+jq -n --arg query "$GRAPHQL_QUERY" '{query: $query}' | \
+  curl -s -X POST "$GRAPHQL_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    --data-binary @- | jq '.data.searchProductsByVariationSku'
 
 echo ""
 
-# Test Case 3: Search for partial variation SKU
-echo -e "${BLUE}Test 3: Search for partial SKU (CCGA/10K-2-D)${NC}"
+# Test Case 3: Search for partial variation SKU using prefix resolver
+echo -e "${BLUE}Test 3: searchProductsByVariationSkuPrefix (CCGA/10K-2-D)${NC}"
 echo "---------------------------------------"
 
 GRAPHQL_QUERY='
 query TestPartialSKU {
-  products(where: { search: "CCGA/10K-2-D" }, first: 10) {
-    nodes {
-      databaseId
-      name
-      sku
-    }
+  searchProductsByVariationSkuPrefix(prefix: "CCGA/10K-2-D") {
+    databaseId
+    name
+    sku
   }
 }
 '
 
-echo "Query: Search for 'CCGA/10K-2-D'"
-echo "Expected: Multiple products with '10K-2-D' in name or variation SKUs"
+echo "Query: searchProductsByVariationSkuPrefix(prefix: 'CCGA/10K-2-D')"
+echo "Expected: Multiple products with variations starting with 'CCGA/10K-2-D'"
 echo ""
 
-curl -s -X POST "$GRAPHQL_ENDPOINT" \
-  -H "Content-Type: application/json" \
-  -d "{\"query\": \"$GRAPHQL_QUERY\"}" | jq '.data.products.nodes'
+jq -n --arg query "$GRAPHQL_QUERY" '{query: $query}' | \
+  curl -s -X POST "$GRAPHQL_ENDPOINT" \
+    -H "Content-Type: application/json" \
+    --data-binary @- | jq '.data.searchProductsByVariationSkuPrefix'
 
 echo ""
 

--- a/web/src/app/api/search/route.ts
+++ b/web/src/app/api/search/route.ts
@@ -89,100 +89,99 @@ export async function POST(request: NextRequest) {
 
 // Shared search logic for both GET and POST
 async function performSearch(query: string) {
+  // Use GraphQL client with GET method for CDN caching
+  const client = getGraphQLClient(['search'], true);
+  const sdk = getSdk(client);
 
-    // Use GraphQL client with GET method for CDN caching
-    const client = getGraphQLClient(['search'], true);
-    const sdk = getSdk(client);
+  const trimmedQuery = query.trim();
+  const normalizedQuery = trimmedQuery.toLowerCase();
+  const shouldCheckVariations = looksLikeSku(trimmedQuery);
 
-    const trimmedQuery = query.trim();
-    const normalizedQuery = trimmedQuery.toLowerCase();
-    const shouldCheckVariations = looksLikeSku(trimmedQuery);
+  // Build query array conditionally - add custom variation SKU search if input looks like a SKU
+  const queryPromises = [
+    // Query 1: Search product name/description (fuzzy match)
+    sdk.SearchProducts({ search: trimmedQuery, first: 8 }),
+    // Query 2: Search by parent product SKU (exact match)
+    sdk.SearchProductsBySKU({ sku: trimmedQuery, first: 8 }),
+  ];
 
-    // Build query array conditionally - add custom variation SKU search if input looks like a SKU
-    const queryPromises = [
-      // Query 1: Search product name/description (fuzzy match)
-      sdk.SearchProducts({ search: trimmedQuery, first: 8 }),
-      // Query 2: Search by parent product SKU (exact match)
-      sdk.SearchProductsBySKU({ sku: trimmedQuery, first: 8 }),
-    ];
-
-    // Query 3: For SKU-like patterns, use custom WPGraphQL resolver to search variation SKUs
-    // This queries wp_postmeta directly for _sku (replicates Relevanssi behavior without the plugin)
-    if (shouldCheckVariations) {
-      logger.debug('Search API variation SKU search enabled', {
-        query: trimmedQuery,
-        normalizedQuery,
-        shouldCheckVariations,
-      });
-      queryPromises.push(
-        sdk.SearchProductsByVariationSku({ sku: trimmedQuery, first: 10 })
-      );
-    } else {
-      logger.debug('Search API variation SKU search skipped', {
-        query: trimmedQuery,
-        normalizedQuery,
-        shouldCheckVariations,
-      });
-    }
-
-    const results = await Promise.all(queryPromises);
-    
-    // Handle variation query results with explicit types
-    let nameData: SearchProductsQuery;
-    let skuData: SearchProductsQuery;
-    let variationData: SearchProductsByVariationSkuQuery | undefined;
-    
-    if (shouldCheckVariations) {
-      [nameData, skuData, variationData] = results as [SearchProductsQuery, SearchProductsQuery, SearchProductsByVariationSkuQuery];
-    } else {
-      [nameData, skuData] = results as [SearchProductsQuery, SearchProductsQuery];
-    }
-    
-    logger.debug('Search API query results', {
-      nameMatches: nameData.products?.nodes?.length || 0,
-      skuMatches: skuData.products?.nodes?.length || 0,
-      variationMatches: variationData?.searchProductsByVariationSku?.length || 0,
+  // Query 3: For SKU-like patterns, use custom WPGraphQL resolver to search variation SKUs
+  // This queries wp_postmeta directly for _sku (replicates Relevanssi behavior without the plugin)
+  if (shouldCheckVariations) {
+    logger.debug('Search API variation SKU search enabled', {
+      query: trimmedQuery,
+      normalizedQuery,
+      shouldCheckVariations,
     });
+    queryPromises.push(
+      sdk.SearchProductsByVariationSku({ sku: trimmedQuery, first: 10 })
+    );
+  } else {
+    logger.debug('Search API variation SKU search skipped', {
+      query: trimmedQuery,
+      normalizedQuery,
+      shouldCheckVariations,
+    });
+  }
 
-    // Extract products from GraphQL responses
-    const nameResults = (nameData.products?.nodes || []) as SearchProduct[];
-    const skuResults = (skuData.products?.nodes || []) as SearchProduct[];
-    
-    // Extract variation search results (custom resolver returns parent products directly)
-    let variationResults: SearchProduct[] = [];
-    if (shouldCheckVariations && variationData?.searchProductsByVariationSku) {
-      variationResults = variationData.searchProductsByVariationSku.filter((p): p is SearchProduct => p !== null);
-      logger.debug('Search API variation SKU search results', {
-        count: variationResults.length,
-        query: normalizedQuery,
-      });
-    }
+  const results = await Promise.all(queryPromises);
+  
+  // Handle variation query results with explicit types
+  let nameData: SearchProductsQuery;
+  let skuData: SearchProductsQuery;
+  let variationData: SearchProductsByVariationSkuQuery | undefined;
+  
+  if (shouldCheckVariations) {
+    [nameData, skuData, variationData] = results as [SearchProductsQuery, SearchProductsQuery, SearchProductsByVariationSkuQuery];
+  } else {
+    [nameData, skuData] = results as [SearchProductsQuery, SearchProductsQuery];
+  }
+  
+  logger.debug('Search API query results', {
+    nameMatches: nameData.products?.nodes?.length || 0,
+    skuMatches: skuData.products?.nodes?.length || 0,
+    variationMatches: variationData?.searchProductsByVariationSku?.length || 0,
+  });
 
-    // Create a Map to deduplicate by product ID with priority ordering
-    // Priority: Variation SKU (exact configured match) > Product SKU (parent match) > Name (fuzzy)
-    const resultsMap = new Map<string, SearchProduct>();
-    
-    // Add variation SKU matches first (highest priority - exact configured product match)
-    variationResults.forEach((product) => {
+  // Extract products from GraphQL responses
+  const nameResults = (nameData.products?.nodes || []) as SearchProduct[];
+  const skuResults = (skuData.products?.nodes || []) as SearchProduct[];
+  
+  // Extract variation search results (custom resolver returns parent products directly)
+  let variationResults: SearchProduct[] = [];
+  if (shouldCheckVariations && variationData?.searchProductsByVariationSku) {
+    variationResults = variationData.searchProductsByVariationSku.filter((p): p is SearchProduct => p !== null);
+    logger.debug('Search API variation SKU search results', {
+      count: variationResults.length,
+      query: normalizedQuery,
+    });
+  }
+
+  // Create a Map to deduplicate by product ID with priority ordering
+  // Priority: Variation SKU (exact configured match) > Product SKU (parent match) > Name (fuzzy)
+  const resultsMap = new Map<string, SearchProduct>();
+  
+  // Add variation SKU matches first (highest priority - exact configured product match)
+  variationResults.forEach((product) => {
+    resultsMap.set(product.id, product);
+  });
+  
+  // Add product SKU results (second priority - parent product SKU match)
+  skuResults.forEach((product) => {
+    if (!resultsMap.has(product.id)) {
       resultsMap.set(product.id, product);
-    });
-    
-    // Add product SKU results (second priority - parent product SKU match)
-    skuResults.forEach((product) => {
-      if (!resultsMap.has(product.id)) {
-        resultsMap.set(product.id, product);
-      }
-    });
+    }
+  });
 
-    // Add name search results (lowest priority - fuzzy name match)
-    nameResults.forEach((product) => {
-      if (!resultsMap.has(product.id)) {
-        resultsMap.set(product.id, product);
-      }
-    });
+  // Add name search results (lowest priority - fuzzy name match)
+  nameResults.forEach((product) => {
+    if (!resultsMap.has(product.id)) {
+      resultsMap.set(product.id, product);
+    }
+  });
 
-    // Convert Map back to array and limit to 8 results for dropdown
-    const mergedResults = Array.from(resultsMap.values()).slice(0, 8);
+  // Convert Map back to array and limit to 8 results for dropdown
+  const mergedResults = Array.from(resultsMap.values()).slice(0, 8);
 
-    return NextResponse.json({ products: { nodes: mergedResults } });
+  return NextResponse.json({ products: { nodes: mergedResults } });
 }

--- a/web/src/app/api/search/route.ts
+++ b/web/src/app/api/search/route.ts
@@ -32,15 +32,15 @@ interface SearchProduct {
 
 /**
  * SKU pattern detector - helps optimize by only running variation query when needed
- * Typical SKU format: letters, numbers, hyphens, slashes (e.g., "BA/TQF-B-2-C80-J-A-B-F")
+ * Typical SKU format: letters, numbers, hyphens, slashes, quotes (e.g., "BA/TQF-B-2-C80-J-A-B-F", "4\"-BB4")
  * 
  * @param query - Search query string to test
- * @returns True if query matches SKU pattern (alphanumeric with dashes/underscores/slashes)
+ * @returns True if query matches SKU pattern (alphanumeric with dashes/underscores/slashes/quotes)
  */
 function looksLikeSku(query: string): boolean {
-  // Match patterns with alphanumeric + dash/underscore/slash (common SKU formats)
-  // At least one letter and one number, may contain dashes/underscores/slashes
-  return /^[A-Za-z0-9\-_/]+$/.test(query) && /[A-Za-z]/.test(query) && /[0-9]/.test(query);
+  // Match patterns with alphanumeric + dash/underscore/slash/quote (common SKU formats)
+  // At least one letter and one number, may contain dashes/underscores/slashes/quotes
+  return /^[A-Za-z0-9\-_/"]+$/.test(query) && /[A-Za-z]/.test(query) && /[0-9]/.test(query);
 }
 
 /**
@@ -94,26 +94,35 @@ async function performSearch(query: string) {
     const client = getGraphQLClient(['search'], true);
     const sdk = getSdk(client);
 
-    const normalizedQuery = query.trim().toLowerCase();
-    const shouldCheckVariations = looksLikeSku(query);
+    const trimmedQuery = query.trim();
+    const normalizedQuery = trimmedQuery.toLowerCase();
+    const shouldCheckVariations = looksLikeSku(trimmedQuery);
 
     // Build query array conditionally - add custom variation SKU search if input looks like a SKU
     const queryPromises = [
       // Query 1: Search product name/description (fuzzy match)
-      sdk.SearchProducts({ search: query, first: 8 }),
+      sdk.SearchProducts({ search: trimmedQuery, first: 8 }),
       // Query 2: Search by parent product SKU (exact match)
-      sdk.SearchProductsBySKU({ sku: query, first: 8 }),
+      sdk.SearchProductsBySKU({ sku: trimmedQuery, first: 8 }),
     ];
 
     // Query 3: For SKU-like patterns, use custom WPGraphQL resolver to search variation SKUs
     // This queries wp_postmeta directly for _sku (replicates Relevanssi behavior without the plugin)
     if (shouldCheckVariations) {
-      console.log('[Search API] Query looks like SKU, searching variation SKUs for:', query);
+      logger.debug('Search API variation SKU search enabled', {
+        query: trimmedQuery,
+        normalizedQuery,
+        shouldCheckVariations,
+      });
       queryPromises.push(
-        sdk.SearchProductsByVariationSku({ sku: query, first: 10 })
+        sdk.SearchProductsByVariationSku({ sku: trimmedQuery, first: 10 })
       );
     } else {
-      console.log('[Search API] Query does not look like SKU, skipping variation search for:', query);
+      logger.debug('Search API variation SKU search skipped', {
+        query: trimmedQuery,
+        normalizedQuery,
+        shouldCheckVariations,
+      });
     }
 
     const results = await Promise.all(queryPromises);
@@ -129,7 +138,7 @@ async function performSearch(query: string) {
       [nameData, skuData] = results as [SearchProductsQuery, SearchProductsQuery];
     }
     
-    console.log('[Search API] Query results:', {
+    logger.debug('Search API query results', {
       nameMatches: nameData.products?.nodes?.length || 0,
       skuMatches: skuData.products?.nodes?.length || 0,
       variationMatches: variationData?.searchProductsByVariationSku?.length || 0,
@@ -143,7 +152,10 @@ async function performSearch(query: string) {
     let variationResults: SearchProduct[] = [];
     if (shouldCheckVariations && variationData?.searchProductsByVariationSku) {
       variationResults = variationData.searchProductsByVariationSku.filter((p): p is SearchProduct => p !== null);
-      console.log('[Search API] Variation SKU search found:', variationResults.length, 'products for query:', normalizedQuery);
+      logger.debug('Search API variation SKU search results', {
+        count: variationResults.length,
+        query: normalizedQuery,
+      });
     }
 
     // Create a Map to deduplicate by product ID with priority ordering

--- a/web/src/lib/graphql/generated.ts
+++ b/web/src/lib/graphql/generated.ts
@@ -39231,7 +39231,7 @@ export type SearchProductsByVariationSkuQuery = { __typename?: 'RootQuery', sear
     | { __typename?: 'ExternalProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
     | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
     | { __typename?: 'SimpleProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
-    | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
+    | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
    | null | undefined> | null | undefined };
 
 export type SearchProductsByVariationSkuPrefixQueryVariables = Exact<{
@@ -39244,7 +39244,7 @@ export type SearchProductsByVariationSkuPrefixQuery = { __typename?: 'RootQuery'
     | { __typename?: 'ExternalProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
     | { __typename?: 'GroupProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
     | { __typename?: 'SimpleProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined }
-    | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined, variations?: { __typename?: 'ProductWithVariationsToProductVariationConnection', nodes: Array<{ __typename?: 'SimpleProductVariation', sku?: string | null | undefined }> } | null | undefined }
+    | { __typename?: 'VariableProduct', sku?: string | null | undefined, partNumber?: string | null | undefined, price?: string | null | undefined, shortDescription?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined, slug?: string | null | undefined, parent?: { __typename?: 'ProductCategoryToParentProductCategoryConnectionEdge', node: { __typename?: 'ProductCategory', id: string, name?: string | null | undefined, slug?: string | null | undefined } } | null | undefined }> } | null | undefined }
    | null | undefined> | null | undefined };
 
 
@@ -41523,7 +41523,7 @@ export const SearchProductsBySkuDocument = gql`
     `;
 export const ListVariableProductsWithVariationSkusDocument = gql`
     query ListVariableProductsWithVariationSkus($first: Int = 50) {
-  products(where: {orderby: {field: DATE, order: ASC}}, first: $first) {
+  products(where: {type: VARIABLE, visibility: VISIBLE}, first: $first) {
     nodes {
       id
       databaseId
@@ -41630,11 +41630,6 @@ export const SearchProductsByVariationSkuDocument = gql`
           }
         }
       }
-      variations(first: 100) {
-        nodes {
-          sku
-        }
-      }
     }
   }
 }
@@ -41666,11 +41661,6 @@ export const SearchProductsByVariationSkuPrefixDocument = gql`
               slug
             }
           }
-        }
-      }
-      variations(first: 100) {
-        nodes {
-          sku
         }
       }
     }

--- a/web/src/lib/graphql/queries/search.graphql
+++ b/web/src/lib/graphql/queries/search.graphql
@@ -113,7 +113,7 @@ query SearchProductsBySKU($sku: String!, $first: Int = 24) {
 }
 
 query ListVariableProductsWithVariationSkus($first: Int = 50) {
-  products(where: { orderby: { field: DATE, order: ASC } }, first: $first) {
+  products(where: { type: VARIABLE, visibility: VISIBLE }, first: $first) {
     nodes {
       id
       databaseId
@@ -220,11 +220,6 @@ query SearchProductsByVariationSku($sku: String!, $first: Int = 10) {
           }
         }
       }
-      variations(first: 100) {
-        nodes {
-          sku
-        }
-      }
     }
   }
 }
@@ -257,11 +252,6 @@ query SearchProductsByVariationSkuPrefix($prefix: String!, $first: Int = 20) {
               slug
             }
           }
-        }
-      }
-      variations(first: 100) {
-        nodes {
-          sku
         }
       }
     }


### PR DESCRIPTION
## Copilot PR Review Fixes (13 issues resolved)

### 🔧 Search Route Improvements (route.ts)
- Add double-quote support to SKU regex (handles SKUs like 4"-BB4)
- Fix trim inconsistency: use trimmedQuery for both detection and GraphQL vars
- Replace console.log with logger.debug for structured logging
- Add contextual metadata to all debug logs

### 📊 GraphQL Query Optimizations (search.graphql)
- Remove variations(first: 100) from SearchProductsByVariationSku queries
  * Reduces payload size significantly (was fetching 100 SKUs per result)
  * API route doesn't use variation nodes, only parent product fields
- Restore type: VARIABLE filter to ListVariableProductsWithVariationSkus
  * Was accidentally changed to orderby: DATE which broke filtering
  * Now correctly filters to variable+visible products only

### 🔐 Security & Infrastructure (scripts)
- deploy-variation-search.sh: Use environment variables for SSH credentials
  * Add require_env() helper with fallback defaults for staging
  * Require env vars for production (no hard-coded values)
  * Fix plugin path: bapi-graphql-variation-search.php (was wrong file)
- test-variation-search.sh: Move infrastructure to env vars
  * Add get_env() helper with defaults
  * Fix GraphQL queries to use custom resolvers (searchProductsByVariationSku)
  * Use jq for proper JSON escaping (prevents curl payload errors)

### 🐛 SQL Injection Fix (bapi-variation-sku-search.php)
- Prepare variation SKU clause separately before appending to $search
  * Prevents wpdb->prepare() issues with existing % wildcards
  * Note: This file is NOT deployed (historical investigation code)
  * Active plugin is bapi-graphql-variation-search.php (already secure)

### 📖 Documentation Updates
- VARIATION-SKU-SEARCH-IMPLEMENTATION.md: Clarify current vs historical
  * Mark posts_search and triple-query approaches as historical notes
  * Document current resolver-based implementation clearly
  * Prevent confusion about which approach is active

### ✅ TypeScript & Build
- Regenerate GraphQL types after query changes
- Production build passes all checks

