### PR TITLE
Fix Recently Viewed product links removing duplicate locale prefix

### DIFF
--- a/web/src/components/products/RecentlyViewed.tsx
+++ b/web/src/components/products/RecentlyViewed.tsx
@@ -108,7 +108,7 @@ export default function RecentlyViewed({
             </button>
 
             {/* Product link */}
-            <Link href={`/en/product/${product.slug}`} className="block">
+            <Link href={`/product/${product.slug}`} className="block">
               {/* Product image */}
               <div
                 className={`relative bg-neutral-50 ${compact ? 'aspect-square' : 'aspect-[4/3]'}`}


### PR DESCRIPTION
## Fix Recently Viewed Product Links (Duplicate Locale Prefix)

### Problem
Clicking products in the "Recently Viewed" section resulted in 404 errors. URLs were generating with duplicate locale prefixes: `/en/en/product/digital-co-and-no2-sensor`

### Root Cause
The `RecentlyViewed` component had a hardcoded `/en/` prefix in the product link:
```tsx
<Link href={`/en/product/${product.slug}`} className="block">

Pattern Consistency
This fix brings RecentlyViewed in line with all other product link patterns:

✅ ProductCard.tsx - uses /product/${slug}
✅ ProductGrid.tsx - uses /product/${product.slug}
✅ CartItems.tsx - uses /product/${product.slug}
✅ RelatedProductsClient.tsx - uses /product/${product.slug}
✅ ProductComparison.tsx - uses /product/${product.slug}
Testing
 No TypeScript errors
 Verified link pattern matches codebase conventions
 Manual test: Click Recently Viewed products → should navigate to correct product page
