### PR TITLE
fix: normalize periods in attribute slugs

### DIFF
--- a/web/src/lib/variations.ts
+++ b/web/src/lib/variations.ts
@@ -41,8 +41,8 @@ export function normalizeAttributeSlug(name: string): string {
     .replace(/^(pa_|attribute_pa_)/, '')
     // Convert ampersands to "and" to match WooCommerce slug generation
     .replace(/\s*&\s*/g, '-and-')
-    // Remove special characters (degree symbol, percent, commas, quotes, angle brackets)
-    .replace(/[°,%<>'"]/g, '')
+    // Remove special characters (degree symbol, percent, commas, quotes, angle brackets, periods)
+    .replace(/[°,%<>'"\.]/g, '')
     // Convert underscores to hyphens (WordPress uses both)
     .replace(/_/g, '-')
     // Replace spaces with hyphens


### PR DESCRIPTION
- Add period (.) to special characters regex in normalizeAttributeSlug()
- Fixes empty dropdown bug for 'Comm. Jack and Test and Balance' attribute
- Product attribute 'Comm. Jack and Test and Balance' now matches variation attribute 'comm-jack-and-test-and-balance'
- Before: comm.-jack-and-test-and-balance (mismatch)
- After: comm-jack-and-test-and-balance (match)

