### PR TITLE
fix: Remove fake accessories subcategories, replace with single 'All …

### DIFF
--- a/docs/ACCESSORIES-INVESTIGATION.md
+++ b/docs/ACCESSORIES-INVESTIGATION.md
@@ -1,0 +1,264 @@
+# Accessories Subcategories Investigation - Issue #9
+
+**Date:** April 29, 2026  
+**Issue:** Three subcategories wrong in Accessories, pages don't function correctly  
+**Root Cause:** Fake subcategories added to headless site that don't exist in WordPress or legacy site  
+**Status:** ✅ Fixed
+
+---
+
+## Investigation Summary
+
+Terry's QA feedback stated: *"Accessories line covers so many unrelated things that it would be hard to make subcategories"*
+
+This investigation confirmed that the headless site incorrectly added three fake subcategories that:
+1. Don't exist as WordPress categories
+2. Weren't on the legacy site
+3. All pointed to the same generic `/accessories` page (broken navigation)
+
+---
+
+## WordPress Structure Analysis
+
+### Accessories Category (ID 313)
+
+```bash
+ssh -p 17338 bapiheadlessstaging@35.224.70.159
+cd public
+wp term list product_cat --parent=313
+```
+
+**Result:** Accessories has **NO subcategories** in WordPress.
+
+The category contains 64 mixed products with **filter-based navigation**:
+- **Application filters**: Averaging, Duct Temp, Immersion, Room Temp, etc. (10 application types)
+- **Enclosure Style filters**: BAPI-Com, BAPI-Stat 4, Button Sensor, Wall Plates, etc.
+- **Sensor Output filters**: 4-20mA/0-5V/0-10V, Thermistor/RTD, Modbus, Echelon
+- **Humidity Output filters**: Various humidity output types
+
+This confirms Terry's assessment: accessories are too diverse for meaningful subcategories.
+
+---
+
+## Legacy Site Structure (bapihvac.com)
+
+Navigated to: `https://www.bapihvac.com/products/accessories/`
+
+**Navigation structure:**
+```
+Products (dropdown menu)
+├── Test Instruments
+├── Temperature Sensors
+├── Humidity Sensors
+├── Pressure Sensors
+├── Air Quality
+├── Wireless
+├── Accessories        ← Single link, NO subcategories
+├── ETA
+└── WAM
+```
+
+**Key finding:** Accessories is a **simple link** with no dropdown subcategories, same as Test Instruments, ETA, and WAM.
+
+---
+
+## Headless Site Problem (bapi-headless.vercel.app)
+
+**Before fix:** Mega-menu showed three fake subcategories
+
+```typescript
+// web/src/components/layout/Header/config.ts (INCORRECT)
+{
+  title: t('products.accessories.title'),
+  slug: 'accessories',
+  icon: '/images/icons/Accessories_Icon.webp',
+  links: [
+    {
+      label: t('products.accessories.mounting'),
+      href: '/accessories',  // ← All point to same page!
+      description: t('products.accessories.mountingDesc'),
+    },
+    {
+      label: t('products.accessories.enclosures'),
+      href: '/accessories',  // ← Broken navigation
+    },
+    {
+      label: t('products.accessories.cables'),
+      href: '/accessories',  // ← Useless subcategories
+    },
+  ],
+}
+```
+
+**Issues identified:**
+1. **Non-existent categories**: "Mounting Hardware", "Enclosures", "Cables & Connectors" don't exist in WordPress
+2. **Broken navigation**: All three "subcategories" routed to same generic page
+3. **Poor UX**: Users clicking different subcategories got identical results
+4. **Inconsistent with legacy**: Legacy site has no accessories subcategories
+
+---
+
+## Solution Implemented
+
+### Option Considered & Rejected: Remove from mega-menu entirely
+Make Accessories a top-level link like Resources/Support/Company.
+
+**Why rejected:** Would require restructuring the entire mega-menu component, too invasive for launch deadline.
+
+### Option Implemented: Single "View All" link in mega-menu column
+
+Keep Accessories in mega-menu but with **one comprehensive link** instead of fake subcategories.
+
+```typescript
+// web/src/components/layout/Header/config.ts (CORRECT)
+{
+  title: t('products.accessories.title'),
+  slug: 'accessories',
+  icon: '/images/icons/Accessories_Icon.webp',
+  links: [
+    {
+      label: t('products.accessories.allAccessories'),
+      href: '/products/accessories',
+      description: t('products.accessories.allAccessoriesDesc'),
+    },
+  ],
+}
+```
+
+**Benefits:**
+- ✅ Matches WordPress structure (no subcategories)
+- ✅ Consistent with legacy site philosophy
+- ✅ Single, clear call-to-action
+- ✅ Users land on filter page where they can browse by application/enclosure/output
+- ✅ Minimal code changes (translation keys only)
+
+---
+
+## Files Changed
+
+### 1. Navigation Config
+**File:** `web/src/components/layout/Header/config.ts`
+
+**Change:** Replaced 3 fake subcategories with 1 "All Accessories" link pointing to `/products/accessories`
+
+### 2. Translation Strings
+**File:** `web/messages/en.json`
+
+**Before:**
+```json
+"accessories": {
+  "title": "Accessories",
+  "mounting": "Mounting Hardware",
+  "mountingDesc": "Plates, boxes, brackets",
+  "enclosures": "Enclosures",
+  "enclosuresDesc": "BAPI-Box & covers",
+  "cables": "Cables & Connectors",
+  "cablesDesc": "Wiring accessories"
+}
+```
+
+**After:**
+```json
+"accessories": {
+  "title": "Accessories",
+  "allAccessories": "All Accessories",
+  "allAccessoriesDesc": "Mounting hardware, enclosures, cables, and sensor accessories"
+}
+```
+
+**Impact:** Simpler, more accurate description of the diverse accessories catalog.
+
+---
+
+## Comparison: Legacy vs Headless
+
+| Aspect | Legacy Site | Headless (Before) | Headless (After Fix) |
+|--------|-------------|-------------------|---------------------|
+| **Navigation** | Single link | Mega-menu with 3 subcategories | Mega-menu with 1 link |
+| **Subcategories** | None | 3 fake ones | None |
+| **User clicks to browse** | 1 click | 2 clicks (but broken) | 2 clicks (working) |
+| **Page structure** | Filter-based | Filter-based | Filter-based |
+| **Consistency with WordPress** | ✅ | ❌ | ✅ |
+| **UX clarity** | Clear | Confusing | Clear |
+
+**Navigation improvement:** While legacy has no mega-menu dropdown at all, the headless fix provides a **single clear entry point** in the mega-menu structure, maintaining consistency with other product categories while respecting the reality that accessories are too diverse for subcategorization.
+
+---
+
+## Testing Checklist
+
+- [x] WordPress structure verified (no subcategories)
+- [x] Legacy site comparison complete
+- [x] Navigation config updated
+- [x] Translation strings added
+- [x] Production build successful
+- [x] TypeScript validation passed
+- [x] ESLint checks passed
+- [ ] Visual QA in staging
+- [ ] Cross-browser testing
+- [ ] Mobile responsive check
+
+---
+
+## Recommendations
+
+### For Phase 1 (May 4, 2026 Launch)
+✅ **Current fix is appropriate** - matches WordPress reality and legacy UX patterns
+
+### For Phase 2 (Post-Launch)
+Consider these enhancements:
+
+1. **Enhanced Filtering UI**
+   - Featured application filters on accessories landing page
+   - Quick links for popular combinations (e.g., "Room Temperature Mounting", "Duct Sensor Cables")
+   - Visual icons for each application type
+
+2. **Search Optimization**
+   - Add prominent search bar on accessories page
+   - Implement autocomplete for part numbers
+   - Tag products with use cases (e.g., "compatible with BA/10K-2", "wireless mounting")
+
+3. **Cross-Selling**
+   - "Frequently bought together" for sensor + accessory combos
+   - Automatic accessory suggestions based on cart contents
+
+---
+
+## Lessons Learned
+
+1. **WordPress is source of truth** - Always verify category structure in WordPress before implementing navigation
+2. **Legacy site patterns matter** - Terry's knowledge of business logic is encoded in legacy UX decisions
+3. **"No subcategories" is valid** - Not every category needs to be subdivided
+4. **User comments are gold** - Terry's note "too many unrelated things" was the key insight
+5. **Filter-based > Forced categorization** - For diverse product sets, let users filter by their own criteria
+
+---
+
+## Impact Assessment
+
+**User Experience:**
+- ✅ Clear, single entry point for all accessories
+- ✅ No confusion from fake subcategories
+- ✅ Filter page provides better browsing than forced categories
+
+**Performance:**
+- ✅ Faster mega-menu rendering (1 link vs 3)
+- ✅ Reduced translation bundle size
+- ✅ Simpler navigation state management
+
+**Maintenance:**
+- ✅ Easier to update (single link vs 3)
+- ✅ No need to track which products belong to which fake subcategory
+- ✅ Consistent with WordPress data model
+
+---
+
+## Conclusion
+
+The accessories "subcategories" problem was a classic case of **over-engineering** the navigation. The headless implementation tried to impose structure where the legacy site wisely kept it simple.
+
+**Key insight from Terry:** "Accessories line covers so many unrelated things that it would be hard to make subcategories"
+
+The fix honors this wisdom by providing a **single, clear path** to the accessories catalog where users can leverage the powerful filter system to find exactly what they need.
+
+**Result:** Better UX, simpler code, and consistency with WordPress data structure.

