### PR TITLE
feat: add missing 3 Air Quality subcategories to navigation (Issue #8)

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -92,7 +92,13 @@
         "voc": "VOC Sensors",
         "vocDesc": "Volatile organic compounds",
         "particulate": "Particulate Matter",
-        "particulateDesc": "PM2.5 and PM10"
+        "particulateDesc": "PM2.5 and PM10",
+        "nitrogenDioxide": "Nitrogen Dioxide",
+        "nitrogenDioxideDesc": "NO₂ gas detection",
+        "carbonMonoxide": "Carbon Monoxide",
+        "carbonMonoxideDesc": "CO gas detection",
+        "refrigerantLeak": "Refrigerant Leak Detection",
+        "refrigerantLeakDesc": "Refrigerant leak sensors"
       },
       "wireless": {
         "title": "Wireless",

--- a/web/src/components/layout/Header/config.ts
+++ b/web/src/components/layout/Header/config.ts
@@ -128,6 +128,21 @@ export const getMegaMenuItems = (t: any): MegaMenuItem[] => [
               href: '/products/air-quality-sensors/particulate',
               description: t('products.airQuality.particulateDesc'),
             },
+            {
+              label: t('products.airQuality.nitrogenDioxide'),
+              href: '/products/air-quality-sensors/nitrogen-dioxide',
+              description: t('products.airQuality.nitrogenDioxideDesc'),
+            },
+            {
+              label: t('products.airQuality.carbonMonoxide'),
+              href: '/products/air-quality-sensors/carbon-monoxide',
+              description: t('products.airQuality.carbonMonoxideDesc'),
+            },
+            {
+              label: t('products.airQuality.refrigerantLeak'),
+              href: '/products/air-quality-sensors/refrigerant-leak-det',
+              description: t('products.airQuality.refrigerantLeakDesc'),
+            },
           ],
         },
         {


### PR DESCRIPTION
- Add Nitrogen Dioxide subcategory (3 products)
- Add Carbon Monoxide subcategory (7 products)
- Add Refrigerant Leak Detection subcategory (3 products)
- Update English translations for all 3 new subcategories
- Update mega menu navigation config to show all 6 Air Quality sensors

Now mega menu displays all 6 subcategories matching WordPress structure:
1. CO₂ Sensors (carbon-dioxide)
2. VOC Sensors (voc)
3. Particulate Matter (particulate)
4. Nitrogen Dioxide (nitrogen-dioxide)
5. Carbon Monoxide (carbon-monoxide)
6. Refrigerant Leak Detection (refrigerant-leak-det)

Resolves Terry QA feedback Issue #8

