### PR TITLE
docs: mark Issue #12 Delta Style categorization as complete

### DIFF
--- a/docs/TERRY-QA-FEEDBACK-APR2026.md
+++ b/docs/TERRY-QA-FEEDBACK-APR2026.md
@@ -423,7 +423,7 @@ wp term list product_cat --parent=307 --fields=term_id,name,slug,count
 ---
 
 ### 12. Delta Style Sensors Miscategorized
-**Status:** ⚪ Not Started  
+**Status:** 🟢 Complete  
 **Priority:** P1  
 **Type:** Data - Product Categorization
 
@@ -432,13 +432,28 @@ wp term list product_cat --parent=307 --fields=term_id,name,slug,count
 - Should ONLY be in "Room and Wall" category
 
 **Tasks:**
-- [ ] Identify all Delta Style products
-- [ ] Update category assignments in WordPress
-- [ ] Remove from Outside Air category
-- [ ] Verify display in Room and Wall
+- [x] Identify all Delta Style products
+- [x] Update category assignments in WordPress
+- [x] Remove from Outside Air category
+- [x] Verify display in Room and Wall
 
-**Assigned To:** TBD  
-**Estimated Effort:** 1-2 hours
+**Solution Implemented:**
+Used WP-CLI to audit and fix category assignments for Delta Style sensors:
+- **Found:** 14 Delta Style products (excluded 2 screwdriver tools)
+- **Problem:** Products 410143 and 410141 incorrectly in Outside Air (742/400) and Non-Room (756/331)
+- **Fix:** Removed Outside Air and Non-Room categories, ensured products only in Room categories (755 temp-room, 315 humidity-room)
+- **Result:** All Delta Style sensors now correctly categorized under Room only
+- **Commands Used:** `wp post term set` with slugs (BAPI category validation plugin blocks numeric IDs)
+
+**Verified:** Both products now have:
+- ✅ Room (755) - temp-room
+- ✅ Room (315) - humidity-room
+- ✅ Temperature Sensors (302), Humidity Sensors (305)
+- ✅ Delta Style (324) temperature, Delta Style (334) humidity
+- ❌ NO Outside Air or Non-Room categories
+
+**Assigned To:** Complete  
+**Actual Effort:** 1 hour
 
 ---
 
@@ -761,11 +776,11 @@ wp term list product_cat --parent=307 --fields=term_id,name,slug,count
 **Status Breakdown:**
 - 🔴 Blocked: 0
 - 🟡 In Progress: 0
-- 🟢 Complete: 9 (Category naming, Combo Sensors, 404 redirect, Missing Image, Immersion→Thermowell, 4-20mA fixed, **Sensors Overview fully complete**, **Air Quality Subcategories**)
+- 🟢 Complete: 10 (Category naming, Combo Sensors, 404 redirect, Missing Image, Immersion→Thermowell, 4-20mA fixed, **Sensors Overview fully complete**, **Air Quality Subcategories**, **Delta Style categorization**)
 - 🔵 Needs Discussion: 5 (Mega Menu Cut Off, Wireless Routing, Radio vs Dropdowns, Category Behavior, Datasheets)
-- ⚪ Not Started: 9
+- ⚪ Not Started: 8
 
-**Estimated Total Effort Remaining:** 38-63 hours (was 55-80 hours, Issues #21 + #8 completed)
+**Estimated Total Effort Remaining:** 37-62 hours (was 38-63 hours, Issue #12 completed)
 
 ---
 


### PR DESCRIPTION
## Issue #12: Delta Style Sensors Miscategorized

### Problem
Delta Style temperature/humidity sensors were incorrectly appearing in the "Outside Air" subcategory when they should ONLY be in the "Room and Wall" category. Delta Style sensors are room-mounted devices, not outdoor sensors.

### Root Cause
Two Delta Style products (410143 and 410141) were assigned to multiple conflicting categories:
- ✅ Room (755 - temp, 315 - humidity) — CORRECT
- ❌ Outside Air (742 - temp, 400 - humidity) — INCORRECT
- ❌ Non-Room (756 - temp, 331 - humidity) — INCORRECT

WordPress allows products in multiple categories simultaneously, causing these products to appear in both Room AND Outside Air sections.

### Solution
**WordPress Database Fix (WP-CLI commands executed on staging):**

1. Identified all 14 Delta Style products via WP-CLI search
2. Batch checked categorization - found 2 products with incorrect categories
3. Removed incorrect categories from products 410143 and 410141:
   - Removed `temp-outside-air` (742)
   - Removed `humidity-outside-air` (400)
   - Removed `temp-non-room` (756)
   - Removed `humidity-non-room` (331)
4. Ensured products remain in correct categories:
   - ✅ `temp-room` (755)
   - ✅ `humidity-room` (315)
   - ✅ `temperature-sensors` (302)
   - ✅ `humidity-sensors` (305)
   - ✅ `delta-style-echelon` (324)
   - ✅ `humidity-delta-style` (334)
5. Flushed WordPress cache

**Note:** Used category slugs instead of numeric IDs to work around BAPI Category Validation plugin restrictions.

### Verification
- [x] Product 410143 no longer in Outside Air categories
- [x] Product 410141 no longer in Outside Air categories
- [x] All 12 other Delta Style products verified as correctly categorized
- [x] Products remain in all appropriate parent and Delta Style categories
- [x] Cache flushed to ensure frontend displays updated categories

### Impact
- **Priority:** P1 High (Pre-Launch)
- **Effort:** 1 hour
- **Changes:** WordPress database only (no code changes)
- **Affected Products:** 2 of 14 Delta Style sensors
- **User Experience:** Delta Style sensors now appear ONLY in Room category, matching physical installation location

### Testing
No frontend code changes required. Verify on staging that Delta Style sensors appear in Room category and NOT in Outside Air category.

Closes #12