--- a/docs/DAILY-LOG.md
+++ b/docs/DAILY-LOG.md
@@ -528,6 +528,224 @@ curl -s -X POST "https://bapiheadlessstaging.kinsta.cloud/graphql" \
 
 ---
 
+## April 29, 2026 — Issue #9: Accessories Subcategories Fix 📦✅
+
+**Status:** ✅ COMPLETE - Ready for PR  
+**Branch:** `investigate/issue-9-accessories`  
+**Context:** Three subcategories wrong in Accessories, pages don't function correctly  
+**Priority:** 🔴 P1 - Pre-Launch (Navigation/Category Issue)  
+**Time:** ~1.5 hours (investigation → legacy comparison → fix)  
+**Approach:** Remove fake subcategories, replace with single "All Accessories" link
+
+### 🐛 USER REPORT
+
+**Issue:** Terry QA Feedback Issue #9 - Accessories Subcategories Wrong  
+**Problem:** Three subcategories in Accessories mega-menu don't work correctly  
+**Terry's Note:** "Accessories line covers so many unrelated things that it would be hard to make subcategories"
+
+**Current Incorrect Subcategories:**
+- Mounting Hardware → `/accessories`
+- Enclosures → `/accessories`
+- Cables & Connectors → `/accessories`
+
+**Problem:** All three "subcategories" point to the same generic page - broken navigation UX
+
+### 🔍 COMPREHENSIVE INVESTIGATION
+
+**Phase 1: WordPress Category Structure Verification**
+```bash
+ssh -p 17338 bapiheadlessstaging@35.224.70.159
+cd public
+wp term list product_cat --parent=313 --fields=term_id,name,slug,count
+```
+
+**Finding:** Accessories category (ID 313) has **NO subcategories** in WordPress ✅
+
+**WordPress Structure:**
+- **64 products** in single "Accessories" category
+- **Filter-based navigation** with 3 filter types:
+  - Application (10 types): Averaging, Duct Temp, Immersion, Room Temp, etc.
+  - Enclosure Style (7 types): BAPI-Com, BAPI-Stat 4, Button Sensor, Wall Plates, etc.
+  - Sensor Output (5 types): 4-20mA, Thermistor/RTD, Modbus, Echelon
+
+**Conclusion:** Terry is correct - accessories are too diverse for meaningful subcategories. WordPress reflects this with filter-based organization.
+
+**Phase 2: Legacy Site Structure (bapihvac.com)**
+
+Navigated to: `https://www.bapihvac.com/products/accessories/`
+
+**Navigation Pattern:**
+```
+Products (dropdown menu)
+├── Test Instruments       ← Single link, no subcategories
+├── Temperature Sensors    ← Has subcategories
+├── Humidity Sensors       ← Has subcategories
+├── Pressure Sensors       ← Has subcategories
+├── Air Quality           ← Has subcategories
+├── Wireless              ← Single link, no subcategories
+├── Accessories           ← Single link, NO subcategories ✅
+├── ETA                   ← Single link, no subcategories
+└── WAM                   ← Single link, no subcategories
+```
+
+**Key Finding:** Legacy site treats Accessories like Test Instruments - **simple link with no dropdown subcategories** ✅
+
+**Phase 3: Headless Site Analysis**
+
+**Current Mega-Menu Config:**
+```typescript
+// web/src/components/layout/Header/config.ts (BEFORE FIX)
+{
+  title: t('products.accessories.title'),
+  slug: 'accessories',
+  icon: '/images/icons/Accessories_Icon.webp',
+  links: [
+    {
+      label: t('products.accessories.mounting'),
+      href: '/accessories',  // ❌ All point to same page
+      description: t('products.accessories.mountingDesc'),
+    },
+    {
+      label: t('products.accessories.enclosures'),
+      href: '/accessories',  // ❌ Broken navigation
+    },
+    {
+      label: t('products.accessories.cables'),
+      href: '/accessories',  // ❌ Useless subcategories
+    },
+  ],
+}
+```
+
+**Issues Identified:**
+1. **Non-existent in WordPress:** "Mounting Hardware", "Enclosures", "Cables & Connectors" don't exist as WordPress categories
+2. **Broken UX:** All three "subcategories" route to same page - users clicking different options get identical results
+3. **Inconsistent with legacy:** Legacy site has NO accessories subcategories
+4. **Ignores Terry's wisdom:** "too many unrelated things" - filters work better than forced categories
+
+### ✅ SOLUTION IMPLEMENTED
+
+**Approach:** Replace 3 fake subcategories with single "All Accessories" link
+
+**Code Changes:**
+```typescript
+// web/src/components/layout/Header/config.ts (AFTER FIX)
+{
+  title: t('products.accessories.title'),
+  slug: 'accessories',
+  icon: '/images/icons/Accessories_Icon.webp',
+  links: [
+    {
+      label: t('products.accessories.allAccessories'),
+      href: '/products/accessories',
+      description: t('products.accessories.allAccessoriesDesc'),
+    },
+  ],
+}
+```
+
+**Translation Updates:**
+```json
+// web/messages/en.json (BEFORE)
+"accessories": {
+  "title": "Accessories",
+  "mounting": "Mounting Hardware",
+  "mountingDesc": "Plates, boxes, brackets",
+  "enclosures": "Enclosures",
+  "enclosuresDesc": "BAPI-Box & covers",
+  "cables": "Cables & Connectors",
+  "cablesDesc": "Wiring accessories"
+}
+
+// web/messages/en.json (AFTER)
+"accessories": {
+  "title": "Accessories",
+  "allAccessories": "All Accessories",
+  "allAccessoriesDesc": "Mounting hardware, enclosures, cables, and sensor accessories"
+}
+```
+
+**Benefits:**
+- ✅ Matches WordPress structure (no subcategories)
+- ✅ Consistent with legacy site UX pattern
+- ✅ Single, clear call-to-action
+- ✅ Users land on filter page where they can browse by application/enclosure/output
+- ✅ Honors Terry's assessment that accessories are too diverse for subcategorization
+- ✅ Simpler code, fewer translation keys
+
+### 📊 COMPARISON: LEGACY VS HEADLESS
+
+| Aspect | Legacy Site | Headless (Before Fix) | Headless (After Fix) |
+|--------|-------------|----------------------|---------------------|
+| **Navigation** | Single link | Mega-menu with 3 subcats | Mega-menu with 1 link |
+| **Subcategories** | None | 3 fake ones | None |
+| **User clicks** | 1 click | 2 clicks (broken) | 2 clicks (working) |
+| **Page structure** | Filter-based | Filter-based | Filter-based |
+| **WordPress consistency** | ✅ | ❌ | ✅ |
+| **UX clarity** | Clear | Confusing | Clear |
+
+**Navigation Improvement:** While legacy has no mega-menu at all, headless provides a **single clear entry point** in the mega-menu structure, maintaining consistency with other product categories while respecting the reality that accessories are too diverse for subcategorization.
+
+### 📝 FILES CHANGED
+
+1. **web/src/components/layout/Header/config.ts** (Lines 175-195)
+   - Replaced 3 fake subcategories with single "All Accessories" link
+   - Updated href to use full path: `/products/accessories`
+
+2. **web/messages/en.json** (Lines 114-121)
+   - Removed: mounting, mountingDesc, enclosures, enclosuresDesc, cables, cablesDesc
+   - Added: allAccessories, allAccessoriesDesc
+
+**Documentation:**
+- `docs/ACCESSORIES-INVESTIGATION.md` (NEW) - Comprehensive investigation report
+- `docs/TERRY-QA-FEEDBACK-APR2026.md` (UPDATED) - Issue #9 marked complete
+
+### 🧪 TESTING
+
+- [x] WordPress structure verified (no subcategories)
+- [x] Legacy site comparison complete
+- [x] Navigation config updated
+- [x] Translation strings updated
+- [x] Production build successful (Exit code 0)
+- [x] TypeScript validation passed
+- [x] ESLint checks passed
+- [ ] Visual QA in staging
+- [ ] Cross-browser testing
+- [ ] Mobile responsive check
+
+**Build Verification:**
+```bash
+cd /home/ateece/bapi-headless/web && pnpm run build
+# ✓ Compiled successfully in 9.2s
+# ✓ TypeScript validation passed
+# ✓ Generated 852 static pages
+# Exit code: 0 ✅
+```
+
+### 🎓 LESSONS LEARNED
+
+1. **User feedback contains hidden wisdom** - Terry's note "too many unrelated things" was the key insight
+2. **WordPress is source of truth** - Always verify category structure before implementing navigation
+3. **Legacy patterns matter** - Business logic is encoded in legacy UX decisions
+4. **"No subcategories" is valid** - Not every category needs subdivision
+5. **Filter-based > Forced categorization** - For diverse product sets, filters work better
+6. **Simpler is better** - Single clear link beats 3 broken ones
+
+### 🚀 NEXT STEPS
+
+1. Push branch and create PR for review
+2. Deploy to staging for visual QA
+3. Test mega-menu navigation across all devices
+4. Consider Phase 2 enhancements:
+   - Featured application filters on accessories landing page
+   - Quick links for popular combinations
+   - "Frequently bought together" cross-selling
+
+**Branch:** `investigate/issue-9-accessories`  
+**Ready for:** Immediate PR creation
+
+---
+
 ## April 28, 2026 — Attribute Slug Normalization: Period Character Bug Fix 🔧✅
 
 **Status:** ✅ COMPLETE - Merged to main  

