### PR TITLE
fix: Remove fake test instruments subcategories, replace with single …

### DIFF
--- a/docs/DAILY-LOG.md
+++ b/docs/DAILY-LOG.md
@@ -8,6 +8,115 @@
 
 ---
 
+## April 29, 2026 — Test Instruments Subcategories Fix 📊✅
+
+**Status:** ✅ COMPLETE - Ready for PR  
+**Branch:** `investigate/test-instruments-structure`  
+**Context:** Same pattern as Accessories - fake subcategories in mega-menu  
+**Priority:** 🟡 P2 - Navigation Consistency  
+**Time:** ~30 minutes (pattern recognition → quick fix)  
+**Approach:** Apply same solution as Accessories (Issue #9)
+
+### 🎯 PATTERN RECOGNITION
+
+After fixing Accessories (Issue #9), user requested: "We need to do the same for Test Instruments as we did for Accessories."
+
+**Investigation confirmed identical pattern:**
+- WordPress: Test Instruments (ID 600) has NO subcategories
+- Legacy site: Test Instruments is simple link (no dropdown)
+- Headless: 3 fake subcategories all pointing to same page
+
+### 🔍 QUICK VERIFICATION
+
+**WordPress Structure:**
+```bash
+wp term list product_cat --search='Test Instruments'
+# Result: term_id=600, parent=0, NO children
+
+wp term list product_cat --parent=600
+# Result: EMPTY
+```
+
+**Current Fake Subcategories:**
+1. Blu-Test Temperature → `/test-instruments`
+2. Blu-Test Humidity → `/test-instruments`
+3. Blu-Test Pressure → `/test-instruments`
+
+### ✅ SOLUTION IMPLEMENTED
+
+**Same fix as Accessories:**
+- Replace 3 fake subcategories with single "All Test Instruments" link
+- Comprehensive description: "NIST-traceable temperature, humidity, and pressure references"
+- Matches WordPress structure and legacy site pattern
+
+**Files Changed:**
+```typescript
+// web/src/components/layout/Header/config.ts
+{
+  title: t('products.testInstruments.title'),
+  slug: 'test-instruments',
+  icon: '/images/icons/Test_Instruments_Icon.webp',
+  links: [
+    {
+      label: t('products.testInstruments.allTestInstruments'),
+      href: '/products/test-instruments',
+      description: t('products.testInstruments.allTestInstrumentsDesc'),
+    },
+  ],
+}
+```
+
+```json
+// web/messages/en.json
+"testInstruments": {
+  "title": "Test Instruments",
+  "allTestInstruments": "All Test Instruments",
+  "allTestInstrumentsDesc": "NIST-traceable temperature, humidity, and pressure references"
+}
+```
+
+### 📝 DOCUMENTATION
+
+- `docs/TEST-INSTRUMENTS-FIX.md` - Full investigation and fix documentation
+- Follows same pattern as `docs/ACCESSORIES-INVESTIGATION.md`
+
+### 🧪 TESTING
+
+- [x] Production build successful (Exit code 0, 852 pages generated)
+- [x] TypeScript validation passed
+- [x] ESLint checks passed
+- [ ] Visual QA in staging
+- [ ] Cross-browser testing
+
+**Build Verification:**
+```bash
+cd /home/ateece/bapi-headless/web && pnpm run build
+# ✓ Compiled successfully in 9.7s
+# ✓ TypeScript validation passed
+# ✓ Generated 852 static pages
+# Exit code: 0 ✅
+```
+
+### 🎯 CATEGORIES WITH NO SUBCATEGORIES
+
+**Pattern established - these categories should have single "All" links:**
+1. ✅ Accessories (Issue #9) - Fixed
+2. ✅ Test Instruments (This fix)
+3. ❓ ETA - Need to verify next
+4. ❓ WAM - Featured section (not in columns)
+
+### 🚀 NEXT STEPS
+
+1. Commit and push branch
+2. Create PR for review
+3. Consider systematic review of all mega-menu categories
+4. Check ETA for same pattern
+
+**Branch:** `investigate/test-instruments-structure`  
+**Ready for:** Immediate PR creation
+
+---
+
 ## April 29, 2026 — Issue #4: Wireless Mega-Menu Navigation Fix 🧭✅
 
 **Status:** ✅ COMPLETE - Ready for PR  

--- a/docs/TEST-INSTRUMENTS-FIX.md
+++ b/docs/TEST-INSTRUMENTS-FIX.md
@@ -1,0 +1,252 @@
+# Test Instruments Subcategories Fix
+
+**Date:** April 29, 2026  
+**Pattern:** Identical to Accessories (Issue #9)  
+**Root Cause:** Fake subcategories added to headless site that don't exist in WordPress or legacy site  
+**Status:** ✅ Fixed
+
+---
+
+## Investigation Summary
+
+Following the same investigation pattern as Accessories, we confirmed that Test Instruments has the **exact same issue**: fake subcategories in the mega-menu that don't exist in WordPress or on the legacy site.
+
+---
+
+## WordPress Structure Analysis
+
+### Test Instruments Category (ID 600)
+
+```bash
+ssh -p 17338 bapiheadlessstaging@35.224.70.159
+cd public
+wp term list product_cat --search='Test Instruments'
+# Result: term_id=600, parent=0 (top-level)
+
+wp term list product_cat --parent=600
+# Result: EMPTY - NO subcategories
+```
+
+**Finding:** Test Instruments has **NO subcategories** in WordPress.
+
+---
+
+## Legacy Site Structure (bapihvac.com)
+
+Navigation structure from Products dropdown:
+```
+Products (dropdown menu)
+├── Test Instruments       ← Single link, NO subcategories ✅
+├── Temperature Sensors    ← Has subcategories
+├── Humidity Sensors       ← Has subcategories
+├── Pressure Sensors       ← Has subcategories
+├── Air Quality           ← Has subcategories
+├── Wireless              ← Single link, no subcategories
+├── Accessories           ← Single link, NO subcategories
+├── ETA                   ← Single link, no subcategories
+└── WAM                   ← Single link, no subcategories
+```
+
+**Key finding:** Test Instruments is a **simple link** with no dropdown subcategories, exactly like Accessories, ETA, and WAM.
+
+---
+
+## Headless Site Problem (Before Fix)
+
+**Mega-menu showed three fake subcategories:**
+
+```typescript
+// web/src/components/layout/Header/config.ts (INCORRECT)
+{
+  title: t('products.testInstruments.title'),
+  slug: 'test-instruments',
+  icon: '/images/icons/Test_Instruments_Icon.webp',
+  links: [
+    {
+      label: t('products.testInstruments.bluTestTemperature'),
+      href: '/test-instruments',  // ← All point to same page!
+      description: t('products.testInstruments.bluTestTemperatureDesc'),
+      badge: t('badges.new'),
+    },
+    {
+      label: t('products.testInstruments.bluTestHumidity'),
+      href: '/test-instruments',  // ← Broken navigation
+    },
+    {
+      label: t('products.testInstruments.bluTestPressure'),
+      href: '/test-instruments',  // ← Useless subcategories
+    },
+  ],
+}
+```
+
+**Issues identified:**
+1. **Non-existent categories**: "Blu-Test Temperature", "Blu-Test Humidity", "Blu-Test Pressure" don't exist as WordPress categories
+2. **Broken navigation**: All three "subcategories" routed to same generic page
+3. **Poor UX**: Users clicking different subcategories got identical results
+4. **Inconsistent with legacy**: Legacy site has no test instruments subcategories
+
+---
+
+## Solution Implemented
+
+### Single "All Test Instruments" link in mega-menu column
+
+Keep Test Instruments in mega-menu but with **one comprehensive link** instead of fake subcategories.
+
+```typescript
+// web/src/components/layout/Header/config.ts (CORRECT)
+{
+  title: t('products.testInstruments.title'),
+  slug: 'test-instruments',
+  icon: '/images/icons/Test_Instruments_Icon.webp',
+  links: [
+    {
+      label: t('products.testInstruments.allTestInstruments'),
+      href: '/products/test-instruments',
+      description: t('products.testInstruments.allTestInstrumentsDesc'),
+    },
+  ],
+}
+```
+
+**Benefits:**
+- ✅ Matches WordPress structure (no subcategories)
+- ✅ Consistent with legacy site philosophy (simple link like Accessories)
+- ✅ Single, clear call-to-action
+- ✅ Users land on test instruments page where they can browse all products
+- ✅ Minimal code changes (translation keys only)
+
+---
+
+## Files Changed
+
+### 1. Navigation Config
+**File:** `web/src/components/layout/Header/config.ts`
+
+**Change:** Replaced 3 fake subcategories with 1 "All Test Instruments" link pointing to `/products/test-instruments`
+
+### 2. Translation Strings
+**File:** `web/messages/en.json`
+
+**Before:**
+```json
+"testInstruments": {
+  "title": "Test Instruments",
+  "bluTestTemperature": "Blu-Test Temperature",
+  "bluTestTemperatureDesc": "NIST-traceable reference",
+  "bluTestHumidity": "Blu-Test Humidity",
+  "bluTestHumidityDesc": "Temp + RH reference",
+  "bluTestPressure": "Blu-Test Pressure",
+  "bluTestPressureDesc": "Digital manometer"
+}
+```
+
+**After:**
+```json
+"testInstruments": {
+  "title": "Test Instruments",
+  "allTestInstruments": "All Test Instruments",
+  "allTestInstrumentsDesc": "NIST-traceable temperature, humidity, and pressure references"
+}
+```
+
+**Impact:** Simpler, more accurate description of the test instruments catalog.
+
+---
+
+## Comparison: Legacy vs Headless
+
+| Aspect | Legacy Site | Headless (Before) | Headless (After Fix) |
+|--------|-------------|-------------------|---------------------|
+| **Navigation** | Single link | Mega-menu with 3 subcategories | Mega-menu with 1 link |
+| **Subcategories** | None | 3 fake ones | None |
+| **User clicks to browse** | 1 click | 2 clicks (but broken) | 2 clicks (working) |
+| **Consistency with WordPress** | ✅ | ❌ | ✅ |
+| **UX clarity** | Clear | Confusing | Clear |
+
+---
+
+## Pattern Recognition
+
+**Categories with NO subcategories in WordPress:**
+1. ✅ **Accessories** (Issue #9) - Fixed
+2. ✅ **Test Instruments** (This fix)
+3. ❓ **ETA** - Need to verify
+4. ❓ **WAM** - Featured section, not in columns
+
+**Categories WITH subcategories in WordPress:**
+- Temperature Sensors (10 application-based)
+- Humidity Sensors (2 subcategories)
+- Pressure Sensors (3 subcategories)
+- Air Quality (6 subcategories)
+- Bluetooth Wireless (7 subcategories)
+
+---
+
+## Testing Checklist
+
+- [x] WordPress structure verified (no subcategories)
+- [x] Legacy site comparison complete
+- [x] Navigation config updated
+- [x] Translation strings added
+- [ ] Production build successful
+- [ ] TypeScript validation passed
+- [ ] ESLint checks passed
+- [ ] Visual QA in staging
+- [ ] Cross-browser testing
+- [ ] Mobile responsive check
+
+---
+
+## Recommendations
+
+### Systematic Review Needed
+Consider reviewing **all** mega-menu categories to ensure they match WordPress structure:
+1. Query each category for subcategories in WordPress
+2. Compare with headless navigation config
+3. Fix any mismatches before May 4, 2026 launch
+
+### Pattern Established
+We now have a proven pattern for categories without subcategories:
+- Single "All [Category]" link
+- Comprehensive description
+- Matches WordPress reality
+
+---
+
+## Lessons Learned
+
+1. **Consistency is key** - Same problem, same solution works perfectly
+2. **WordPress defines structure** - Don't invent subcategories that don't exist
+3. **Legacy site encodes business logic** - Simple links for simple categories
+4. **Pattern recognition saves time** - Once we identified the Accessories issue, Test Instruments was quick
+
+---
+
+## Impact Assessment
+
+**User Experience:**
+- ✅ Clear, single entry point for all test instruments
+- ✅ No confusion from fake subcategories
+- ✅ Consistent navigation pattern across Accessories and Test Instruments
+
+**Performance:**
+- ✅ Faster mega-menu rendering (1 link vs 3)
+- ✅ Reduced translation bundle size
+- ✅ Simpler navigation state management
+
+**Maintenance:**
+- ✅ Easier to update (single link vs 3)
+- ✅ Consistent with WordPress data model
+- ✅ Scalable pattern for other simple categories
+
+---
+
+## Conclusion
+
+Test Instruments had the **exact same issue** as Accessories: fake subcategories that didn't exist in WordPress or on the legacy site. The fix was identical - replace with a single "All Test Instruments" link.
+
+**Result:** Better UX, simpler code, and consistency with WordPress data structure.
+
+**Next:** Consider reviewing ETA and any other top-level categories to ensure they follow the correct pattern.

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -118,12 +118,8 @@
       },
       "testInstruments": {
         "title": "Test Instruments",
-        "bluTestTemperature": "Blu-Test Temperature",
-        "bluTestTemperatureDesc": "NIST-traceable reference",
-        "bluTestHumidity": "Blu-Test Humidity",
-        "bluTestHumidityDesc": "Temp + RH reference",
-        "bluTestPressure": "Blu-Test Pressure",
-        "bluTestPressureDesc": "Digital manometer"
+        "allTestInstruments": "All Test Instruments",
+        "allTestInstrumentsDesc": "NIST-traceable temperature, humidity, and pressure references"
       },
       "featured": {
         "title": "WAM™ Wireless Asset Monitoring",

--- a/web/src/components/layout/Header/config.ts
+++ b/web/src/components/layout/Header/config.ts
@@ -191,20 +191,9 @@ export const getMegaMenuItems = (t: any): MegaMenuItem[] => [
           icon: '/images/icons/Test_Instruments_Icon.webp',
           links: [
             {
-              label: t('products.testInstruments.bluTestTemperature'),
-              href: '/test-instruments',
-              description: t('products.testInstruments.bluTestTemperatureDesc'),
-              badge: t('badges.new'),
-            },
-            {
-              label: t('products.testInstruments.bluTestHumidity'),
-              href: '/test-instruments',
-              description: t('products.testInstruments.bluTestHumidityDesc'),
-            },
-            {
-              label: t('products.testInstruments.bluTestPressure'),
-              href: '/test-instruments',
-              description: t('products.testInstruments.bluTestPressureDesc'),
+              label: t('products.testInstruments.allTestInstruments'),
+              href: '/products/test-instruments',
+              description: t('products.testInstruments.allTestInstrumentsDesc'),
             },
           ],
         },


### PR DESCRIPTION
…'All Test Instruments' link

Apply same pattern as Accessories fix (Issue #9) to Test Instruments category.

Problem:
- Mega-menu showed 3 fake subcategories (Blu-Test Temperature, Blu-Test Humidity, Blu-Test Pressure) all pointing to same /test-instruments page
- WordPress has NO subcategories under Test Instruments (term_id 600, parent 0)
- Legacy site shows Test Instruments as simple link (no dropdown)

Solution:
- Replace 3 fake subcategories with single 'All Test Instruments' link
- Add comprehensive description: 'NIST-traceable temperature, humidity, and pressure references'
- Matches WordPress structure and legacy UX pattern

Files Changed:
- web/src/components/layout/Header/config.ts (testInstruments section)
- web/messages/en.json (simplified translation keys)
- docs/TEST-INSTRUMENTS-FIX.md (investigation documentation)
- docs/DAILY-LOG.md (session entry)

Testing:
- Production build successful (Exit code 0, 852 pages)
- TypeScript validation passed
- ESLint checks passed

Pattern Recognition:
Categories with NO WordPress subcategories should have single 'All' link: ✅ Accessories (Issue #9)
✅ Test Instruments (this fix)
❓ ETA (needs verification)
❓ WAM (featured section)

