### PR TITLE
Fix/cart product variation display

### DIFF
--- a/web/src/components/cart/CartDrawer.tsx
+++ b/web/src/components/cart/CartDrawer.tsx
@@ -24,7 +24,7 @@ const CartDrawer = () => {
         aria-labelledby="cart-drawer-title"
         className="cart-drawer fixed right-0 top-0 z-modal flex h-full w-full max-w-md flex-col bg-white shadow-xl"
       >
-        {/* Header with safe area padding to prevent overlap with sticky header */}
+        {/* Header with responsive top padding to prevent overlap with sticky header (96px mobile, 112px tablet, 128px desktop) */}
         <div className="flex items-center justify-between border-b border-neutral-200 p-4 pt-24 sm:pt-28 lg:pt-32">
           <h2 id="cart-drawer-title" className="text-xl font-bold text-neutral-900">
             Shopping Cart

--- a/web/src/components/cart/CartPage/CartItems.tsx
+++ b/web/src/components/cart/CartPage/CartItems.tsx
@@ -142,7 +142,7 @@ export default function CartItems({
                 </Link>
 
                 {/* Variation Details */}
-                {item.selectedAttributes && Object.keys(item.selectedAttributes).length > 0 && (
+                {item.selectedAttributes && Object.keys(item.selectedAttributes).length > 0 ? (
                   <div className="mt-2 space-y-1 text-sm text-neutral-700">
                     {Object.entries(item.selectedAttributes).map(([attr, value]) => (
                       <div key={attr} className="flex gap-2">
@@ -153,6 +153,8 @@ export default function CartItems({
                       </div>
                     ))}
                   </div>
+                ) : (
+                  variation && <p className="mt-1 text-sm text-neutral-700">{variation.name}</p>
                 )}
 
                 {/* Part Number or SKU */}

--- a/web/src/components/cart/CartPage/CartItems.tsx
+++ b/web/src/components/cart/CartPage/CartItems.tsx
@@ -56,6 +56,10 @@ interface CartItem {
       };
     };
   };
+  // Product configuration details
+  selectedAttributes?: Record<string, string>;
+  variationSku?: string;
+  partNumber?: string;
 }
 
 interface CartItemsProps {
@@ -138,7 +142,25 @@ export default function CartItems({
                 </Link>
 
                 {/* Variation Details */}
-                {variation && <p className="mt-1 text-sm text-neutral-700">{variation.name}</p>}
+                {item.selectedAttributes && Object.keys(item.selectedAttributes).length > 0 && (
+                  <div className="mt-2 space-y-1 text-sm text-neutral-700">
+                    {Object.entries(item.selectedAttributes).map(([attr, value]) => (
+                      <div key={attr} className="flex gap-2">
+                        <span className="font-medium capitalize">
+                          {attr.replace(/-/g, ' ')}:
+                        </span>
+                        <span>{value}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {/* Part Number or SKU */}
+                {(item.partNumber || item.variationSku) && (
+                  <p className="mt-1 font-mono text-xs text-neutral-600">
+                    {item.partNumber || item.variationSku}
+                  </p>
+                )}
 
                 {/* Quantity and Remove - Mobile */}
                 <div className="mt-4 flex items-center gap-4 sm:hidden">

--- a/web/src/components/cart/CartPage/CartPageClient.tsx
+++ b/web/src/components/cart/CartPage/CartPageClient.tsx
@@ -78,6 +78,10 @@ interface CartItem {
       };
     };
   };
+  // Product configuration details
+  selectedAttributes?: Record<string, string>;
+  variationSku?: string;
+  partNumber?: string;
 }
 
 export default function CartPageClient() {
@@ -164,9 +168,14 @@ export default function CartPageClient() {
               ? {
                   node: {
                     databaseId: item.variationId,
+                    name: item.variationName || '',
                   },
                 }
               : null,
+            // Pass through product configuration details
+            selectedAttributes: item.selectedAttributes,
+            variationSku: item.variationSku,
+            partNumber: item.partNumber,
           })),
         },
       };

--- a/web/src/components/cart/CartPage/CartPageClient.tsx
+++ b/web/src/components/cart/CartPage/CartPageClient.tsx
@@ -163,12 +163,19 @@ export default function CartPageClient() {
                 image: item.image,
               },
             },
-            // Add variation data if present
+            // Add variation data if present (populate with required fields for display)
             variation: item.variationId
               ? {
                   node: {
+                    id: `variation-${item.variationId}`,
                     databaseId: item.variationId,
                     name: item.variationName || '',
+                    price: item.price,
+                    regularPrice: item.price, // Zustand store doesn't track separate regular/sale prices yet
+                    salePrice: undefined,
+                    stockStatus: 'IN_STOCK',
+                    stockQuantity: undefined,
+                    image: item.image,
                   },
                 }
               : null,

--- a/web/src/components/cart/CartPage/__tests__/CartItems.test.tsx
+++ b/web/src/components/cart/CartPage/__tests__/CartItems.test.tsx
@@ -150,6 +150,10 @@ describe('CartItems Component', () => {
       const itemWithVariation = [
         {
           ...mockItems[0],
+          selectedAttributes: {
+            size: 'Large',
+            color: 'Blue',
+          },
           variation: {
             node: {
               id: 'var-1',
@@ -163,7 +167,11 @@ describe('CartItems Component', () => {
       ];
 
       render(<CartItems {...defaultProps} items={itemWithVariation} />);
-      expect(screen.getByText('Size: Large, Color: Blue')).toBeInTheDocument();
+      // Check that attributes are displayed with labels
+      expect(screen.getByText(/size:/i)).toBeInTheDocument();
+      expect(screen.getByText('Large')).toBeInTheDocument();
+      expect(screen.getByText(/color:/i)).toBeInTheDocument();
+      expect(screen.getByText('Blue')).toBeInTheDocument();
     });
 
     it('uses variation image when available', () => {


### PR DESCRIPTION

## Files Changed
- `web/src/components/cart/CartPage/CartItems.tsx`
- `web/src/components/cart/CartPage/CartPageClient.tsx`

## Testing Status
⚠️ **Note**: One test is currently failing in `CartItems.test.tsx` (line 166). The test expects specific variation attribute text that may need adjustment to match the actual rendered format. This will be addressed before merge.

## UI Impact
**Before**: Cart page showed only product name and basic details  
**After**: Cart page shows complete configuration:
- Product name
- Selected attributes (e.g., "Transmitter Output: 4-20mA", "Housing: BAPI-Box")
- Variation SKU
- Part number (when available)

## Related Work
This fix aligns with the cart drawer implementation and ensures consistency across all cart views.

## Checklist
- [x] Code follows project TypeScript conventions
- [x] Changes committed with descriptive message
- [x] Branch pushed to remote
- [ ] Tests passing (1 failing test to be fixed)
- [ ] Ready for code review