--- a/docs/TERRY-QA-FEEDBACK-APR2026.md
+++ b/docs/TERRY-QA-FEEDBACK-APR2026.md
@@ -396,7 +396,7 @@ wp term list product_cat --parent=307 --fields=term_id,name,slug,count
 ---
 
 ### 9. Accessories Subcategories Wrong
-**Status:** ⚪ Not Started  
+**Status:** ✅ Complete  
 **Priority:** P1  
 **Type:** Bug - Category Structure
 
@@ -405,18 +405,37 @@ wp term list product_cat --parent=307 --fields=term_id,name,slug,count
 - Pages don't function correctly
 - Terry notes: "Accessories line covers so many unrelated things that it would be hard to make subcategories"
 
-**Current Incorrect Subcategories:**
-- Mounting Hardware
-- Enclosures
-- Cables & Connectors
+**Root Cause:**
+- Headless site added 3 fake subcategories: "Mounting Hardware", "Enclosures", "Cables & Connectors"
+- All three pointed to same `/accessories` page (broken navigation)
+- These subcategories don't exist in WordPress or on legacy site
 
-**Recommendation:**
-- [ ] Discuss if subcategories should exist at all
-- [ ] Consider removing subcategories for Accessories
-- [ ] Update navigation to match decision
+**Investigation Findings:**
+- ✅ WordPress: Accessories has NO subcategories (64 diverse products with filter-based navigation)
+- ✅ Legacy site: Accessories is a simple link, no dropdown subcategories
+- ✅ Headless: Incorrectly added fake subcategories causing UX confusion
 
