### PR TITLE
fix: reduce product image height from 400px/450px to 300px/350px

### DIFF
--- a/web/src/components/products/ProductGallery.tsx
+++ b/web/src/components/products/ProductGallery.tsx
@@ -260,7 +260,7 @@ export default function ProductGallery({ images, productName, variation, variati
         {/* Main Image */}
         <div
           data-testid="main-image-container"
-          className="group relative flex h-[400px] w-full cursor-zoom-in items-center justify-center overflow-hidden rounded-xl border border-neutral-200 bg-white md:h-[450px]"
+          className="group relative flex h-[300px] w-full cursor-zoom-in items-center justify-center overflow-hidden rounded-xl border border-neutral-200 bg-white md:h-[350px]"
           onClick={() => openLightbox(selectedIndex)}
           aria-label={`View ${productName} in full screen`}
         >


### PR DESCRIPTION
Reduced main product image container height on ProductGallery:
- Mobile: 400px → 300px
- Desktop (md+): 450px → 350px

This makes the product image appear at a more appropriate size (~25% smaller) on the product page, addressing the issue where the image appeared to be rendering at 200% scale.

The image was taking up too much vertical space in the 5-column layout (lg:col-span-5 of 12-column grid). The new height provides better visual balance with the product description content.

Tests: All 1350 tests passing
Build: Production build successful

