### PR TITLE
feat: Request HD1080 quality by default for YouTube embeds

### DIFF
--- a/web/src/components/shared/YouTubeEmbed.tsx
+++ b/web/src/components/shared/YouTubeEmbed.tsx
@@ -59,7 +59,7 @@ export default function YouTubeEmbed({
   thumbnailQuality = 'hqdefault',
   autoLoad = false,
   className = '',
-  params = 'rel=0&modestbranding=1',
+  params = 'rel=0&modestbranding=1&vq=hd1080',
   showDuration = false,
   durationSeconds,
 }: YouTubeEmbedProps) {


### PR DESCRIPTION
- Add vq=hd1080 parameter to default YouTube embed params
- Ensures highest quality playback is automatically selected
- YouTube will adapt based on bandwidth and screen size

