### PR TITLE
fix: prevent hero image cutoff on landing pages at 1536px and 1920px …

### DIFF
--- a/web/src/app/[locale]/accessories/page.tsx
+++ b/web/src/app/[locale]/accessories/page.tsx
@@ -153,7 +153,7 @@ export default async function AccessoriesPage({ params }: Props) {
             <span className="font-medium text-white">{t('breadcrumb.accessories')}</span>
           </nav>
 
-          <div className="grid items-center gap-12 lg:grid-cols-[55%_45%] lg:gap-16 xl:gap-12 2xl:gap-16">
+          <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16 xl:gap-12 2xl:gap-16">
             {/* Left Column - Content */}
             <div>
               <h1 className="mb-5 text-4xl font-bold leading-tight text-white drop-shadow-lg lg:text-5xl xl:mb-4">
@@ -180,14 +180,14 @@ export default async function AccessoriesPage({ params }: Props) {
 
             {/* Right Column - Hero Image */}
             <div className="relative">
-              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg xl:mx-auto xl:max-w-[640px]">
+              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg">
                 <Image
                   src="/images/products/families/Accessories_Family_2025_US.webp"
                   alt={t('hero.imageAlt')}
                   width={2400}
                   height={1543}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, (max-width: 1279px) 45vw, 640px"
+                  sizes="(max-width: 1023px) 100vw, 50vw"
                   priority
                   quality={85}
                 />

--- a/web/src/app/[locale]/accessories/page.tsx
+++ b/web/src/app/[locale]/accessories/page.tsx
@@ -187,7 +187,7 @@ export default async function AccessoriesPage({ params }: Props) {
                   width={2400}
                   height={1543}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, 50vw"
+                  sizes="(max-width: 1023px) 100vw, (max-width: 1600px) 50vw, 800px"
                   priority
                   quality={85}
                 />

--- a/web/src/app/[locale]/temperature/page.tsx
+++ b/web/src/app/[locale]/temperature/page.tsx
@@ -183,7 +183,7 @@ export default async function TemperaturePage({ params }: Props) {
             <span className="font-medium text-white">{t('breadcrumb.temperature')}</span>
           </nav>
 
-          <div className="grid items-center gap-8 lg:grid-cols-[55%_45%] lg:gap-10 xl:gap-8 2xl:gap-10">
+          <div className="grid items-center gap-8 lg:grid-cols-2 lg:gap-10 xl:gap-8 2xl:gap-10">
             {/* Left Column - Content */}
             <div>
               <h1 className="mb-5 text-4xl font-bold leading-tight text-white drop-shadow-lg lg:text-5xl xl:mb-4">
@@ -211,14 +211,14 @@ export default async function TemperaturePage({ params }: Props) {
 
             {/* Right Column - Hero Image */}
             <div className="relative">
-              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg xl:mx-auto xl:max-w-[640px]">
+              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg">
                 <Image
                   src="/images/temperature/room/product_family.png"
                   alt={t('hero.title')}
                   width={640}
                   height={640}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, (max-width: 1279px) 45vw, 640px"
+                  sizes="(max-width: 1023px) 100vw, 50vw"
                   priority
                   quality={85}
                 />

--- a/web/src/app/[locale]/temperature/page.tsx
+++ b/web/src/app/[locale]/temperature/page.tsx
@@ -218,7 +218,7 @@ export default async function TemperaturePage({ params }: Props) {
                   width={640}
                   height={640}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, 50vw"
+                  sizes="(max-width: 1023px) 100vw, (max-width: 1600px) 50vw, 800px"
                   priority
                   quality={85}
                 />

--- a/web/src/app/[locale]/wam/page.tsx
+++ b/web/src/app/[locale]/wam/page.tsx
@@ -133,9 +133,9 @@ export default async function WAMPage({ params }: Props) {
                   width={640}
                   height={411}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, 50vw"
+                  sizes="(max-width: 1023px) 100vw, (max-width: 1600px) 50vw, 800px"
                   priority
-                  quality={90}
+                  quality={85}
                 />
               </div>
             </div>

--- a/web/src/app/[locale]/wam/page.tsx
+++ b/web/src/app/[locale]/wam/page.tsx
@@ -85,7 +85,7 @@ export default async function WAMPage({ params }: Props) {
             <span className="font-medium text-white">{t('breadcrumb.wam')}</span>
           </nav>
 
-          <div className="grid items-center gap-12 lg:grid-cols-[55%_45%] lg:gap-16 xl:gap-12 2xl:gap-16">
+          <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16 xl:gap-12 2xl:gap-16">
             {/* Left Column - Content */}
             <div>
               {/* WAM Logo */}
@@ -126,14 +126,14 @@ export default async function WAMPage({ params }: Props) {
 
             {/* Right Column - Hero Image */}
             <div className="relative">
-              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg xl:mx-auto xl:max-w-[640px]">
+              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg">
                 <Image
                   src="/images/wam/dashboards/wam-hero-sensors-gateway.png"
                   alt="WAM wireless sensors with gateway - temperature and humidity monitoring system"
                   width={640}
                   height={411}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, (max-width: 1279px) 45vw, 640px"
+                  sizes="(max-width: 1023px) 100vw, 50vw"
                   priority
                   quality={90}
                 />

--- a/web/src/app/[locale]/wireless/page.tsx
+++ b/web/src/app/[locale]/wireless/page.tsx
@@ -214,7 +214,7 @@ export default async function WirelessPage({ params }: Props) {
             <span className="font-medium text-white">{t('breadcrumb.wireless')}</span>
           </nav>
 
-          <div className="grid items-center gap-12 lg:grid-cols-[55%_45%] lg:gap-16 xl:gap-12 2xl:gap-16">
+          <div className="grid items-center gap-12 lg:grid-cols-2 lg:gap-16 xl:gap-12 2xl:gap-16">
             {/* Left Column - Content */}
             <div>
               <div className="mb-6 inline-block rounded-full bg-primary-400/30 px-4 py-2 text-sm font-semibold text-white backdrop-blur-sm">
@@ -245,14 +245,14 @@ export default async function WirelessPage({ params }: Props) {
 
             {/* Right Column - Hero Image */}
             <div className="relative">
-              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg xl:mx-auto xl:max-w-[640px]">
+              <div className="overflow-hidden rounded-2xl bg-white p-8 shadow-lg">
                 <Image
                   src="/images/wireless/Wireless_HVAC_2025_Plain.webp"
                   alt="BAPI Wireless HVAC Sensors"
                   width={2400}
                   height={1543}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, (max-width: 1279px) 45vw, 640px"
+                  sizes="(max-width: 1023px) 100vw, 50vw"
                   priority
                   quality={85}
                 />

--- a/web/src/app/[locale]/wireless/page.tsx
+++ b/web/src/app/[locale]/wireless/page.tsx
@@ -252,7 +252,7 @@ export default async function WirelessPage({ params }: Props) {
                   width={2400}
                   height={1543}
                   className="h-auto w-full"
-                  sizes="(max-width: 1023px) 100vw, 50vw"
+                  sizes="(max-width: 1023px) 100vw, (max-width: 1600px) 50vw, 800px"
                   priority
                   quality={85}
                 />


### PR DESCRIPTION
- Changed grid layout from 55%/45% to balanced 50/50 columns
- Updated image sizes attribute to reflect new grid proportions
- Fixes overflow issue on Accessories, Temperature, WAM, and Wireless pages
- Ensures hero images display fully at xl (1536px) and 2xl (1920px) breakpoints