-**Assigned To:** TBD  
-**Estimated Effort:** 1-2 hours + discussion
+**Solution Implemented:**
+- Replaced 3 fake subcategories with single "All Accessories" link
+- Matches WordPress structure (no subcategories)
+- Consistent with legacy site UX pattern
+- Users land on filter page to browse by application/enclosure/output
+
+**Files Changed:**
+- `web/src/components/layout/Header/config.ts` - Updated accessories navigation
+- `web/messages/en.json` - Simplified translation keys
+
+**Documentation:**
+- Full investigation: `docs/ACCESSORIES-INVESTIGATION.md`
+
+**Result:**
+- ✅ Clear, single entry point for accessories
+- ✅ No confusion from fake subcategories  
+- ✅ Filter page provides better browsing than forced categories
+- ✅ Consistent with WordPress data model
+
+**Assigned To:** Complete  
+**Actual Effort:** 1.5 hours
 
 ---
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -113,12 +113,8 @@
       },
       "accessories": {
         "title": "Accessories",
-        "mounting": "Mounting Hardware",
-        "mountingDesc": "Plates, boxes, brackets",
-        "enclosures": "Enclosures",
-        "enclosuresDesc": "BAPI-Box & covers",
-        "cables": "Cables & Connectors",
-        "cablesDesc": "Wiring accessories"
+        "allAccessories": "All Accessories",
+        "allAccessoriesDesc": "Mounting hardware, enclosures, cables, and sensor accessories"
       },
       "testInstruments": {
         "title": "Test Instruments",

--- a/web/src/components/layout/Header/config.ts
+++ b/web/src/components/layout/Header/config.ts
@@ -179,19 +179,9 @@ export const getMegaMenuItems = (t: any): MegaMenuItem[] => [
           icon: '/images/icons/Accessories_Icon.webp',
           links: [
             {
-              label: t('products.accessories.mounting'),
-              href: '/accessories',
-              description: t('products.accessories.mountingDesc'),
-            },
-            {
-              label: t('products.accessories.enclosures'),
-              href: '/accessories',
-              description: t('products.accessories.enclosuresDesc'),
-            },
-            {
-              label: t('products.accessories.cables'),
-              href: '/accessories',
-              description: t('products.accessories.cablesDesc'),
+              label: t('products.accessories.allAccessories'),
+              href: '/products/accessories',
+              description: t('products.accessories.allAccessoriesDesc'),
             },
           ],
         },


### PR DESCRIPTION
…Accessories' link

Fixes Issue #9 - Accessories Subcategories Wrong

Problem:
- Headless site had 3 fake subcategories: Mounting Hardware, Enclosures, Cables & Connectors
- All three pointed to same /accessories page (broken navigation)
- These subcategories don't exist in WordPress or legacy site
- Terry's note: 'Accessories line covers so many unrelated things that it would be hard to make subcategories'

Investigation:
- WordPress: Accessories (ID 313) has NO subcategories, 64 diverse products with filter-based navigation
- Legacy site: Accessories is simple link with no dropdown, same as Test Instruments/ETA/WAM
- Headless: Incorrectly added fake subcategories causing UX confusion

Solution:
- Replace 3 fake subcategories with single 'All Accessories' link to /products/accessories
- Matches WordPress structure (no subcategories)
- Consistent with legacy site UX pattern
- Users land on filter page to browse by application/enclosure/output
- Honors business logic that accessories are too diverse for subcategorization

Files Changed:
- web/src/components/layout/Header/config.ts - Updated accessories navigation
- web/messages/en.json - Simplified translation keys (allAccessories, allAccessoriesDesc)
- docs/ACCESSORIES-INVESTIGATION.md - Comprehensive investigation report
- docs/TERRY-QA-FEEDBACK-APR2026.md - Issue #9 marked complete
- docs/DAILY-LOG.md - Added Issue #9 session entry

Impact:
- Clear, single entry point for all accessories
- No confusion from fake subcategories
- Filter page provides better browsing than forced categories
- Simpler code, fewer translation keys

Testing:
- Production build successful (Exit code 0, 852 pages generated)
- TypeScript validation passed
- ESLint checks passed

