### PR TITLE
fix: reduce header height by making logo smaller and reducing padding

### DIFF
--- a/web/src/components/layout/Header/components/Logo.tsx
+++ b/web/src/components/layout/Header/components/Logo.tsx
@@ -15,7 +15,7 @@ const Logo: React.FC = () => (
       width={HEADER_CONFIG.logo.width}
       height={HEADER_CONFIG.logo.height}
       priority
-      className="h-16 w-auto sm:h-20 md:h-24 lg:h-28 xl:h-32"
+      className="h-12 w-auto sm:h-14 md:h-16 lg:h-18 xl:h-20"
     />
   </Link>
 );

--- a/web/src/components/layout/Header/index.tsx
+++ b/web/src/components/layout/Header/index.tsx
@@ -44,9 +44,9 @@ export const Header: React.FC<HeaderProps> = ({ className }) => {
         className
       )}
     >
-      <div className="relative mx-auto max-w-7xl px-4 py-2 sm:px-6 lg:px-8 lg:py-3">
+      <div className="relative mx-auto max-w-7xl px-4 py-1.5 sm:px-6 lg:px-8 lg:py-2">
         {/* Top Row: Region, Language, Sign In, Cart - Hidden on mobile, visible on desktop */}
-        <div className="bg-linear-to-r mb-2 hidden items-end justify-end gap-3 rounded-full from-neutral-50/50 via-white to-neutral-50/50 px-2 py-1 lg:mb-3 lg:flex">
+        <div className="bg-linear-to-r mb-1.5 hidden items-end justify-end gap-3 rounded-full from-neutral-50/50 via-white to-neutral-50/50 px-2 py-1 lg:mb-2 lg:flex">
           <RegionSelector />
           <div className="mb-2 h-6 w-px bg-neutral-300" />
           <LanguageSelector />


### PR DESCRIPTION
- Reduce logo heights: h-12 to h-20 (down from h-16 to h-32)
- Reduce header padding: py-1.5 to py-2 (down from py-2 to py-3)
- Reduce row spacing: mb-1.5 to mb-2 (down from mb-2 to mb-3)
- Overall header height reduced by ~25-40% across all breakpoints

