### PR TITLE
feat: translate bluTestLandingPage to all 10 locales

### DIFF
--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -4052,228 +4052,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ اختبار وقياس دقيق لأنظمة التدفئة والتهوية وتكييف الهواء",
+      "description": "مجسات اختبار وقياس احترافية لاختبار أنظمة التدفئة والتهوية وتكييف الهواء. قياس دقيق باستخدام تطبيق Blu-View لأنظمة iOS وAndroid.",
+      "keywords": "مجسات اختبار HVAC، قياس درجة الحرارة، تطبيق Blu-View، مجسات دقيقة، معدات الاختبار، اختبار HVAC، اختبار أتمتة المباني"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "الرئيسية",
+      "products": "المنتجات",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "مجسات HVAC دقيقة يمكنك الوثوق بها.",
+      "description": "مجموعة من مجسات الاختبار لمتطلبات الدقة الصارمة عبر أنظمة التدفئة والتهوية وتكييف الهواء والتبريد. تتكامل بسلاسة مع تطبيق Blu-View للقياس الدقيق وتسجيل البيانات السهل.",
+      "cta": "استكشف المجسات",
+      "secondaryCta": "تنزيل تطبيق Blu-View"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "قياس دقيق",
+        "description": "مستشعرات عالية الدقة لقياس درجة الحرارة والرطوبة والضغط ونقطة الندى ومستوى الإضاءة. مثالية لتشغيل والتحقق من أنظمة التدفئة والتهوية وتكييف الهواء."
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "تسجيل البيانات على الجهاز",
+        "description": "تخزين بيانات القياس مباشرة على المجسات مع ذاكرة تخزين مدمجة. تنزيل السجلات في أي وقت باستخدام تطبيق Blü-Test للتحليل الشامل."
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "التكامل مع الأجهزة الذكية",
+        "description": "الاتصال عبر Bluetooth لعرض البيانات المباشرة على هاتفك الذكي أو جهازك اللوحي. يوفر تطبيق Blü-Test مراقبة في الوقت الفعلي وإدارة سهلة للأجهزة."
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "لماذا تهم أجهزة المرجع الدقيقة",
+      "subtitle": "في أنظمة التدفئة والتهوية وتكييف الهواء التجارية، الدقة ليست اختيارية - إنها أساسية. القياسات غير الدقيقة تؤدي إلى تشخيص خاطئ للمشاكل، وإضاعة الوقت، ومكالمات الصيانة المكلفة. مجسات Blü-Test تمنحك الثقة في كل قراءة.",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "دقة درجة الحرارة",
+        "description": "دقة ±0.18°F تضمن تشخيص دقيق للنظام وأداء مثالي للمعدات. اكتشف فروق درجات الحرارة التي تشير إلى مكونات معطلة قبل أن تسبب فشل النظام."
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "الرطوبة ونقطة الندى",
+        "description": "دقة ±1% RH تمنع مشاكل التكثيف، ونمو العفن، وشكاوى الراحة. التحقق من أن أنظمة التدفئة والتهوية وتكييف الهواء تحافظ على جودة الهواء الداخلي المناسبة وتلبي متطلبات رموز البناء."
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "الضغط التفاضلي",
+        "description": "دقة ±0.25% تكشف عن تسرب القنوات، وتحميل الفلاتر، وقيود تدفق الهواء. تحسين كفاءة النظام وتحديد المشاكل قبل أن تؤثر على تكاليف الطاقة أو راحة الساكنين."
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "تدفق الهواء بمعامل K",
+        "description": "قياسات دقيقة لمعامل K تمكن من حسابات دقيقة لتدفق الهواء لموازنة النظام، والتشغيل، والتحقق من الأداء. ضمان معدلات تهوية مناسبة وتشغيل موفر للطاقة."
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "معايرة قابلة للتتبع إلى NIST",
+        "description": "كل مجس يتضمن شهادة دقة قابلة للتتبع إلى معايير NIST. توثيق الامتثال للمنشآت الحرجة، والدفاع عن عملك ببيانات معتمدة، والحفاظ على المصداقية المهنية."
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "التكامل مع تطبيق Blü-View",
+        "description": "تحقق من قوة الإشارة لجميع المستشعرات الخاصة بك لضمان اتصال قوي. عرض القراءات المباشرة، وتسجيل البيانات، وإنشاء التقارير، ومقارنة القراءات مع المستشعرات اللاسلكية مباشرة من التطبيق."
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "خط الأساس للحقيقة",
+        "description": "استخدام جهاز مرجعي عالي الدقة يسمح لك بالتحقق بثقة من المستشعرات الموجودة في المبنى، وتشخيص المشاكل النظامية المعقدة، وضمان الامتثال التنظيمي بأقل قدر من التخمين."
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "Bluetooth الحقيقة",
+      "description": "الاتصال اللاسلكي يعني عدم الحاجة لكتابة القراءات. تطبيق Blu-View يسجل القياسات تلقائيًا مع الطوابع الزمنية، ويزيل أخطاء النسخ، ويُنشئ تقارير احترافية.",
+      "feature1": "نقل البيانات اللاسلكي في الوقت الفعلي إلى هاتفك الذكي أو جهازك اللوحي",
+      "feature2": "تسجيل تلقائي للطابع الزمني والموقع لتوثيق كامل",
+      "feature3": "التصدير إلى PDF أو Excel أو التخزين السحابي لسهولة المشاركة والأرشفة"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "تطبيق Blü-View",
+      "subtitle": "تطبيق Blü-View يضع التحكم الكامل في متناول يدك. عرض البيانات المباشرة، وتنزيل السجلات، وتحديث البرامج الثابتة، وإدارة أجهزة متعددة من واجهة واحدة.",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "المراقبة في الوقت الفعلي",
+        "description": "عرض بيانات المستشعر المباشرة من جميع المجسات المتصلة. مراقبة درجة الحرارة والرطوبة والضغط والمزيد في الوقت الفعلي مع شاشات عرض بديهية."
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "تنزيل السجلات",
+        "description": "الوصول إلى سجلات القياس المخزنة من ذاكرة الجهاز المدمجة. تصدير البيانات للتحليل والإبلاغ وتوثيق الامتثال."
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "إدارة الأجهزة",
+        "description": "إدارة مجسات متعددة، والتحقق من مستويات البطارية، وتحديث البرامج الثابتة، وتلقي تذكيرات المعايرة كلها من لوحة تحكم مركزية واحدة."
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "تنزيل التطبيق",
+      "learnMore": "معرفة المزيد"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "مجموعة Blü-Test",
+      "subtitle": "عائلة شاملة من المجسات الذكية المعتمدة من NIST. جميعها تتميز بمسجل بيانات مدمج، وشاشة LCD مدمجة على المقبض، واتصال Bluetooth سلس.",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "مجس حرارة 9.5 بوصة",
+        "description": "مدى ممتد لقياس درجة الحرارة في عمق القنوات أو وحدات معالجة الهواء الكبيرة.",
+        "feature1": "طول ممتد للقياسات العميقة",
+        "feature2": "ثيرمستور من النوع الثاني 10K",
+        "feature3": "بناء متين من الفولاذ المقاوم للصدأ"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "مجس حرارة 6 بوصات",
+        "description": "مجس متعدد الاستخدامات بطول قياسي مثالي للتحقق من درجة الحرارة في أنظمة التدفئة والتهوية وتكييف الهواء لأغراض عامة.",
+        "feature1": "تصميم مدمج للاستخدام العام",
+        "feature2": "وقت استجابة سريع",
+        "feature3": "ثيرمستور من النوع الثاني 10K"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "مجس حرارة ثاقب 4 بوصات",
+        "description": "طرف ثاقب متين لاختراق العزل أو فحص درجات حرارة السطح.",
+        "feature1": "يخترق العزل والقنوات",
+        "feature2": "طرف حاد لسهولة الإدخال",
+        "feature3": "مثالي للمواقع التي يصعب الوصول إليها"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "مجس حرارة عن بعد",
+        "description": "مجس سلكي مرن للمناطق التي يصعب الوصول إليها أو للمراقبة المستمرة دون إمساك المقبض.",
+        "feature1": "مجس قابل للفصل على كابل",
+        "feature2": "وضع مرن",
+        "feature3": "قدرة مدى ممتد"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "مجس حرارة ورطوبة 8 بوصات",
+        "description": "مستشعر مركب لدرجة حرارة البصلة الجافة الدقيقة، ونسبة الرطوبة النسبية، وحسابات نقطة الندى.",
+        "feature1": "قدرة قياس مزدوجة",
+        "feature2": "استشعار RH دقيق",
+        "feature3": "قراءات درجة الحرارة / الرطوبة المدمجة"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "مجس ضغط النطاق القياسي",
+        "description": "قياس موثوق للضغط التفاضلي (-5 إلى +5 بوصة عمود ماء) لأنظمة التدفئة والتهوية وتكييف الهواء التجارية القياسية.",
+        "feature1": "يقيس ضغط القنوات والغرف",
+        "feature2": "نطاقات من ±1 بوصة عمود ماء إلى ±10 بوصة عمود ماء",
+        "feature3": "ضغط تفاضلي عالي الدقة"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "مجس ضغط النطاق المنخفض",
+        "description": "قياس عالي الدقة للضغط التفاضلي (-1 إلى +1 بوصة عمود ماء) للغرف النظيفة الحساسة أو بيئات المختبرات.",
+        "feature1": "قياس ضغط فائق الحساسية",
+        "feature2": "نطاقات من ±0.1 بوصة عمود ماء إلى ±0.5 بوصة عمود ماء",
+        "feature3": "مثالي لتطبيقات الغرف النظيفة والمختبرات"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "المواصفات الفنية",
+      "subtitle": "مصممة للدقة ومبنية لتحمل البيئات التجارية الصارمة.",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "عام",
+        "measurement": "نطاق القياس",
+        "accuracy": "الدقة",
+        "environmental": "البيئة والشهادات"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "الطاقة",
+          "value": "بطارية قابلة لإعادة الشحن 3.7 فولت، 2,600 مللي أمبير في الساعة"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "الشحن",
+          "value": "شاحن USB قياسي، 1.5 أمبير أو أكثر، كابل Micro-USB مشمول"
         },
         "communication": {
-          "label": "Communication",
-          "value": "Bluetooth LE, Class 2 v4.2"
+          "label": "الاتصال",
+          "value": "Bluetooth LE، الفئة 2 الإصدار 4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "تسجيل البيانات",
+          "value": "فترات 10 ثوانٍ"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "درجة الحرارة",
+          "value": "-40 إلى 185°F (-40 إلى 85°C)"
         },
         "rh": {
-          "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "label": "نسبة الرطوبة النسبية",
+          "value": "5 إلى 95% غير متكثفة @ -40 إلى 158°F (-40 إلى 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "الضغط التفاضلي (منخفض)",
+          "value": "-1 إلى +1 بوصة عمود ماء (-250 إلى +250 باسكال) @ -4 إلى 158°F (-20 إلى 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "الضغط التفاضلي (قياسي)",
+          "value": "-5 إلى +5 بوصة عمود ماء (-1,250 إلى +1,250 باسكال) @ -4 إلى 158°F (-20 إلى 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "مجسات درجة الحرارة فقط",
+          "value": "±0.18°F من -13 إلى 167°F (±0.1°C من -25 إلى 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "مجسات درجة الحرارة / الرطوبة",
+          "value": "درجة الحرارة: ±0.36°F @ 77°F (±0.2°C عند 25°C) | نسبة الرطوبة النسبية: ±1%RH @ 77°F (25°C) من 10 إلى 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "الضغط التفاضلي (منخفض)",
+          "value": "±0.25% من النطاق الكامل، -1 إلى +1 بوصة عمود ماء (-250 إلى +250 باسكال) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "الضغط التفاضلي (قياسي)",
+          "value": "±0.25% من النطاق الكامل، -5 إلى +5 بوصة عمود ماء (-1,250 إلى +1,250 باسكال) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "نطاق التشغيل",
+          "value": "الجسم: -22 إلى 158°F (-30 إلى 70°C) | مجسات درجة الحرارة: -40 إلى 185°F (-40 إلى 85°C) | مجس نسبة الرطوبة النسبية: 5 إلى 95% غير متكثفة @ -40 إلى 158°F (-40 إلى 70°C) | مجس الضغط: -4 إلى 158°F (-20 إلى 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "ضغط الانفجار",
+          "value": "النطاق المنخفض: 415 بوصة عمود ماء (103 كيلو باسكال) | النطاق القياسي: 500 بوصة عمود ماء (124 كيلو باسكال)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
-          "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
+          "label": "موافقات الجهات الرسمية",
+          "value": "CE EN 61326-1:2013 EMC، RoHS، NSF، FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "هل أنت مستعد لترقية اختبار أنظمة التدفئة والتهوية وتكييف الهواء الخاصة بك؟",
+      "subtitle": "متخصصو الاختبار والقياس لدينا جاهزون لمساعدتك في اختيار المجسات المناسبة لتطبيقاتك. احصل على مشورة الخبراء وأسعار تنافسية.",
+      "contactSales": "اتصل بالمبيعات",
+      "viewProducts": "عرض جميع المجسات"
     }
   }
 }

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -4105,7 +4105,7 @@
         "description": "Jede Sonde enthält ein Genauigkeitszertifikat, das auf NIST-Standards rückverfolgbar ist. Dokumentieren Sie die Einhaltung für kritische Einrichtungen, verteidigen Sie Ihre Arbeit mit zertifizierten Daten und wahren Sie professionelle Glaubwürdigkeit."
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
+        "title": "Blü-View App-Integration",
         "description": "Überprüfen Sie die Signalstärke für alle Ihre Sensoren, um eine starke Verbindung sicherzustellen. Zeigen Sie Live-Messwerte an, protokollieren Sie Daten, erstellen Sie Berichte und vergleichen Sie Messwerte mit drahtlosen Sensoren direkt aus der App."
       },
       "baseline": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -4052,228 +4052,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ Präzisions-HLK-Test & Messung",
+      "description": "Professionelle Test- und Messsonden für HLK-Tests. Präzisionsmessung mit der Blu-View App für iOS und Android.",
+      "keywords": "HLK-Testsonden, Temperaturmessung, Blu-View App, Präzisionssonden, Testgeräte, HLK-Tests, Gebäudeautomationstests"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "Startseite",
+      "products": "Produkte",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "Präzisions-HLK-Sonden, denen Sie vertrauen können.",
+      "description": "Eine Reihe von Testsonden für anspruchsvolle Genauigkeitsanforderungen in HLK- und Kältesystemen. Nahtlose Integration mit der Blu-View App für präzise Messungen und einfache Datenprotokollierung.",
+      "cta": "Sonden erkunden",
+      "secondaryCta": "Blu-View App herunterladen"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "Präzisionsmessung",
+        "description": "Hochgenaue Sensoren für Temperatur-, Feuchtigkeits-, Druck-, Taupunkt- und Lichtpegelmessungen. Ideal für HLK-Inbetriebnahme und Verifizierung."
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "Integrierte Datenprotokollierung",
+        "description": "Speichern Sie Messdaten direkt auf den Sonden mit integriertem Speicher. Laden Sie Protokolle jederzeit mit der Blü-Test App für umfassende Analysen herunter."
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "Smart-Device-Integration",
+        "description": "Verbinden Sie sich per Bluetooth, um Live-Daten auf Ihrem Smartphone oder Tablet anzuzeigen. Die Blü-Test App bietet Echtzeitüberwachung und einfaches Gerätemanagement."
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "Warum genaue Referenzgeräte wichtig sind",
+      "subtitle": "In der gewerblichen HLK ist Präzision nicht optional – sie ist unverzichtbar. Ungenaue Messungen führen zu Fehldiagnosen, Zeitverschwendung und kostspieligen Rückrufen. Blü-Test Sonden geben Ihnen Vertrauen in jede Messung.",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "Temperaturgenauigkeit",
+        "description": "±0,18°F Genauigkeit gewährleistet präzise Systemdiagnosen und optimale Geräteleistung. Erkennen Sie Temperaturdifferenzen, die auf fehlerhafte Komponenten hinweisen, bevor sie einen Systemausfall verursachen."
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "Feuchtigkeit & Taupunkt",
+        "description": "±1% RH Genauigkeit verhindert Kondensationsprobleme, Schimmelbildung und Komfortbeschwerden. Validieren Sie, dass HLK-Systeme die richtige Raumluftqualität aufrechterhalten und Bauvorschriften erfüllen."
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "Differenzdruck",
+        "description": "±0,25% Genauigkeit deckt Kanalleckagen, Filterbeladung und Luftstromeinschränkungen auf. Optimieren Sie die Systemeffizienz und identifizieren Sie Probleme, bevor sie Energiekosten oder Nutzerkomfort beeinträchtigen."
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "K-Faktor-Luftstrom",
+        "description": "Genaue K-Faktor-Messungen ermöglichen präzise Luftstromberechnungen für Systemabgleich, Inbetriebnahme und Leistungsverifizierung. Gewährleisten Sie korrekte Belüftungsraten und energieeffizienten Betrieb."
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "NIST-rückverfolgbare Kalibrierung",
+        "description": "Jede Sonde enthält ein Genauigkeitszertifikat, das auf NIST-Standards rückverfolgbar ist. Dokumentieren Sie die Einhaltung für kritische Einrichtungen, verteidigen Sie Ihre Arbeit mit zertifizierten Daten und wahren Sie professionelle Glaubwürdigkeit."
       },
       "appIntegration": {
         "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "description": "Überprüfen Sie die Signalstärke für alle Ihre Sensoren, um eine starke Verbindung sicherzustellen. Zeigen Sie Live-Messwerte an, protokollieren Sie Daten, erstellen Sie Berichte und vergleichen Sie Messwerte mit drahtlosen Sensoren direkt aus der App."
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "Die Basis der Wahrheit",
+        "description": "Die Verwendung eines hochgenauen Referenzgeräts ermöglicht es Ihnen, vorhandene Gebäudesensoren sicher zu validieren, komplexe systemische Probleme zu diagnostizieren und die Einhaltung gesetzlicher Vorschriften mit minimalem Rätselraten sicherzustellen."
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "Das Bluetooth der Wahrheit",
+      "description": "Drahtlose Konnektivität bedeutet, dass Sie keine Messwerte mehr notieren müssen. Die Blu-View App protokolliert Messungen automatisch mit Zeitstempeln, eliminiert Übertragungsfehler und erstellt professionelle Berichte.",
+      "feature1": "Drahtlose Echtzeit-Datenübertragung an Ihr Smartphone oder Tablet",
+      "feature2": "Automatische Zeitstempel- und Standortprotokollierung für vollständige Dokumentation",
+      "feature3": "Export in PDF, Excel oder Cloud-Speicher für einfaches Teilen und Archivieren"
     },
     "bluView": {
       "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "subtitle": "Die Blü-View App gibt Ihnen die vollständige Kontrolle auf Knopfdruck. Zeigen Sie Live-Daten an, laden Sie Protokolle herunter, aktualisieren Sie die Firmware und verwalten Sie mehrere Geräte über eine Benutzeroberfläche.",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "Echtzeitüberwachung",
+        "description": "Zeigen Sie Live-Sensordaten von allen verbundenen Sonden an. Überwachen Sie Temperatur, Feuchtigkeit, Druck und mehr in Echtzeit mit intuitiven Anzeigen."
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "Protokolle herunterladen",
+        "description": "Greifen Sie auf gespeicherte Messprotokolle aus dem integrierten Gerätespeicher zu. Exportieren Sie Daten für Analysen, Berichte und Konformitätsdokumentation."
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "Geräteverwaltung",
+        "description": "Verwalten Sie mehrere Sonden, überprüfen Sie Batteriestände, aktualisieren Sie die Firmware und erhalten Sie Kalibrierungserinnerungen von einem zentralen Dashboard aus."
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "App herunterladen",
+      "learnMore": "Mehr erfahren"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "Die Blü-Test Suite",
+      "subtitle": "Eine umfassende Familie intelligenter, NIST-zertifizierter Sonden. Alle verfügen über einen integrierten Datenlogger, ein eingebautes LCD-Display am Griff und nahtlose Bluetooth-Konnektivität.",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "9,5\" Temperatursonde",
+        "description": "Erweiterte Reichweite für Temperaturmessungen tief in Kanälen oder großen Luftbehandlungsgeräten.",
+        "feature1": "Verlängerte Länge für tiefe Messungen",
+        "feature2": "10K Typ II Thermistor",
+        "feature3": "Robuste Edelstahlkonstruktion"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "6\" Temperatursonde",
+        "description": "Vielseitige Sonde mit Standardlänge, ideal für allgemeine HLK-Temperaturvalidierung.",
+        "feature1": "Kompaktes Design für allgemeine Nutzung",
+        "feature2": "Schnelle Reaktionszeit",
+        "feature3": "10K Typ II Thermistor"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "4\" Durchstoß-Temperatursonde",
+        "description": "Robuste Durchstoßspitze zum Durchdringen von Isolierung oder zur Überprüfung von Oberflächentemperaturen.",
+        "feature1": "Durchdringt Isolierung und Kanalwände",
+        "feature2": "Scharfe Spitze für einfaches Einführen",
+        "feature3": "Ideal für schwer zugängliche Stellen"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "Fern-Temperatursonde",
+        "description": "Flexible verkabelte Sonde für schwer zugängliche Bereiche oder kontinuierliche Überwachung ohne Halten des Griffs.",
+        "feature1": "Trennbare Sonde am Kabel",
+        "feature2": "Flexible Positionierung",
+        "feature3": "Erweiterte Reichweite"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "8\" Temperatur- & Feuchtigkeitssonde",
+        "description": "Kombinierter Sensor für genaue Trockentemperatur, %RH und Taupunktberechnungen.",
+        "feature1": "Duale Messfähigkeit",
+        "feature2": "Genaue RH-Erfassung",
+        "feature3": "Kombinierte Temperatur-/Feuchtigkeitsmessungen"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "Standardbereich-Drucksonde",
+        "description": "Zuverlässige Differenzdruckmessung (-5 bis +5\" WC) für Standard-Gewerbe-HLK-Systeme.",
+        "feature1": "Misst Kanal- und Raumdruck",
+        "feature2": "±1\" WC bis ±10\" WC Bereiche",
+        "feature3": "Hohe Genauigkeit beim Differenzdruck"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "Niedrigbereich-Drucksonde",
+        "description": "Hochpräzise Differenzdruckmessung (-1 bis +1\" WC) für empfindliche Reinräume oder Laborumgebungen.",
+        "feature1": "Ultrasensitive Druckmessung",
+        "feature2": "±0,1\" WC bis ±0,5\" WC Bereiche",
+        "feature3": "Perfekt für Reinraum- und Laboranwendungen"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "Technische Spezifikationen",
+      "subtitle": "Entwickelt für Präzision und gebaut, um anspruchsvollen gewerblichen Umgebungen standzuhalten.",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "Allgemein",
+        "measurement": "Messbereich",
+        "accuracy": "Genauigkeit",
+        "environmental": "Umgebung & Zertifizierungen"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "Stromversorgung",
+          "value": "3,7V, 2.600 mAh wiederaufladbare Batterie"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "Aufladung",
+          "value": "Standard-USB-Ladegerät, 1,5A oder höher, Micro-USB-Kabel im Lieferumfang"
         },
         "communication": {
-          "label": "Communication",
-          "value": "Bluetooth LE, Class 2 v4.2"
+          "label": "Kommunikation",
+          "value": "Bluetooth LE, Klasse 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "Datenprotokollierung",
+          "value": "10-Sekunden-Intervalle"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "Temperatur",
+          "value": "-40 bis 185°F (-40 bis 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 bis 95% nicht kondensierend @ -40 bis 158°F (-40 bis 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Diff. Druck (Niedrig)",
+          "value": "-1 bis +1\" WC (-250 bis +250 Pascal) @ -4 bis 158°F (-20 bis 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Diff. Druck (Std)",
+          "value": "-5 bis +5\" WC (-1.250 bis +1.250 Pascal) @ -4 bis 158°F (-20 bis 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "Nur-Temperatur-Sonden",
+          "value": "±0,18°F von -13 bis 167°F (±0,1°C von -25 bis 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "Temperatur-/Feuchtigkeitssonden",
+          "value": "Temp: ±0,36°F @ 77°F (±0,2°C bei 25°C) | %RH: ±1%RH @ 77°F (25°C) von 10 bis 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "Diff. Druck (Niedrig)",
+          "value": "±0,25% vom FS-Bereich, -1 bis +1\" WC (-250 bis +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "Diff. Druck (Std)",
+          "value": "±0,25% vom FS-Bereich, -5 bis +5\" WC (-1.250 bis +1.250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "Betriebsbereich",
+          "value": "Gehäuse: -22 bis 158°F (-30 bis 70°C) | Temp-Sonden: -40 bis 185°F (-40 bis 85°C) | %RH-Sonde: 5 bis 95% nicht kondensierend @ -40 bis 158°F (-40 bis 70°C) | Drucksonde: -4 bis 158°F (-20 bis 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "Berstdruck",
+          "value": "Niedrigbereich: 415\" WC (103 kPa) | Standardbereich: 500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "Behördenzulassungen",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "Bereit, Ihre HLK-Tests zu verbessern?",
+      "subtitle": "Unsere Test- und Messspezialisten helfen Ihnen gerne bei der Auswahl der richtigen Sonden für Ihre Anwendungen. Erhalten Sie fachkundige Beratung und wettbewerbsfähige Preise.",
+      "contactSales": "Vertrieb kontaktieren",
+      "viewProducts": "Alle Sonden anzeigen"
     }
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -4049,228 +4049,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ Pruebas y Mediciones de Precisión para HVAC",
+      "description": "Sondas de prueba y medición de grado profesional para pruebas de HVAC. Medición de precisión con la aplicación Blu-View para iOS y Android.",
+      "keywords": "sondas de prueba HVAC, medición de temperatura, aplicación Blu-View, sondas de precisión, equipo de prueba, pruebas HVAC, pruebas de automatización de edificios"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "Inicio",
+      "products": "Productos",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "Sondas de Precisión para HVAC en las que Puede Confiar.",
+      "description": "Una suite de sondas de prueba para requisitos exigentes de precisión en sistemas HVAC y de refrigeración. Integre perfectamente con la aplicación Blu-View para mediciones precisas y registro de datos fácil.",
+      "cta": "Explorar Sondas",
+      "secondaryCta": "Descargar Aplicación Blu-View"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "Medición de Precisión",
+        "description": "Sensores de alta precisión para mediciones de temperatura, humedad, presión, punto de rocío y nivel de luz. Ideal para puesta en marcha y verificación de HVAC."
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "Registro de Datos Integrado",
+        "description": "Almacene datos de medición directamente en las sondas con almacenamiento incorporado. Descargue registros en cualquier momento usando la aplicación Blü-Test para análisis completo."
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "Integración con Dispositivos Inteligentes",
+        "description": "Conéctese vía Bluetooth para ver datos en vivo en su smartphone o tableta. La aplicación Blü-Test proporciona monitoreo en tiempo real y gestión fácil de dispositivos."
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "Por Qué Importan los Dispositivos de Referencia Precisos",
+      "subtitle": "En HVAC comercial, la precisión no es opcional—es esencial. Las mediciones inexactas conducen a problemas mal diagnosticados, tiempo perdido y costosas devoluciones de llamadas. Las sondas Blü-Test le dan confianza en cada lectura.",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "Precisión de Temperatura",
+        "description": "Precisión de ±0.18°F asegura diagnósticos precisos del sistema y rendimiento óptimo del equipo. Detecte diferenciales de temperatura que indican componentes defectuosos antes de que causen falla del sistema."
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "Humedad y Punto de Rocío",
+        "description": "Precisión de ±1% RH previene problemas de condensación, crecimiento de moho y quejas de confort. Valide que los sistemas HVAC mantengan una calidad de aire interior adecuada y cumplan con los requisitos del código de edificación."
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "Presión Diferencial",
+        "description": "Precisión de ±0.25% revela fugas de ductos, carga de filtros y restricciones de flujo de aire. Optimice la eficiencia del sistema e identifique problemas antes de que impacten los costos de energía o el confort de los ocupantes."
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "Flujo de Aire Factor-K",
+        "description": "Las mediciones precisas de Factor-K permiten cálculos precisos de flujo de aire para balanceo del sistema, puesta en marcha y verificación de rendimiento. Asegure tasas de ventilación adecuadas y operación eficiente energéticamente."
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "Calibración Trazable a NIST",
+        "description": "Cada sonda incluye un Certificado de Precisión trazable a estándares NIST. Documente el cumplimiento para instalaciones críticas, defienda su trabajo con datos certificados y mantenga credibilidad profesional."
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Integración con Aplicación Blü-View",
+        "description": "Verifique la intensidad de señal de todos sus sensores para asegurar una conexión fuerte. Vea lecturas en vivo, registre datos, genere informes y compare lecturas con sensores inalámbricos directamente desde la aplicación."
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "La Línea Base de la Verdad",
+        "description": "Usar un dispositivo de referencia de alta precisión le permite validar con confianza los sensores de edificios existentes, diagnosticar problemas sistémicos complejos y asegurar el cumplimiento regulatorio con mínimas conjeturas."
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "El Bluetooth de la Verdad",
+      "description": "La conectividad inalámbrica significa no más anotaciones de lecturas. La aplicación Blu-View registra automáticamente mediciones con marcas de tiempo, elimina errores de transcripción y genera informes profesionales.",
+      "feature1": "Transmisión inalámbrica de datos en tiempo real a su smartphone o tableta",
+      "feature2": "Registro automático de marca de tiempo y ubicación para documentación completa",
+      "feature3": "Exporte a PDF, Excel o almacenamiento en la nube para compartir y archivar fácilmente"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Aplicación Blü-View",
+      "subtitle": "La aplicación Blü-View pone el control completo al alcance de sus dedos. Vea datos en vivo, descargue registros, actualice firmware y gestione múltiples dispositivos desde una interfaz.",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "Monitoreo en Tiempo Real",
+        "description": "Vea datos de sensores en vivo de todas las sondas conectadas. Monitoree temperatura, humedad, presión y más en tiempo real con pantallas intuitivas."
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "Descargar Registros",
+        "description": "Acceda a registros de medición almacenados en la memoria del dispositivo. Exporte datos para análisis, informes y documentación de cumplimiento."
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "Gestión de Dispositivos",
+        "description": "Gestione múltiples sondas, verifique niveles de batería, actualice firmware y reciba recordatorios de calibración todo desde un panel central."
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "Descargar la Aplicación",
+      "learnMore": "Más Información"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "La Suite Blü-Test",
+      "subtitle": "Una familia completa de sondas inteligentes certificadas por NIST. Todas cuentan con un registrador de datos integrado, una pantalla LCD incorporada en el mango y conectividad Bluetooth perfecta.",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "Sonda de Temperatura de 9.5\"",
+        "description": "Alcance extendido para medir temperatura en lo profundo de ductos o manejadoras de aire grandes.",
+        "feature1": "Longitud extendida para mediciones profundas",
+        "feature2": "Termistor 10K Tipo II",
+        "feature3": "Construcción robusta de acero inoxidable"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "Sonda de Temperatura de 6\"",
+        "description": "Sonda versátil de longitud estándar ideal para validación general de temperatura HVAC.",
+        "feature1": "Diseño compacto para uso general",
+        "feature2": "Tiempo de respuesta rápido",
+        "feature3": "Termistor 10K Tipo II"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "Sonda de Temperatura Perforante de 4\"",
+        "description": "Punta perforante robusta para penetrar aislamiento o verificar temperaturas superficiales.",
+        "feature1": "Penetra aislamiento y ductos",
+        "feature2": "Punta afilada para inserción fácil",
+        "feature3": "Ideal para ubicaciones de difícil acceso"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "Sonda de Temperatura Remota",
+        "description": "Sonda cableada flexible para áreas de difícil acceso o monitoreo continuo sin sostener el mango.",
+        "feature1": "Sonda separable en cable",
+        "feature2": "Posicionamiento flexible",
+        "feature3": "Capacidad de alcance extendido"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "Sonda de Temperatura y Humedad de 8\"",
+        "description": "Sensor combinado para temperatura de bulbo seco precisa, %RH y cálculos de punto de rocío.",
+        "feature1": "Capacidad de medición dual",
+        "feature2": "Detección precisa de RH",
+        "feature3": "Lecturas combinadas de temp/humedad"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "Sonda de Presión de Rango Estándar",
+        "description": "Medición confiable de presión diferencial (-5 a +5\" WC) para sistemas HVAC comerciales estándar.",
+        "feature1": "Mide presión de ductos y habitaciones",
+        "feature2": "Rangos de ±1\" WC a ±10\" WC",
+        "feature3": "Presión diferencial de alta precisión"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "Sonda de Presión de Rango Bajo",
+        "description": "Medición de presión diferencial de alta precisión (-1 a +1\" WC) para salas limpias sensibles o entornos de laboratorio.",
+        "feature1": "Medición de presión ultrasensible",
+        "feature2": "Rangos de ±0.1\" WC a ±0.5\" WC",
+        "feature3": "Perfecta para aplicaciones de salas limpias y laboratorios"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "Especificaciones Técnicas",
+      "subtitle": "Diseñadas para precisión y construidas para resistir entornos comerciales rigurosos.",
       "table": {
         "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "measurement": "Rango de Medición",
+        "accuracy": "Precisión",
+        "environmental": "Ambiental y Certificaciones"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "Alimentación",
+          "value": "Batería Recargable de 3.7V, 2,600 mAh"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "Carga",
+          "value": "Cargador USB Estándar, 1.5A o mayor, cable Micro-USB incluido"
         },
         "communication": {
-          "label": "Communication",
-          "value": "Bluetooth LE, Class 2 v4.2"
+          "label": "Comunicación",
+          "value": "Bluetooth LE, Clase 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "Registro de Datos",
+          "value": "Intervalos de 10 segundos"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "Temperatura",
+          "value": "-40 a 185°F (-40 a 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 a 95% Sin condensación @ -40 a 158°F (-40 a 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Presión Dif. (Bajo)",
+          "value": "-1 a +1\" WC (-250 a +250 Pascal) @ -4 a 158°F (-20 a 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Presión Dif. (Est)",
+          "value": "-5 a +5\" WC (-1,250 a +1,250 Pascal) @ -4 a 158°F (-20 a 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "Sondas Solo de Temperatura",
+          "value": "±0.18°F de -13 a 167°F (±0.1°C de -25 a 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "Sondas de Temp/Humedad",
+          "value": "Temp: ±0.36°F @ 77°F (±0.2°C a 25°C) | %RH: ±1%RH @ 77°F (25°C) de 10 a 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "Presión Dif. (Bajo)",
+          "value": "±0.25% del Rango FS, -1 a +1\" WC (-250 a +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "Presión Dif. (Est)",
+          "value": "±0.25% del Rango FS, -5 a +5\" WC (-1,250 a +1,250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "Rango de Operación",
+          "value": "Cuerpo: -22 a 158°F (-30 a 70°C) | Sondas de Temp: -40 a 185°F (-40 a 85°C) | Sonda %RH: 5 a 95% Sin condensación @ -40 a 158°F (-40 a 70°C) | Sonda de Presión: -4 a 158°F (-20 a 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "Presión de Ruptura",
+          "value": "Rango Bajo: 415\" WC (103 kPa) | Rango Estándar: 500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "Aprobaciones de Agencias",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "¿Listo para Actualizar sus Pruebas de HVAC?",
+      "subtitle": "Nuestros especialistas en pruebas y mediciones están listos para ayudarle a elegir las sondas adecuadas para sus aplicaciones. Obtenga asesoramiento experto y precios competitivos.",
+      "contactSales": "Contactar Ventas",
+      "viewProducts": "Ver Todas las Sondas"
     }
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -4052,228 +4052,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ Tests et Mesures HVAC de Précision",
+      "description": "Sondes de test et de mesure de qualité professionnelle pour les tests HVAC. Mesure de précision avec l'application Blu-View pour iOS et Android.",
+      "keywords": "sondes de test HVAC, mesure de température, application Blu-View, sondes de précision, équipement de test, tests HVAC, tests d'automatisation du bâtiment"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "Accueil",
+      "products": "Produits",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "Sondes HVAC de Précision en qui Vous Pouvez Avoir Confiance.",
+      "description": "Une suite de sondes de test pour des exigences de précision rigoureuses dans les systèmes HVAC et de réfrigération. Intégration transparente avec l'application Blu-View pour une mesure précise et un enregistrement de données facile.",
+      "cta": "Explorer les Sondes",
+      "secondaryCta": "Télécharger l'Application Blu-View"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "Mesure de Précision",
+        "description": "Capteurs de haute précision pour les mesures de température, d'humidité, de pression, de point de rosée et de niveau de lumière. Idéal pour la mise en service et la vérification HVAC."
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "Enregistrement de Données Intégré",
+        "description": "Stockez les données de mesure directement sur les sondes avec stockage intégré. Téléchargez les journaux à tout moment à l'aide de l'application Blü-Test pour une analyse complète."
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "Intégration avec Appareils Intelligents",
+        "description": "Connexion via Bluetooth pour visualiser les données en direct sur votre smartphone ou tablette. L'application Blü-Test offre une surveillance en temps réel et une gestion facile des appareils."
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "Pourquoi les Appareils de Référence Précis Sont Importants",
+      "subtitle": "Dans le domaine du HVAC commercial, la précision n'est pas optionnelle—elle est essentielle. Des mesures inexactes conduisent à des problèmes mal diagnostiqués, du temps perdu et des rappels coûteux. Les sondes Blü-Test vous donnent confiance dans chaque lecture.",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "Précision de Température",
+        "description": "Une précision de ±0,18°F garantit des diagnostics système précis et des performances optimales de l'équipement. Détectez les différentiels de température qui indiquent des composants défaillants avant qu'ils ne causent une panne du système."
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "Humidité et Point de Rosée",
+        "description": "Une précision de ±1% HR prévient les problèmes de condensation, la croissance de moisissures et les plaintes de confort. Validez que les systèmes HVAC maintiennent une qualité d'air intérieur appropriée et respectent les exigences du code du bâtiment."
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "Pression Différentielle",
+        "description": "Une précision de ±0,25% révèle les fuites de conduits, l'encrassement des filtres et les restrictions de débit d'air. Optimisez l'efficacité du système et identifiez les problèmes avant qu'ils n'impactent les coûts énergétiques ou le confort des occupants."
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "Débit d'Air par Facteur K",
+        "description": "Des mesures précises du facteur K permettent des calculs précis du débit d'air pour l'équilibrage du système, la mise en service et la vérification des performances. Assurez des taux de ventilation appropriés et un fonctionnement économe en énergie."
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "Étalonnage Traçable NIST",
+        "description": "Chaque sonde comprend un certificat de précision traçable aux normes NIST. Documentez la conformité pour les installations critiques, défendez votre travail avec des données certifiées et maintenez votre crédibilité professionnelle."
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Intégration avec l'Application Blü-View",
+        "description": "Vérifiez la force du signal de tous vos capteurs pour assurer une connexion solide. Visualisez les lectures en direct, enregistrez les données, générez des rapports et comparez les lectures avec les capteurs sans fil directement depuis l'application."
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "La Référence de Vérité",
+        "description": "L'utilisation d'un appareil de référence de haute précision vous permet de valider en toute confiance les capteurs de bâtiment existants, de diagnostiquer des problèmes systémiques complexes et d'assurer la conformité réglementaire avec un minimum de conjectures."
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "Le Bluetooth de Vérité",
+      "description": "La connectivité sans fil signifie plus besoin de noter les lectures. L'application Blu-View enregistre automatiquement les mesures avec horodatage, élimine les erreurs de transcription et génère des rapports professionnels.",
+      "feature1": "Transmission de données sans fil en temps réel vers votre smartphone ou tablette",
+      "feature2": "Horodatage et enregistrement de localisation automatiques pour une documentation complète",
+      "feature3": "Exportation vers PDF, Excel ou stockage cloud pour un partage et archivage faciles"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Application Blü-View",
+      "subtitle": "L'application Blü-View met le contrôle complet à portée de main. Visualisez les données en direct, téléchargez les journaux, mettez à jour le micrologiciel et gérez plusieurs appareils depuis une seule interface.",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "Surveillance en Temps Réel",
+        "description": "Visualisez les données de capteur en direct de toutes les sondes connectées. Surveillez la température, l'humidité, la pression et plus encore en temps réel avec des affichages intuitifs."
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "Télécharger les Journaux",
+        "description": "Accédez aux journaux de mesure stockés dans la mémoire embarquée de l'appareil. Exportez les données pour l'analyse, les rapports et la documentation de conformité."
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "Gestion des Appareils",
+        "description": "Gérez plusieurs sondes, vérifiez les niveaux de batterie, mettez à jour le micrologiciel et recevez des rappels d'étalonnage depuis un tableau de bord central."
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "Télécharger l'Application",
+      "learnMore": "En Savoir Plus"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "La Suite Blü-Test",
+      "subtitle": "Une famille complète de sondes intelligentes certifiées NIST. Toutes disposent d'un enregistreur de données embarqué, d'un écran LCD intégré sur la poignée et d'une connectivité Bluetooth transparente.",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "Sonde de Température 9,5\"",
+        "description": "Portée étendue pour mesurer la température en profondeur dans les conduits ou les grandes centrales de traitement d'air.",
+        "feature1": "Longueur étendue pour mesures profondes",
+        "feature2": "Thermistance 10K Type II",
+        "feature3": "Construction robuste en acier inoxydable"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "Sonde de Température 6\"",
+        "description": "Sonde polyvalente de longueur standard, idéale pour la validation générale de température HVAC.",
+        "feature1": "Conception compacte pour usage général",
+        "feature2": "Temps de réponse rapide",
+        "feature3": "Thermistance 10K Type II"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "Sonde de Température Perforante 4\"",
+        "description": "Pointe perforante robuste pour pénétrer l'isolation ou vérifier les températures de surface.",
+        "feature1": "Pénètre l'isolation et les conduits",
+        "feature2": "Pointe acérée pour insertion facile",
+        "feature3": "Idéale pour les emplacements difficiles d'accès"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "Sonde de Température à Distance",
+        "description": "Sonde câblée flexible pour les zones difficiles d'accès ou la surveillance continue sans tenir la poignée.",
+        "feature1": "Sonde séparable sur câble",
+        "feature2": "Positionnement flexible",
+        "feature3": "Capacité de portée étendue"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "Sonde de Température et Humidité 8\"",
+        "description": "Capteur combiné pour une mesure précise de la température sèche, du %HR et des calculs de point de rosée.",
+        "feature1": "Capacité de mesure double",
+        "feature2": "Détection précise de l'HR",
+        "feature3": "Lectures combinées température/humidité"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "Sonde de Pression Gamme Standard",
+        "description": "Mesure fiable de la pression différentielle (-5 à +5\" CE) pour les systèmes HVAC commerciaux standards.",
+        "feature1": "Mesure la pression des conduits et des pièces",
+        "feature2": "Plages de ±1\" CE à ±10\" CE",
+        "feature3": "Pression différentielle de haute précision"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "Sonde de Pression Gamme Basse",
+        "description": "Mesure de pression différentielle de haute précision (-1 à +1\" CE) pour les salles blanches sensibles ou les environnements de laboratoire.",
+        "feature1": "Mesure de pression ultra-sensible",
+        "feature2": "Plages de ±0,1\" CE à ±0,5\" CE",
+        "feature3": "Parfaite pour les applications de salle blanche et laboratoire"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "Spécifications Techniques",
+      "subtitle": "Conçues pour la précision et construites pour résister aux environnements commerciaux rigoureux.",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "Général",
+        "measurement": "Plage de Mesure",
+        "accuracy": "Précision",
+        "environmental": "Environnement et Certifications"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "Alimentation",
+          "value": "Batterie Rechargeable 3,7V, 2 600 mAh"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "Charge",
+          "value": "Chargeur USB Standard, 1,5A ou supérieur, câble Micro-USB inclus"
         },
         "communication": {
           "label": "Communication",
-          "value": "Bluetooth LE, Class 2 v4.2"
+          "value": "Bluetooth LE, Classe 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "Enregistrement de Données",
+          "value": "Intervalles de 10 secondes"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "Température",
+          "value": "-40 à 185°F (-40 à 85°C)"
         },
         "rh": {
-          "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "label": "%HR",
+          "value": "5 à 95% Sans condensation @ -40 à 158°F (-40 à 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Pression Diff. (Basse)",
+          "value": "-1 à +1\" CE (-250 à +250 Pascal) @ -4 à 158°F (-20 à 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Pression Diff. (Std)",
+          "value": "-5 à +5\" CE (-1 250 à +1 250 Pascal) @ -4 à 158°F (-20 à 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "Sondes de Température Uniquement",
+          "value": "±0,18°F de -13 à 167°F (±0,1°C de -25 à 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "Sondes Temp/Humidité",
+          "value": "Temp : ±0,36°F @ 77°F (±0,2°C à 25°C) | %HR : ±1%HR @ 77°F (25°C) de 10 à 85%HR"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "Pression Diff. (Basse)",
+          "value": "±0,25% de l'étendue PE, -1 à +1\" CE (-250 à +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "Pression Diff. (Std)",
+          "value": "±0,25% de l'étendue PE, -5 à +5\" CE (-1 250 à +1 250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "Plage de Fonctionnement",
+          "value": "Corps : -22 à 158°F (-30 à 70°C) | Sondes Temp : -40 à 185°F (-40 à 85°C) | Sonde %HR : 5 à 95% Sans condensation @ -40 à 158°F (-40 à 70°C) | Sonde Pression : -4 à 158°F (-20 à 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "Pression d'Éclatement",
+          "value": "Gamme Basse : 415\" CE (103 kPa) | Gamme Standard : 500\" CE (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "Approbations Réglementaires",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "Prêt à Améliorer vos Tests HVAC ?",
+      "subtitle": "Nos spécialistes en tests et mesures sont prêts à vous aider à choisir les bonnes sondes pour vos applications. Obtenez des conseils d'experts et des prix compétitifs.",
+      "contactSales": "Contacter les Ventes",
+      "viewProducts": "Voir Toutes les Sondes"
     }
   }
 }

--- a/web/messages/hi.json
+++ b/web/messages/hi.json
@@ -4051,228 +4051,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ सटीक HVAC परीक्षण और माप",
+      "description": "HVAC परीक्षण के लिए व्यावसायिक-ग्रेड परीक्षण और माप प्रोब। iOS और Android के लिए Blu-View ऐप के साथ सटीक माप।",
+      "keywords": "HVAC परीक्षण प्रोब, तापमान माप, Blu-View ऐप, सटीक प्रोब, परीक्षण उपकरण, HVAC परीक्षण, भवन स्वचालन परीक्षण"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "होम",
+      "products": "उत्पाद",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "सटीक HVAC प्रोब जिन पर आप भरोसा कर सकते हैं।",
+      "description": "HVAC और रेफ्रिजरेशन सिस्टम में मांग वाली सटीकता आवश्यकताओं के लिए परीक्षण प्रोब का एक समूह। सटीक माप और आसान डेटा लॉगिंग के लिए Blu-View ऐप के साथ निर्बाध रूप से एकीकृत करें।",
+      "cta": "प्रोब देखें",
+      "secondaryCta": "Blu-View ऐप डाउनलोड करें"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "सटीक माप",
+        "description": "तापमान, आर्द्रता, दबाव, ओस बिंदु और प्रकाश स्तर माप के लिए अत्यधिक सटीक सेंसर। HVAC कमीशनिंग और सत्यापन के लिए आदर्श।"
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "ऑनबोर्ड डेटा लॉगिंग",
+        "description": "बिल्ट-इन स्टोरेज के साथ प्रोब पर सीधे माप डेटा संग्रहीत करें। व्यापक विश्लेषण के लिए Blü-Test ऐप का उपयोग करके किसी भी समय लॉग डाउनलोड करें।"
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "स्मार्ट डिवाइस एकीकरण",
+        "description": "अपने स्मार्टफोन या टैबलेट पर लाइव डेटा देखने के लिए Bluetooth के माध्यम से कनेक्ट करें। Blü-Test ऐप रीयल-टाइम निगरानी और आसान डिवाइस प्रबंधन प्रदान करता है।"
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "सटीक संदर्भ उपकरण क्यों महत्वपूर्ण हैं",
+      "subtitle": "वाणिज्यिक HVAC में, सटीकता वैकल्पिक नहीं है—यह आवश्यक है। गलत माप से गलत निदान, समय की बर्बादी और महंगे कॉलबैक होते हैं। Blü-Test प्रोब आपको हर रीडिंग में विश्वास देते हैं।",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "तापमान सटीकता",
+        "description": "±0.18°F सटीकता सटीक सिस्टम डायग्नोस्टिक्स और इष्टतम उपकरण प्रदर्शन सुनिश्चित करती है। विफल हो रहे घटकों को इंगित करने वाले तापमान अंतर का पता लगाएं, इससे पहले कि वे सिस्टम विफलता का कारण बनें।"
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "आर्द्रता और ओस बिंदु",
+        "description": "±1% RH सटीकता संघनन समस्याओं, मोल्ड वृद्धि और आराम की शिकायतों को रोकती है। सत्यापित करें कि HVAC सिस्टम उचित इनडोर वायु गुणवत्ता बनाए रखता है और भवन कोड आवश्यकताओं को पूरा करता है।"
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "विभेदक दबाव",
+        "description": "±0.25% सटीकता डक्ट रिसाव, फ़िल्टर लोडिंग और वायुप्रवाह प्रतिबंधों को प्रकट करती है। सिस्टम दक्षता को अनुकूलित करें और ऊर्जा लागत या निवासियों के आराम को प्रभावित करने से पहले समस्याओं की पहचान करें।"
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "K-Factor वायुप्रवाह",
+        "description": "सटीक K-Factor माप सिस्टम संतुलन, कमीशनिंग और प्रदर्शन सत्यापन के लिए सटीक वायुप्रवाह गणना सक्षम करता है। उचित वेंटिलेशन दर और ऊर्जा कुशल संचालन सुनिश्चित करें।"
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "NIST-ट्रेसेबल कैलिब्रेशन",
+        "description": "प्रत्येक प्रोब में NIST मानकों के लिए ट्रेसेबल सटीकता का प्रमाणपत्र शामिल है। महत्वपूर्ण सुविधाओं के लिए अनुपालन का दस्तावेज़ीकरण करें, प्रमाणित डेटा के साथ अपने काम का बचाव करें, और पेशेवर विश्वसनीयता बनाए रखें।"
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Blü-View ऐप एकीकरण",
+        "description": "मजबूत कनेक्शन सुनिश्चित करने के लिए अपने सभी सेंसर के लिए सिग्नल ताकत की जाँच करें। लाइव रीडिंग देखें, डेटा लॉग करें, रिपोर्ट तैयार करें, और सीधे ऐप से वायरलेस सेंसर के खिलाफ रीडिंग की तुलना करें।"
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "सत्य की आधार रेखा",
+        "description": "एक अत्यधिक सटीक संदर्भ उपकरण का उपयोग करने से आप आत्मविश्वास से मौजूदा भवन सेंसर को मान्य कर सकते हैं, जटिल प्रणालीगत समस्याओं का निदान कर सकते हैं, और न्यूनतम अनुमान के साथ नियामक अनुपालन सुनिश्चित कर सकते हैं।"
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "सत्य का Bluetooth",
+      "description": "वायरलेस कनेक्टिविटी का मतलब है अब रीडिंग लिखने की आवश्यकता नहीं। Blu-View ऐप स्वचालित रूप से टाइमस्टैम्प के साथ माप लॉग करता है, प्रतिलेखन त्रुटियों को समाप्त करता है, और पेशेवर रिपोर्ट तैयार करता है।",
+      "feature1": "आपके स्मार्टफोन या टैबलेट पर रीयल-टाइम वायरलेस डेटा ट्रांसमिशन",
+      "feature2": "पूर्ण दस्तावेज़ीकरण के लिए स्वचालित टाइमस्टैम्प और स्थान लॉगिंग",
+      "feature3": "आसान साझाकरण और संग्रहण के लिए PDF, Excel, या क्लाउड स्टोरेज में निर्यात करें"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Blü-View ऐप",
+      "subtitle": "Blü-View ऐप आपकी उंगलियों पर पूर्ण नियंत्रण रखता है। लाइव डेटा देखें, लॉग डाउनलोड करें, फर्मवेयर अपडेट करें, और एक इंटरफ़ेस से कई उपकरणों को प्रबंधित करें।",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "रीयल-टाइम निगरानी",
+        "description": "सभी कनेक्टेड प्रोब से लाइव सेंसर डेटा देखें। सहज प्रदर्शन के साथ तापमान, आर्द्रता, दबाव और अधिक को रीयल-टाइम में मॉनिटर करें।"
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "लॉग डाउनलोड करें",
+        "description": "ऑनबोर्ड डिवाइस मेमोरी से संग्रहीत माप लॉग तक पहुंचें। विश्लेषण, रिपोर्टिंग और अनुपालन दस्तावेज़ीकरण के लिए डेटा निर्यात करें।"
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "डिवाइस प्रबंधन",
+        "description": "कई प्रोब प्रबंधित करें, बैटरी स्तर की जाँच करें, फर्मवेयर अपडेट करें, और एक केंद्रीय डैशबोर्ड से कैलिब्रेशन रिमाइंडर प्राप्त करें।"
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "ऐप डाउनलोड करें",
+      "learnMore": "और जानें"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "Blü-Test सुइट",
+      "subtitle": "बुद्धिमान, NIST-प्रमाणित प्रोब का एक व्यापक परिवार। सभी में एक ऑनबोर्ड डेटा लॉगर, हैंडल पर एक बिल्ट-इन LCD डिस्प्ले, और निर्बाध Bluetooth कनेक्टिविटी है।",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "9.5\" तापमान प्रोब",
+        "description": "डक्ट या बड़े एयर हैंडलर के भीतर गहराई में तापमान मापने के लिए विस्तारित पहुंच।",
+        "feature1": "गहरे माप के लिए विस्तारित लंबाई",
+        "feature2": "10K Type II थर्मिस्टर",
+        "feature3": "मजबूत स्टेनलेस स्टील निर्माण"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "6\" तापमान प्रोब",
+        "description": "सामान्य प्रयोजन HVAC तापमान सत्यापन के लिए बहुमुखी, मानक लंबाई प्रोब।",
+        "feature1": "सामान्य उपयोग के लिए कॉम्पैक्ट डिज़ाइन",
+        "feature2": "तेज़ प्रतिक्रिया समय",
+        "feature3": "10K Type II थर्मिस्टर"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "4\" छेदने वाला तापमान प्रोब",
+        "description": "इंसुलेशन को भेदने या सतह के तापमान की जाँच करने के लिए मजबूत छेदने वाली टिप।",
+        "feature1": "इंसुलेशन और डक्टवर्क को भेदता है",
+        "feature2": "आसान सम्मिलन के लिए तेज़ टिप",
+        "feature3": "कठिन-पहुंच वाले स्थानों के लिए आदर्श"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "रिमोट तापमान प्रोब",
+        "description": "कठिन-पहुंच वाले क्षेत्रों या हैंडल को पकड़े बिना निरंतर निगरानी के लिए लचीला वायर्ड प्रोब।",
+        "feature1": "केबल पर अलग करने योग्य प्रोब",
+        "feature2": "लचीली स्थिति",
+        "feature3": "विस्तारित पहुंच क्षमता"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "8\" तापमान और आर्द्रता प्रोब",
+        "description": "सटीक ड्राई बल्ब तापमान, %RH, और ओस बिंदु गणना के लिए संयुक्त सेंसर।",
+        "feature1": "दोहरी माप क्षमता",
+        "feature2": "सटीक RH सेंसिंग",
+        "feature3": "संयुक्त तापमान/आर्द्रता रीडिंग"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "मानक रेंज दबाव प्रोब",
+        "description": "मानक वाणिज्यिक HVAC सिस्टम के लिए विश्वसनीय विभेदक दबाव माप (-5 से +5\" WC)।",
+        "feature1": "डक्ट और कमरे के दबाव को मापता है",
+        "feature2": "±1\" WC से ±10\" WC रेंज",
+        "feature3": "उच्च सटीकता विभेदक दबाव"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "निम्न रेंज दबाव प्रोब",
+        "description": "संवेदनशील क्लीनरूम या लैब वातावरण के लिए उच्च-सटीकता विभेदक दबाव माप (-1 से +1\" WC)।",
+        "feature1": "अल्ट्रा-संवेदनशील दबाव माप",
+        "feature2": "±0.1\" WC से ±0.5\" WC रेंज",
+        "feature3": "क्लीन रूम और लैब अनुप्रयोगों के लिए बिल्कुल सही"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "तकनीकी विनिर्देश",
+      "subtitle": "सटीकता के लिए इंजीनियर और कठोर वाणिज्यिक वातावरण का सामना करने के लिए निर्मित।",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "सामान्य",
+        "measurement": "माप रेंज",
+        "accuracy": "सटीकता",
+        "environmental": "पर्यावरण और प्रमाणन"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "पावर",
+          "value": "3.7V, 2,600 mAh रिचार्जेबल बैटरी"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "चार्जिंग",
+          "value": "मानक USB चार्जर, 1.5A या अधिक, Micro-USB केबल शामिल"
         },
         "communication": {
-          "label": "Communication",
+          "label": "संचार",
           "value": "Bluetooth LE, Class 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "डेटा लॉगिंग",
+          "value": "10 सेकंड के अंतराल"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "तापमान",
+          "value": "-40 से 185°F (-40 से 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 से 95% गैर-संघनित @ -40 से 158°F (-40 से 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "विभेदक दबाव (निम्न)",
+          "value": "-1 से +1\" WC (-250 से +250 Pascal) @ -4 से 158°F (-20 से 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "विभेदक दबाव (मानक)",
+          "value": "-5 से +5\" WC (-1,250 से +1,250 Pascal) @ -4 से 158°F (-20 से 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "केवल तापमान प्रोब",
+          "value": "±0.18°F -13 से 167°F (±0.1°C -25 से 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "तापमान/आर्द्रता प्रोब",
+          "value": "तापमान: ±0.36°F @ 77°F (±0.2°C 25°C पर) | %RH: ±1%RH @ 77°F (25°C) 10 से 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "विभेदक दबाव (निम्न)",
+          "value": "±0.25% FS स्पान का, -1 से +1\" WC (-250 से +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "विभेदक दबाव (मानक)",
+          "value": "±0.25% FS स्पान का, -5 से +5\" WC (-1,250 से +1,250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "ऑपरेटिंग रेंज",
+          "value": "बॉडी: -22 से 158°F (-30 से 70°C) | तापमान प्रोब: -40 से 185°F (-40 से 85°C) | %RH प्रोब: 5 से 95% गैर-संघनित @ -40 से 158°F (-40 से 70°C) | दबाव प्रोब: -4 से 158°F (-20 से 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "बर्स्ट दबाव",
+          "value": "निम्न रेंज: 415\" WC (103 kPa) | मानक रेंज: 500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "एजेंसी अनुमोदन",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "अपने HVAC परीक्षण को अपग्रेड करने के लिए तैयार हैं?",
+      "subtitle": "हमारे परीक्षण और माप विशेषज्ञ आपके अनुप्रयोगों के लिए सही प्रोब चुनने में आपकी मदद करने के लिए तैयार हैं। विशेषज्ञ सलाह और प्रतिस्पर्धी मूल्य प्राप्त करें।",
+      "contactSales": "बिक्री से संपर्क करें",
+      "viewProducts": "सभी प्रोब देखें"
     }
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -4051,228 +4051,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ 精密HVAC試験・測定",
+      "description": "HVAC試験用のプロフェッショナルグレードの試験・測定プローブ。iOS及びAndroid用Blu-Viewアプリによる精密測定。",
+      "keywords": "HVAC試験プローブ, 温度測定, Blu-Viewアプリ, 精密プローブ, 試験機器, HVAC試験, ビル自動化試験"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "ホーム",
+      "products": "製品",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "信頼できる精密HVACプローブ。",
+      "description": "HVAC及び冷凍システム全体で厳しい精度要件に対応する試験プローブのスイート。Blu-Viewアプリとシームレスに統合し、精密測定と簡単なデータロギングを実現します。",
+      "cta": "プローブを見る",
+      "secondaryCta": "Blu-Viewアプリをダウンロード"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "精密測定",
+        "description": "温度、湿度、圧力、露点、照度測定用の高精度センサー。HVACコミッショニングと検証に最適です。"
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "オンボードデータロギング",
+        "description": "内蔵ストレージで測定データをプローブに直接保存。Blü-Testアプリを使用していつでもログをダウンロードして包括的な分析が可能です。"
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "スマートデバイス統合",
+        "description": "Bluetooth経由で接続し、スマートフォンやタブレットでリアルタイムデータを表示。Blü-Testアプリはリアルタイムモニタリングと簡単なデバイス管理を提供します。"
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "正確な基準デバイスが重要な理由",
+      "subtitle": "商業用HVACでは、精度はオプションではなく不可欠です。不正確な測定は誤診断、時間の無駄、高コストのコールバックにつながります。Blü-Testプローブはすべての測定値に自信を与えます。",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "温度精度",
+        "description": "±0.18°Fの精度により、正確なシステム診断と最適な機器性能を保証します。システム故障を引き起こす前に、故障コンポーネントを示す温度差を検出します。"
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "湿度と露点",
+        "description": "±1% RHの精度により、結露問題、カビの発生、快適性の苦情を防止します。HVACシステムが適切な室内空気質を維持し、建築基準の要件を満たしていることを検証します。"
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "差圧",
+        "description": "±0.25%の精度により、ダクト漏れ、フィルター負荷、気流制限を明らかにします。システム効率を最適化し、エネルギーコストや居住者の快適性に影響を与える前に問題を特定します。"
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "K係数気流",
+        "description": "正確なK係数測定により、システムバランシング、コミッショニング、性能検証のための精密な気流計算が可能になります。適切な換気率とエネルギー効率的な運用を確保します。"
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "NISTトレーサブル校正",
+        "description": "すべてのプローブにはNIST規格にトレーサブルな精度証明書が含まれています。重要施設のコンプライアンスを文書化し、認定データで作業を擁護し、専門的信頼性を維持します。"
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Blü-Viewアプリ統合",
+        "description": "すべてのセンサーの信号強度を確認して、強力な接続を保証します。アプリから直接、ライブ測定値の表示、データのログ記録、レポートの生成、ワイヤレスセンサーとの測定値の比較が可能です。"
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "真実のベースライン",
+        "description": "高精度の基準デバイスを使用することで、既存のビルセンサーを自信を持って検証し、複雑なシステム問題を診断し、最小限の推測で規制コンプライアンスを確保できます。"
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "真実のBluetooth",
+      "description": "ワイヤレス接続により、測定値を書き留める必要がなくなります。Blu-Viewアプリは、タイムスタンプ付きで測定値を自動的にログ記録し、転記エラーを排除し、専門的なレポートを生成します。",
+      "feature1": "スマートフォンまたはタブレットへのリアルタイムワイヤレスデータ転送",
+      "feature2": "完全な文書化のための自動タイムスタンプと場所のログ記録",
+      "feature3": "簡単な共有とアーカイブのためのPDF、Excel、またはクラウドストレージへのエクスポート"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Blü-Viewアプリ",
+      "subtitle": "Blü-Viewアプリにより、完全な制御が指先で可能になります。ライブデータの表示、ログのダウンロード、ファームウェアの更新、1つのインターフェースから複数のデバイスの管理が可能です。",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "リアルタイムモニタリング",
+        "description": "接続されたすべてのプローブからのライブセンサーデータを表示。直感的なディスプレイで温度、湿度、圧力などをリアルタイムで監視します。"
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "ログのダウンロード",
+        "description": "オンボードデバイスメモリから保存された測定ログにアクセス。分析、レポート作成、コンプライアンス文書化のためにデータをエクスポートします。"
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "デバイス管理",
+        "description": "複数のプローブの管理、バッテリーレベルの確認、ファームウェアの更新、校正リマインダーの受信を、すべて1つの中央ダッシュボードから実行します。"
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "アプリをダウンロード",
+      "learnMore": "詳細はこちら"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "Blü-Testスイート",
+      "subtitle": "インテリジェントでNIST認定されたプローブの包括的なファミリー。すべてにオンボードデータロガー、ハンドルに内蔵されたLCDディスプレイ、シームレスなBluetooth接続が搭載されています。",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "9.5インチ温度プローブ",
+        "description": "ダクトや大型エアハンドラー内部の深い位置での温度測定のための延長リーチ。",
+        "feature1": "深い測定のための延長長",
+        "feature2": "10K Type IIサーミスタ",
+        "feature3": "堅牢なステンレススチール構造"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "6インチ温度プローブ",
+        "description": "汎用HVAC温度検証に最適な、汎用性の高い標準長プローブ。",
+        "feature1": "一般使用のためのコンパクト設計",
+        "feature2": "高速応答時間",
+        "feature3": "10K Type IIサーミスタ"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "4インチ穿刺温度プローブ",
+        "description": "断熱材を貫通したり表面温度をチェックしたりするための堅牢な穿刺先端。",
+        "feature1": "断熱材とダクトを貫通",
+        "feature2": "簡単に挿入できる鋭い先端",
+        "feature3": "手の届きにくい場所に最適"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "リモート温度プローブ",
+        "description": "手の届きにくい場所やハンドルを持たずに連続監視するための柔軟な有線プローブ。",
+        "feature1": "ケーブル上の分離可能なプローブ",
+        "feature2": "柔軟な位置決め",
+        "feature3": "延長リーチ機能"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "8インチ温度・湿度プローブ",
+        "description": "正確な乾球温度、%RH、露点計算のための複合センサー。",
+        "feature1": "デュアル測定機能",
+        "feature2": "正確なRH検知",
+        "feature3": "温度/湿度の複合測定値"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "標準レンジ圧力プローブ",
+        "description": "標準的な商業用HVACシステム用の信頼性の高い差圧測定(-5～+5インチ水柱)。",
+        "feature1": "ダクトと室内圧力を測定",
+        "feature2": "±1インチ水柱～±10インチ水柱の範囲",
+        "feature3": "高精度差圧"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "低レンジ圧力プローブ",
+        "description": "クリーンルームや研究室環境用の高精度差圧測定(-1～+1インチ水柱)。",
+        "feature1": "超高感度圧力測定",
+        "feature2": "±0.1インチ水柱～±0.5インチ水柱の範囲",
+        "feature3": "クリーンルームと研究室アプリケーションに最適"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "技術仕様",
+      "subtitle": "精密のために設計され、厳しい商業環境に耐えるように構築されています。",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "一般",
+        "measurement": "測定範囲",
+        "accuracy": "精度",
+        "environmental": "環境及び認証"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "電源",
+          "value": "3.7V、2,600 mAh充電式バッテリー"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "充電",
+          "value": "標準USB充電器、1.5A以上、Micro-USBケーブル付属"
         },
         "communication": {
-          "label": "Communication",
-          "value": "Bluetooth LE, Class 2 v4.2"
+          "label": "通信",
+          "value": "Bluetooth LE、クラス2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "データロギング",
+          "value": "10秒間隔"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "温度",
+          "value": "-40～185°F(-40～85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5～95%非結露 @ -40～158°F(-40～70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "差圧(低)",
+          "value": "-1～+1インチ水柱(-250～+250パスカル)@ -4～158°F(-20～70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "差圧(標準)",
+          "value": "-5～+5インチ水柱(-1,250～+1,250パスカル)@ -4～158°F(-20～70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "温度のみプローブ",
+          "value": "±0.18°F(-13～167°F)、(±0.1°C(-25～75°C))"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "温度/湿度プローブ",
+          "value": "温度:±0.36°F @ 77°F(±0.2°C @ 25°C)|%RH:±1%RH @ 77°F(25°C)、10～85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "差圧(低)",
+          "value": "±0.25% FS スパン、-1～+1インチ水柱(-250～+250 Pa)@ 77°F(25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "差圧(標準)",
+          "value": "±0.25% FS スパン、-5～+5インチ水柱(-1,250～+1,250 Pa)@ 77°F(25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "動作範囲",
+          "value": "本体:-22～158°F(-30～70°C)|温度プローブ:-40～185°F(-40～85°C)|%RHプローブ:5～95%非結露 @ -40～158°F(-40～70°C)|圧力プローブ:-4～158°F(-20～70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "破裂圧力",
+          "value": "低レンジ:415インチ水柱(103 kPa)|標準レンジ:500インチ水柱(124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
-          "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
+          "label": "機関承認",
+          "value": "CE EN 61326-1:2013 EMC、RoHS、NSF、FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "HVAC試験をアップグレードする準備はできていますか?",
+      "subtitle": "当社の試験・測定スペシャリストが、お客様のアプリケーションに適したプローブの選択をお手伝いします。専門的なアドバイスと競争力のある価格を提供します。",
+      "contactSales": "営業担当に問い合わせる",
+      "viewProducts": "すべてのプローブを見る"
     }
   }
 }

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -4051,228 +4051,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ Precyzyjne Testowanie i Pomiary HVAC",
+      "description": "Profesjonalne sondy testowe i pomiarowe do testowania HVAC. Precyzyjny pomiar z aplikacją Blu-View dla iOS i Android.",
+      "keywords": "sondy testowe HVAC, pomiar temperatury, aplikacja Blu-View, sondy precyzyjne, sprzęt testowy, testowanie HVAC, testowanie automatyki budynkowej"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "Strona główna",
+      "products": "Produkty",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "Precyzyjne Sondy HVAC, Którym Możesz Zaufać.",
+      "description": "Zestaw sond testowych spełniających wymagania dotyczące dokładności w systemach HVAC i chłodniczych. Bezproblemowa integracja z aplikacją Blu-View zapewnia precyzyjny pomiar i łatwe rejestrowanie danych.",
+      "cta": "Poznaj Sondy",
+      "secondaryCta": "Pobierz Aplikację Blu-View"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "Precyzyjny Pomiar",
+        "description": "Czujniki o wysokiej dokładności do pomiaru temperatury, wilgotności, ciśnienia, punktu rosy i poziomu oświetlenia. Idealne do rozruchu i weryfikacji HVAC."
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "Wbudowane Rejestrowanie Danych",
+        "description": "Przechowuj dane pomiarowe bezpośrednio na sondach z wbudowaną pamięcią. Pobieraj logi w dowolnym momencie za pomocą aplikacji Blü-Test do kompleksowej analizy."
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "Integracja z Urządzeniami Mobilnymi",
+        "description": "Połącz się przez Bluetooth, aby wyświetlać dane na żywo na smartfonie lub tablecie. Aplikacja Blü-Test zapewnia monitorowanie w czasie rzeczywistym i łatwe zarządzanie urządzeniami."
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "Dlaczego Dokładne Urządzenia Referencyjne Mają Znaczenie",
+      "subtitle": "W komercyjnych systemach HVAC precyzja nie jest opcjonalna — jest niezbędna. Niedokładne pomiary prowadzą do błędnych diagnoz, marnowania czasu i kosztownych wizyt serwisowych. Sondy Blü-Test dają pewność przy każdym odczycie.",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "Dokładność Temperatury",
+        "description": "Dokładność ±0,18°F zapewnia precyzyjną diagnostykę systemu i optymalną wydajność urządzeń. Wykrywaj różnice temperatur wskazujące na uszkodzone komponenty, zanim spowodują awarię systemu."
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "Wilgotność i Punkt Rosy",
+        "description": "Dokładność ±1% RH zapobiega problemom kondensacji, rozwojowi pleśni i skargom na komfort. Sprawdzaj, czy systemy HVAC utrzymują odpowiednią jakość powietrza wewnętrznego i spełniają wymagania przepisów budowlanych."
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "Ciśnienie Różnicowe",
+        "description": "Dokładność ±0,25% ujawnia nieszczelności kanałów, zapchanie filtrów i ograniczenia przepływu powietrza. Optymalizuj wydajność systemu i identyfikuj problemy, zanim wpłyną na koszty energii lub komfort użytkowników."
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "Przepływ Powietrza K-Factor",
+        "description": "Dokładne pomiary K-Factor umożliwiają precyzyjne obliczenia przepływu powietrza do wyważania systemu, rozruchu i weryfikacji wydajności. Zapewnij odpowiednie wskaźniki wentylacji i energooszczędną pracę."
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "Kalibracja Zgodna z NIST",
+        "description": "Każda sonda zawiera Certyfikat Dokładności zgodny ze standardami NIST. Dokumentuj zgodność dla obiektów krytycznych, broń swojej pracy certyfikowanymi danymi i utrzymuj profesjonalną wiarygodność."
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Integracja z Aplikacją Blü-View",
+        "description": "Sprawdzaj moc sygnału wszystkich czujników, aby zapewnić mocne połączenie. Przeglądaj odczyty na żywo, rejestruj dane, generuj raporty i porównuj odczyty z czujników bezprzewodowych bezpośrednio z aplikacji."
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "Punkt Odniesienia Prawdy",
+        "description": "Używanie bardzo dokładnego urządzenia referencyjnego pozwala pewnie walidować istniejące czujniki budynkowe, diagnozować złożone problemy systemowe i zapewniać zgodność z przepisami przy minimalnym zgadywaniu."
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "Bluetooth Prawdy",
+      "description": "Łączność bezprzewodowa oznacza koniec z zapisywaniem odczytów. Aplikacja Blu-View automatycznie rejestruje pomiary z znacznikami czasu, eliminuje błędy transkrypcji i generuje profesjonalne raporty.",
+      "feature1": "Bezprzewodowa transmisja danych w czasie rzeczywistym na smartfon lub tablet",
+      "feature2": "Automatyczne rejestrowanie znaczników czasu i lokalizacji dla pełnej dokumentacji",
+      "feature3": "Eksport do PDF, Excel lub pamięci w chmurze dla łatwego udostępniania i archiwizacji"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Aplikacja Blü-View",
+      "subtitle": "Aplikacja Blü-View zapewnia pełną kontrolę na wyciągnięcie ręki. Przeglądaj dane na żywo, pobieraj logi, aktualizuj oprogramowanie i zarządzaj wieloma urządzeniami z jednego interfejsu.",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "Monitorowanie w Czasie Rzeczywistym",
+        "description": "Przeglądaj dane czujników na żywo ze wszystkich podłączonych sond. Monitoruj temperaturę, wilgotność, ciśnienie i więcej w czasie rzeczywistym za pomocą intuicyjnych wyświetlaczy."
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "Pobieranie Logów",
+        "description": "Uzyskaj dostęp do przechowywanych logów pomiarów z wbudowanej pamięci urządzenia. Eksportuj dane do analizy, raportowania i dokumentacji zgodności."
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "Zarządzanie Urządzeniami",
+        "description": "Zarządzaj wieloma sondami, sprawdzaj poziomy baterii, aktualizuj oprogramowanie i otrzymuj przypomnienia o kalibracji z jednego centralnego pulpitu."
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "Pobierz Aplikację",
+      "learnMore": "Dowiedz Się Więcej"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "Zestaw Blü-Test",
+      "subtitle": "Kompleksowa rodzina inteligentnych, certyfikowanych przez NIST sond. Wszystkie wyposażone w wbudowany rejestrator danych, wyświetlacz LCD na uchwycie i bezproblemową łączność Bluetooth.",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "Sonda Temperatury 9,5\"",
+        "description": "Przedłużony zasięg do pomiaru temperatury głęboko w kanałach lub dużych jednostkach klimatyzacyjnych.",
+        "feature1": "Przedłużona długość do głębokich pomiarów",
+        "feature2": "Termistor 10K Type II",
+        "feature3": "Wytrzymała konstrukcja ze stali nierdzewnej"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "Sonda Temperatury 6\"",
+        "description": "Wszechstronna sonda o standardowej długości, idealna do ogólnych zastosowań walidacji temperatury HVAC.",
+        "feature1": "Kompaktowa konstrukcja do zastosowań ogólnych",
+        "feature2": "Szybki czas odpowiedzi",
+        "feature3": "Termistor 10K Type II"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "Przebijająca Sonda Temperatury 4\"",
+        "description": "Wytrzymała przebijająca końcówka do penetracji izolacji lub sprawdzania temperatur powierzchni.",
+        "feature1": "Przebija izolację i kanały wentylacyjne",
+        "feature2": "Ostra końcówka dla łatwego wprowadzania",
+        "feature3": "Idealna do trudno dostępnych miejsc"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "Zdalna Sonda Temperatury",
+        "description": "Elastyczna sonda przewodowa do trudno dostępnych miejsc lub ciągłego monitorowania bez trzymania uchwytu.",
+        "feature1": "Oddzielana sonda na kablu",
+        "feature2": "Elastyczne pozycjonowanie",
+        "feature3": "Możliwość przedłużonego zasięgu"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "Sonda Temperatury i Wilgotności 8\"",
+        "description": "Kombinowany czujnik do dokładnego pomiaru temperatury termometru suchego, %RH i obliczeń punktu rosy.",
+        "feature1": "Podwójna możliwość pomiaru",
+        "feature2": "Dokładne wykrywanie wilgotności względnej",
+        "feature3": "Połączone odczyty temp/wilgotność"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "Sonda Ciśnienia Zakres Standardowy",
+        "description": "Niezawodny pomiar ciśnienia różnicowego (-5 do +5\" WC) dla standardowych komercyjnych systemów HVAC.",
+        "feature1": "Mierzy ciśnienie w kanałach i pomieszczeniach",
+        "feature2": "Zakresy od ±1\" WC do ±10\" WC",
+        "feature3": "Wysokiej dokładności ciśnienie różnicowe"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "Sonda Ciśnienia Zakres Niski",
+        "description": "Wysokoprecyzyjny pomiar ciśnienia różnicowego (-1 do +1\" WC) dla wrażliwych pomieszczeń czystych lub laboratoriów.",
+        "feature1": "Ultra-czuły pomiar ciśnienia",
+        "feature2": "Zakresy od ±0,1\" WC do ±0,5\" WC",
+        "feature3": "Idealna do pomieszczeń czystych i zastosowań laboratoryjnych"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "Specyfikacje Techniczne",
+      "subtitle": "Zaprojektowane dla precyzji i zbudowane, aby wytrzymać wymagające środowiska komercyjne.",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "Ogólne",
+        "measurement": "Zakres Pomiarowy",
+        "accuracy": "Dokładność",
+        "environmental": "Środowiskowe i Certyfikaty"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "Zasilanie",
+          "value": "3,7V, 2600 mAh Bateria Akumulatorowa"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "Ładowanie",
+          "value": "Standardowa ładowarka USB, 1,5A lub większa, kabel Micro-USB w zestawie"
         },
         "communication": {
-          "label": "Communication",
-          "value": "Bluetooth LE, Class 2 v4.2"
+          "label": "Komunikacja",
+          "value": "Bluetooth LE, Klasa 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "Rejestrowanie Danych",
+          "value": "Odstępy 10-sekundowe"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "Temperatura",
+          "value": "-40 do 185°F (-40 do 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 do 95% bez kondensacji @ -40 do 158°F (-40 do 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Ciśnienie różnicowe (niskie)",
+          "value": "-1 do +1\" WC (-250 do +250 Pascal) @ -4 do 158°F (-20 do 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Ciśnienie różnicowe (std)",
+          "value": "-5 do +5\" WC (-1250 do +1250 Pascal) @ -4 do 158°F (-20 do 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "Tylko Sondy Temperatury",
+          "value": "±0,18°F od -13 do 167°F (±0,1°C od -25 do 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "Sondy Temp/Wilgotność",
+          "value": "Temp: ±0,36°F @ 77°F (±0,2°C przy 25°C) | %RH: ±1%RH @ 77°F (25°C) od 10 do 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "Ciśnienie różnicowe (niskie)",
+          "value": "±0,25% zakresu FS, -1 do +1\" WC (-250 do +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "Ciśnienie różnicowe (std)",
+          "value": "±0,25% zakresu FS, -5 do +5\" WC (-1250 do +1250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "Zakres Pracy",
+          "value": "Obudowa: -22 do 158°F (-30 do 70°C) | Sondy temp: -40 do 185°F (-40 do 85°C) | Sonda %RH: 5 do 95% bez kondensacji @ -40 do 158°F (-40 do 70°C) | Sonda ciśnienia: -4 do 158°F (-20 do 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "Ciśnienie Pęknięcia",
+          "value": "Zakres niski: 415\" WC (103 kPa) | Zakres standardowy: 500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "Certyfikaty",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "Gotowy na Ulepszenie Testowania HVAC?",
+      "subtitle": "Nasi specjaliści ds. testowania i pomiarów są gotowi pomóc w wyborze odpowiednich sond do Twoich zastosowań. Uzyskaj fachową poradę i konkurencyjne ceny.",
+      "contactSales": "Skontaktuj Się z Działem Sprzedaży",
+      "viewProducts": "Zobacz Wszystkie Sondy"
     }
   }
 }

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -4051,228 +4051,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ การทดสอบและวัดค่า HVAC แบบความแม่นยำสูง",
+      "description": "โพรบทดสอบและวัดค่าระดับมืออาชีพสำหรับการทดสอบ HVAC วัดค่าความแม่นยำสูงด้วยแอป Blu-View สำหรับ iOS และ Android",
+      "keywords": "โพรบทดสอบ HVAC, การวัดอุณหภูมิ, แอป Blu-View, โพรบความแม่นยำสูง, อุปกรณ์ทดสอบ, การทดสอบ HVAC, การทดสอบระบบอัตโนมัติอาคาร"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "หน้าหลัก",
+      "products": "ผลิตภัณฑ์",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "โพรบ HVAC ความแม่นยำสูงที่คุณไว้วางใจได้",
+      "description": "ชุดโพรบทดสอบสำหรับความต้องการความแม่นยำสูงในระบบ HVAC และระบบทำความเย็น ผสานรวมได้อย่างลงตัวกับแอป Blu-View เพื่อการวัดค่าที่แม่นยำและบันทึกข้อมูลได้ง่าย",
+      "cta": "สำรวจโพรบ",
+      "secondaryCta": "ดาวน์โหลดแอป Blu-View"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "การวัดค่าความแม่นยำสูง",
+        "description": "เซ็นเซอร์ที่แม่นยำสูงสำหรับการวัดอุณหภูมิ ความชื้น ความดัน จุดน้ำค้าง และระดับแสงสว่าง เหมาะอย่างยิ่งสำหรับการ commissioning และตรวจสอบระบบ HVAC"
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "บันทึกข้อมูลในตัวเครื่อง",
+        "description": "จัดเก็บข้อมูลการวัดค่าลงในโพรบโดยตรงด้วยหน่วยความจำในตัว ดาวน์โหลดบันทึกได้ทุกเมื่อผ่านแอป Blü-Test เพื่อการวิเคราะห์ข้อมูลอย่างครอบคลุม"
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "การผสานรวมกับอุปกรณ์อัจฉริยะ",
+        "description": "เชื่อมต่อผ่าน Bluetooth เพื่อดูข้อมูลแบบเรียลไทม์บนสมาร์ทโฟนหรือแท็บเล็ตของคุณ แอป Blü-Test ให้บริการการตรวจสอบแบบเรียลไทม์และการจัดการอุปกรณ์ได้ง่าย"
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "ทำไมอุปกรณ์อ้างอิงที่แม่นยำจึงสำคัญ",
+      "subtitle": "ใน HVAC เชิงพาณิชย์ ความแม่นยำไม่ใช่ตัวเลือก—แต่เป็นสิ่งจำเป็น การวัดค่าที่ไม่แม่นยำนำไปสู่การวินิจฉัยปัญหาผิดพลาด เสียเวลา และการเรียกกลับที่มีค่าใช้จ่ายสูง โพรบ Blü-Test ให้ความมั่นใจในทุกค่าที่วัดได้",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "ความแม่นยำของอุณหภูมิ",
+        "description": "ความแม่นยำ ±0.18°F รับประกันการวินิจฉัยระบบที่แม่นยำและประสิทธิภาพการทำงานของอุปกรณ์ที่เหมาะสมที่สุด ตรวจจับความแตกต่างของอุณหภูมิที่บ่งบอกถึงชิ้นส่วนที่กำลังเสียหายก่อนที่จะทำให้ระบบล้มเหลว"
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "ความชื้นและจุดน้ำค้าง",
+        "description": "ความแม่นยำ ±1% RH ป้องกันปัญหาการควบแน่น การเติบโตของเชื้อรา และข้อร้องเรียนเรื่องความสะดวกสบาย ยืนยันว่าระบบ HVAC รักษาคุณภาพอากาศภายในอาคารที่เหมาะสมและเป็นไปตามข้อกำหนดของรหัสอาคาร"
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "ความดันแตกต่าง",
+        "description": "ความแม่นยำ ±0.25% เปิดเผยการรั่วซึมของท่อลม การอุดตันของฟิลเตอร์ และการอุดตันของการไหลเวียนอากาศ เพิ่มประสิทธิภาพของระบบและระบุปัญหาก่อนที่จะส่งผลกระทบต่อต้นทุนพลังงานหรือความสะดวกสบายของผู้พักอาศัย"
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "การไหลของอากาศแบบ K-Factor",
+        "description": "การวัด K-Factor ที่แม่นยำช่วยให้สามารถคำนวณการไหลของอากาศได้อย่างแม่นยำสำหรับการปรับสมดุลระบบ การ commissioning และการตรวจสอบประสิทธิภาพ รับประกันอัตราการระบายอากาศที่เหมาะสมและการทำงานที่ประหยัดพลังงาน"
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "การสอบเทียบที่สามารถตรวจสอบย้อนกลับไปยัง NIST",
+        "description": "โพรบทุกตัวมีใบรับรองความแม่นยำที่สามารถตรวจสอบย้อนกลับไปยังมาตรฐาน NIST บันทึกการปฏิบัติตามข้อกำหนดสำหรับสถานที่สำคัญ ปกป้องงานของคุณด้วยข้อมูลที่ได้รับการรับรอง และรักษาความน่าเชื่อถือระดับมืออาชีพ"
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "การผสานรวมกับแอป Blü-View",
+        "description": "ตรวจสอบความแรงของสัญญาณสำหรับเซ็นเซอร์ทั้งหมดของคุณเพื่อให้แน่ใจว่ามีการเชื่อมต่อที่แข็งแรง ดูค่าที่อ่านได้แบบเรียลไทม์ บันทึกข้อมูล สร้างรายงาน และเปรียบเทียบค่าที่อ่านได้กับเซ็นเซอร์ไร้สายได้ทันทีจากแอป"
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "พื้นฐานแห่งความจริง",
+        "description": "การใช้อุปกรณ์อ้างอิงที่แม่นยำสูงช่วยให้คุณตรวจสอบเซ็นเซอร์อาคารที่มีอยู่ได้อย่างมั่นใจ วินิจฉัยปัญหาที่ซับซ้อนของระบบ และรับประกันการปฏิบัติตามข้อกำหนดด้วยการคาดเดาน้อยที่สุด"
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "Bluetooth แห่งความจริง",
+      "description": "การเชื่อมต่อแบบไร้สายหมายความว่าไม่ต้องจดบันทึกค่าที่อ่านได้อีกต่อไป แอป Blu-View บันทึกการวัดค่าพร้อมการประทับเวลาโดยอัตโนมัติ ลดข้อผิดพลาดในการถอดความ และสร้างรายงานระดับมืออาชีพ",
+      "feature1": "การส่งข้อมูลแบบไร้สายแบบเรียลไทม์ไปยังสมาร์ทโฟนหรือแท็บเล็ตของคุณ",
+      "feature2": "การบันทึกประทับเวลาและตำแหน่งโดยอัตโนมัติเพื่อการจัดทำเอกสารที่สมบูรณ์",
+      "feature3": "ส่งออกเป็น PDF, Excel หรือที่เก็บข้อมูลบนคลาวด์เพื่อการแบ่งปันและจัดเก็บข้อมูลได้ง่าย"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "แอป Blü-View",
+      "subtitle": "แอป Blü-View ให้การควบคุมที่สมบูรณ์อยู่ในมือคุณ ดูข้อมูลแบบเรียลไทม์ ดาวน์โหลดบันทึก อัปเดตเฟิร์มแวร์ และจัดการอุปกรณ์หลายตัวจากอินเทอร์เฟซเดียว",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "การตรวจสอบแบบเรียลไทม์",
+        "description": "ดูข้อมูลเซ็นเซอร์แบบเรียลไทม์จากโพรบที่เชื่อมต่อทั้งหมด ตรวจสอบอุณหภูมิ ความชื้น ความดัน และอื่นๆ แบบเรียลไทม์ด้วยการแสดงผลที่ใช้งานง่าย"
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "ดาวน์โหลดบันทึก",
+        "description": "เข้าถึงบันทึกการวัดค่าที่จัดเก็บไว้จากหน่วยความจำของอุปกรณ์ ส่งออกข้อมูลเพื่อการวิเคราะห์ การรายงาน และการจัดทำเอกสารการปฏิบัติตามข้อกำหนด"
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "การจัดการอุปกรณ์",
+        "description": "จัดการโพรบหลายตัว ตรวจสอบระดับแบตเตอรี่ อัปเดตเฟิร์มแวร์ และรับการแจ้งเตือนการสอบเทียบทั้งหมดจากแดชบอร์ดกลางเดียว"
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "ดาวน์โหลดแอป",
+      "learnMore": "เรียนรู้เพิ่มเติม"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "ชุดผลิตภัณฑ์ Blü-Test",
+      "subtitle": "กลุ่มโพรบอัจฉริยะที่ได้รับการรับรองจาก NIST อย่างครอบคลุม ทั้งหมดมีเครื่องบันทึกข้อมูลในตัว จอแสดงผล LCD ในตัวบนด้ามจับ และการเชื่อมต่อ Bluetooth ที่ลงตัว",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "โพรบวัดอุณหภูมิ 9.5 นิ้ว",
+        "description": "ความยาวที่ขยายออกสำหรับการวัดอุณหภูมิลึกเข้าไปในท่อลมหรือเครื่องปรับอากาศขนาดใหญ่",
+        "feature1": "ความยาวที่ขยายออกสำหรับการวัดค่าลึก",
+        "feature2": "เทอร์มิสเตอร์ 10K ประเภท II",
+        "feature3": "โครงสร้างสแตนเลสสตีลที่ทนทาน"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "โพรบวัดอุณหภูมิ 6 นิ้ว",
+        "description": "โพรบความยาวมาตรฐานที่ใช้งานได้หลากหลาย เหมาะสำหรับการตรวจสอบอุณหภูมิ HVAC ทั่วไป",
+        "feature1": "การออกแบบที่กะทัดรัดสำหรับการใช้งานทั่วไป",
+        "feature2": "เวลาตอบสนองที่รวดเร็ว",
+        "feature3": "เทอร์มิสเตอร์ 10K ประเภท II"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "โพรบวัดอุณหภูมิแบบเจาะ 4 นิ้ว",
+        "description": "ปลายแบบเจาะที่ทนทานสำหรับการเจาะฉนวนหรือตรวจสอบอุณหภูมิผิว",
+        "feature1": "เจาะทะลุฉนวนและท่อลม",
+        "feature2": "ปลายแหลมคมสำหรับการใส่ที่ง่าย",
+        "feature3": "เหมาะสำหรับตำแหน่งที่เข้าถึงได้ยาก"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "โพรบวัดอุณหภูมิแบบรีโมท",
+        "description": "โพรบแบบมีสายที่ยืดหยุ่นสำหรับพื้นที่ที่เข้าถึงได้ยากหรือการตรวจสอบอย่างต่อเนื่องโดยไม่ต้องถือด้ามจับ",
+        "feature1": "โพรบที่แยกได้บนสายเคเบิล",
+        "feature2": "การวางตำแหน่งที่ยืดหยุ่น",
+        "feature3": "ความสามารถในการเข้าถึงที่ขยายออก"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "โพรบวัดอุณหภูมิและความชื้น 8 นิ้ว",
+        "description": "เซ็นเซอร์รวมสำหรับอุณหภูมิกระเปาะแห้งที่แม่นยำ %RH และการคำนวณจุดน้ำค้าง",
+        "feature1": "ความสามารถในการวัดค่าสองแบบ",
+        "feature2": "การตรวจจับ RH ที่แม่นยำ",
+        "feature3": "ค่าอ่านอุณหภูมิ/ความชื้นรวมกัน"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "โพรบวัดความดันช่วงมาตรฐาน",
+        "description": "การวัดความดันแตกต่างที่เชื่อถือได้ (-5 ถึง +5\" WC) สำหรับระบบ HVAC เชิงพาณิชย์มาตรฐาน",
+        "feature1": "วัดความดันท่อลมและห้อง",
+        "feature2": "ช่วง ±1\" WC ถึง ±10\" WC",
+        "feature3": "ความดันแตกต่างที่มีความแม่นยำสูง"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "โพรบวัดความดันช่วงต่ำ",
+        "description": "การวัดความดันแตกต่างที่มีความแม่นยำสูง (-1 ถึง +1\" WC) สำหรับห้องคลีนรูมที่ละเอียดอ่อนหรือสภาพแวดล้อมห้องปฏิบัติการ",
+        "feature1": "การวัดความดันที่ละเอียดอ่อนเป็นพิเศษ",
+        "feature2": "ช่วง ±0.1\" WC ถึง ±0.5\" WC",
+        "feature3": "เหมาะสำหรับห้องคลีนรูมและการใช้งานในห้องปฏิบัติการ"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "ข้อมูลจำเพาะทางเทคนิค",
+      "subtitle": "ออกแบบมาเพื่อความแม่นยำและสร้างขึ้นเพื่อทนทานต่อสภาพแวดล้อมเชิงพาณิชย์ที่เข้มงวด",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "ทั่วไป",
+        "measurement": "ช่วงการวัดค่า",
+        "accuracy": "ความแม่นยำ",
+        "environmental": "สภาพแวดล้อมและการรับรอง"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "พลังงาน",
+          "value": "แบตเตอรี่ชาร์จไฟได้ 3.7V, 2,600 mAh"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "การชาร์จ",
+          "value": "อุปกรณ์ชาร์จ USB มาตรฐาน 1.5A หรือมากกว่า รวมสาย Micro-USB"
         },
         "communication": {
-          "label": "Communication",
+          "label": "การสื่อสาร",
           "value": "Bluetooth LE, Class 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "การบันทึกข้อมูล",
+          "value": "ช่วงเวลา 10 วินาที"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "อุณหภูมิ",
+          "value": "-40 ถึง 185°F (-40 ถึง 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 ถึง 95% ไม่เกิดการควบแน่น @ -40 ถึง 158°F (-40 ถึง 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "ความดันแตกต่าง (ต่ำ)",
+          "value": "-1 ถึง +1\" WC (-250 ถึง +250 Pascal) @ -4 ถึง 158°F (-20 ถึง 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "ความดันแตกต่าง (มาตรฐาน)",
+          "value": "-5 ถึง +5\" WC (-1,250 ถึง +1,250 Pascal) @ -4 ถึง 158°F (-20 ถึง 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "โพรบวัดอุณหภูมิเท่านั้น",
+          "value": "±0.18°F จาก -13 ถึง 167°F (±0.1°C จาก -25 ถึง 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "โพรบวัดอุณหภูมิ/ความชื้น",
+          "value": "อุณหภูมิ: ±0.36°F @ 77°F (±0.2°C ที่ 25°C) | %RH: ±1%RH @ 77°F (25°C) จาก 10 ถึง 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "ความดันแตกต่าง (ต่ำ)",
+          "value": "±0.25% ของ FS Span, -1 ถึง +1\" WC (-250 ถึง +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "ความดันแตกต่าง (มาตรฐาน)",
+          "value": "±0.25% ของ FS Span, -5 ถึง +5\" WC (-1,250 ถึง +1,250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "ช่วงการทำงาน",
+          "value": "ตัวเครื่อง: -22 ถึง 158°F (-30 ถึง 70°C) | โพรบอุณหภูมิ: -40 ถึง 185°F (-40 ถึง 85°C) | โพรบ %RH: 5 ถึง 95% ไม่เกิดการควบแน่น @ -40 ถึง 158°F (-40 ถึง 70°C) | โพรบความดัน: -4 ถึง 158°F (-20 ถึง 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "ความดันแตก",
+          "value": "ช่วงต่ำ: 415\" WC (103 kPa) | ช่วงมาตรฐาน: 500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "การรับรองจากหน่วยงาน",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "พร้อมที่จะอัปเกรดการทดสอบ HVAC ของคุณหรือยัง?",
+      "subtitle": "ผู้เชี่ยวชาญด้านการทดสอบและวัดค่าของเราพร้อมที่จะช่วยคุณเลือกโพรบที่เหมาะสมสำหรับการใช้งานของคุณ รับคำแนะนำจากผู้เชี่ยวชาญและราคาที่แข่งขันได้",
+      "contactSales": "ติดต่อฝ่ายขาย",
+      "viewProducts": "ดูโพรบทั้งหมด"
     }
   }
 }

--- a/web/messages/vi.json
+++ b/web/messages/vi.json
@@ -4052,228 +4052,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ Thiết Bị Kiểm Tra & Đo Lường HVAC Chính Xác",
+      "description": "Đầu dò kiểm tra và đo lường cấp chuyên nghiệp cho kiểm tra HVAC. Đo lường chính xác với Ứng dụng Blu-View cho iOS và Android.",
+      "keywords": "đầu dò kiểm tra HVAC, đo nhiệt độ, ứng dụng Blu-View, đầu dò chính xác, thiết bị kiểm tra, kiểm tra HVAC, kiểm tra tự động hóa tòa nhà"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "Trang Chủ",
+      "products": "Sản Phẩm",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "Đầu Dò HVAC Chính Xác Đáng Tin Cậy.",
+      "description": "Bộ đầu dò kiểm tra cho các yêu cầu độ chính xác cao trên hệ thống HVAC và làm lạnh. Tích hợp liền mạch với Ứng dụng Blu-View để đo lường chính xác và ghi dữ liệu dễ dàng.",
+      "cta": "Khám Phá Đầu Dò",
+      "secondaryCta": "Tải Ứng Dụng Blu-View"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "Đo Lường Chính Xác",
+        "description": "Cảm biến có độ chính xác cao cho các phép đo nhiệt độ, độ ẩm, áp suất, điểm sương và cường độ ánh sáng. Lý tưởng cho nghiệm thu và xác minh HVAC."
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "Ghi Dữ Liệu Tích Hợp",
+        "description": "Lưu trữ dữ liệu đo lường trực tiếp trên đầu dò với bộ nhớ tích hợp. Tải xuống nhật ký bất kỳ lúc nào bằng ứng dụng Blü-Test để phân tích toàn diện."
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "Tích Hợp Thiết Bị Thông Minh",
+        "description": "Kết nối qua Bluetooth để xem dữ liệu trực tiếp trên điện thoại thông minh hoặc máy tính bảng. Ứng dụng Blü-Test cung cấp giám sát thời gian thực và quản lý thiết bị dễ dàng."
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "Tại Sao Thiết Bị Tham Chiếu Chính Xác Quan Trọng",
+      "subtitle": "Trong HVAC thương mại, độ chính xác không phải là tùy chọn—mà là điều thiết yếu. Đo lường không chính xác dẫn đến chẩn đoán sai vấn đề, lãng phí thời gian và tốn kém chi phí khắc phục. Đầu dò Blü-Test mang đến sự tự tin cho mọi số đo.",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "Độ Chính Xác Nhiệt Độ",
+        "description": "Độ chính xác ±0.18°F đảm bảo chẩn đoán hệ thống chính xác và hiệu suất thiết bị tối ưu. Phát hiện chênh lệch nhiệt độ cho thấy các thành phần bị lỗi trước khi chúng gây ra sự cố hệ thống."
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "Độ Ẩm & Điểm Sương",
+        "description": "Độ chính xác ±1% RH ngăn ngừa vấn đề ngưng tụ, nấm mốc và khiếu nại về sự thoải mái. Xác thực rằng hệ thống HVAC duy trì chất lượng không khí trong nhà phù hợp và đáp ứng các yêu cầu quy chuẩn xây dựng."
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "Chênh Áp",
+        "description": "Độ chính xác ±0.25% phát hiện rò rỉ ống dẫn, tải lọc và hạn chế luồng khí. Tối ưu hóa hiệu suất hệ thống và xác định vấn đề trước khi chúng ảnh hưởng đến chi phí năng lượng hoặc sự thoải mái của người sử dụng."
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "Lưu Lượng Khí K-Factor",
+        "description": "Đo lường K-Factor chính xác cho phép tính toán lưu lượng khí chính xác để cân bằng hệ thống, nghiệm thu và xác minh hiệu suất. Đảm bảo tốc độ thông gió phù hợp và vận hành tiết kiệm năng lượng."
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "Hiệu Chuẩn Truy Xuất NIST",
+        "description": "Mỗi đầu dò đi kèm Giấy Chứng Nhận Độ Chính Xác có thể truy xuất theo tiêu chuẩn NIST. Ghi chép tuân thủ cho các cơ sở quan trọng, bảo vệ công việc của bạn bằng dữ liệu được chứng nhận và duy trì uy tín chuyên nghiệp."
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Tích Hợp Ứng Dụng Blü-View",
+        "description": "Kiểm tra cường độ tín hiệu cho tất cả cảm biến của bạn để đảm bảo kết nối mạnh. Xem số đo trực tiếp, ghi dữ liệu, tạo báo cáo và so sánh số đo với cảm biến không dây ngay từ ứng dụng."
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "Chuẩn Mực Của Sự Thật",
+        "description": "Sử dụng thiết bị tham chiếu có độ chính xác cao cho phép bạn tự tin xác thực các cảm biến tòa nhà hiện có, chẩn đoán các vấn đề hệ thống phức tạp và đảm bảo tuân thủ quy định với mức độ đoán nhận tối thiểu."
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "Bluetooth Của Sự Thật",
+      "description": "Kết nối không dây có nghĩa là không cần ghi chép số đo nữa. Ứng dụng Blu-View tự động ghi các phép đo với dấu thời gian, loại bỏ lỗi phiên âm và tạo báo cáo chuyên nghiệp.",
+      "feature1": "Truyền dữ liệu không dây thời gian thực đến điện thoại thông minh hoặc máy tính bảng của bạn",
+      "feature2": "Tự động ghi dấu thời gian và vị trí để tài liệu hóa hoàn chỉnh",
+      "feature3": "Xuất sang PDF, Excel hoặc lưu trữ đám mây để dễ dàng chia sẻ và lưu trữ"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Ứng Dụng Blü-View",
+      "subtitle": "Ứng dụng Blü-View đặt toàn bộ quyền kiểm soát trong tầm tay bạn. Xem dữ liệu trực tiếp, tải xuống nhật ký, cập nhật firmware và quản lý nhiều thiết bị từ một giao diện.",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "Giám Sát Thời Gian Thực",
+        "description": "Xem dữ liệu cảm biến trực tiếp từ tất cả các đầu dò được kết nối. Giám sát nhiệt độ, độ ẩm, áp suất và nhiều hơn nữa trong thời gian thực với màn hình trực quan."
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "Tải Xuống Nhật Ký",
+        "description": "Truy cập nhật ký đo lường được lưu trữ từ bộ nhớ thiết bị tích hợp. Xuất dữ liệu để phân tích, báo cáo và tài liệu tuân thủ."
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "Quản Lý Thiết Bị",
+        "description": "Quản lý nhiều đầu dò, kiểm tra mức pin, cập nhật firmware và nhận nhắc nhở hiệu chuẩn tất cả từ một bảng điều khiển trung tâm."
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "Tải Ứng Dụng",
+      "learnMore": "Tìm Hiểu Thêm"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "Bộ Sản Phẩm Blü-Test",
+      "subtitle": "Dòng sản phẩm toàn diện các đầu dò thông minh, được chứng nhận NIST. Tất cả đều có bộ ghi dữ liệu tích hợp, màn hình LCD tích hợp trên tay cầm và kết nối Bluetooth liền mạch.",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "Đầu Dò Nhiệt Độ 9.5\"",
+        "description": "Tầm với mở rộng để đo nhiệt độ sâu bên trong ống dẫn hoặc hộp xử lý không khí lớn.",
+        "feature1": "Chiều dài mở rộng cho các phép đo sâu",
+        "feature2": "Nhiệt trở 10K Type II",
+        "feature3": "Kết cấu thép không gỉ chắc chắn"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "Đầu Dò Nhiệt Độ 6\"",
+        "description": "Đầu dò chiều dài tiêu chuẩn linh hoạt, lý tưởng cho xác thực nhiệt độ HVAC mục đích chung.",
+        "feature1": "Thiết kế nhỏ gọn cho sử dụng chung",
+        "feature2": "Thời gian phản hồi nhanh",
+        "feature3": "Nhiệt trở 10K Type II"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "Đầu Dò Nhiệt Độ Xuyên 4\"",
+        "description": "Đầu xuyên chắc chắn để xuyên qua cách nhiệt hoặc kiểm tra nhiệt độ bề mặt.",
+        "feature1": "Xuyên qua cách nhiệt và ống gió",
+        "feature2": "Đầu nhọn để dễ dàng chèn vào",
+        "feature3": "Lý tưởng cho các vị trí khó tiếp cận"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "Đầu Dò Nhiệt Độ Từ Xa",
+        "description": "Đầu dò có dây linh hoạt cho các khu vực khó tiếp cận hoặc giám sát liên tục mà không cần cầm tay cầm.",
+        "feature1": "Đầu dò có thể tách rời trên dây cáp",
+        "feature2": "Định vị linh hoạt",
+        "feature3": "Khả năng tầm với mở rộng"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "Đầu Dò Nhiệt Độ & Độ Ẩm 8\"",
+        "description": "Cảm biến kết hợp cho nhiệt độ nhiệt kế khô chính xác, %RH và tính toán điểm sương.",
+        "feature1": "Khả năng đo kép",
+        "feature2": "Cảm biến RH chính xác",
+        "feature3": "Số đo nhiệt độ/độ ẩm kết hợp"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "Đầu Dò Áp Suất Dải Tiêu Chuẩn",
+        "description": "Đo chênh áp đáng tin cậy (-5 đến +5\" WC) cho các hệ thống HVAC thương mại tiêu chuẩn.",
+        "feature1": "Đo áp suất ống dẫn và phòng",
+        "feature2": "Dải từ ±1\" WC đến ±10\" WC",
+        "feature3": "Chênh áp độ chính xác cao"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "Đầu Dò Áp Suất Dải Thấp",
+        "description": "Đo chênh áp độ chính xác cao (-1 đến +1\" WC) cho phòng sạch nhạy cảm hoặc môi trường phòng thí nghiệm.",
+        "feature1": "Đo áp suất cực nhạy",
+        "feature2": "Dải từ ±0.1\" WC đến ±0.5\" WC",
+        "feature3": "Hoàn hảo cho ứng dụng phòng sạch và phòng thí nghiệm"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "Thông Số Kỹ Thuật",
+      "subtitle": "Được thiết kế cho độ chính xác và được chế tạo để chịu đựng môi trường thương mại khắc nghiệt.",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "Chung",
+        "measurement": "Phạm Vi Đo",
+        "accuracy": "Độ Chính Xác",
+        "environmental": "Môi Trường & Chứng Nhận"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "Nguồn Điện",
+          "value": "Pin Sạc 3.7V, 2,600 mAh"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "Sạc",
+          "value": "Bộ Sạc USB Tiêu Chuẩn, 1.5A hoặc lớn hơn, Cáp Micro-USB đi kèm"
         },
         "communication": {
-          "label": "Communication",
+          "label": "Truyền Thông",
           "value": "Bluetooth LE, Class 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "Ghi Dữ Liệu",
+          "value": "Khoảng thời gian 10 giây"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "Nhiệt Độ",
+          "value": "-40 đến 185°F (-40 đến 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 đến 95% Không ngưng tụ @ -40 đến 158°F (-40 đến 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Chênh Áp (Thấp)",
+          "value": "-1 đến +1\" WC (-250 đến +250 Pascal) @ -4 đến 158°F (-20 đến 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "Chênh Áp (Tiêu Chuẩn)",
+          "value": "-5 đến +5\" WC (-1,250 đến +1,250 Pascal) @ -4 đến 158°F (-20 đến 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "Đầu Dò Chỉ Nhiệt Độ",
+          "value": "±0.18°F từ -13 đến 167°F (±0.1°C từ -25 đến 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "Đầu Dò Nhiệt Độ/Độ Ẩm",
+          "value": "Nhiệt Độ: ±0.36°F @ 77°F (±0.2°C tại 25°C) | %RH: ±1%RH @ 77°F (25°C) từ 10 đến 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "Chênh Áp (Thấp)",
+          "value": "±0.25% của Khoảng FS, -1 đến +1\" WC (-250 đến +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "Chênh Áp (Tiêu Chuẩn)",
+          "value": "±0.25% của Khoảng FS, -5 đến +5\" WC (-1,250 đến +1,250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "Phạm Vi Hoạt Động",
+          "value": "Thân: -22 đến 158°F (-30 đến 70°C) | Đầu Dò Nhiệt Độ: -40 đến 185°F (-40 đến 85°C) | Đầu Dò %RH: 5 đến 95% Không ngưng tụ @ -40 đến 158°F (-40 đến 70°C) | Đầu Dò Áp Suất: -4 đến 158°F (-20 đến 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "Áp Suất Vỡ",
+          "value": "Dải Thấp: 415\" WC (103 kPa) | Dải Tiêu Chuẩn: 500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "Phê Duyệt Cơ Quan",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "Sẵn Sàng Nâng Cấp Kiểm Tra HVAC Của Bạn?",
+      "subtitle": "Các chuyên gia kiểm tra và đo lường của chúng tôi sẵn sàng giúp bạn chọn đầu dò phù hợp cho ứng dụng của bạn. Nhận tư vấn chuyên gia và giá cạnh tranh.",
+      "contactSales": "Liên Hệ Bộ Phận Bán Hàng",
+      "viewProducts": "Xem Tất Cả Đầu Dò"
     }
   }
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -4051,228 +4051,228 @@
   },
   "bluTestLandingPage": {
     "metadata": {
-      "title": "Blu-Test™ Precision HVAC Test & Measurement",
-      "description": "Professional-grade test and measurement probes for HVAC testing. Precision measurement with the Blu-View App for iOS and Android.",
-      "keywords": "HVAC test probes, temperature measurement, Blu-View app, precision probes, test equipment, HVAC testing, building automation testing"
+      "title": "Blu-Test™ 精密暖通空调测试与测量",
+      "description": "专业级暖通空调测试探头。通过 Blu-View 应用程序（支持 iOS 和 Android）实现精密测量。",
+      "keywords": "暖通空调测试探头, 温度测量, Blu-View 应用, 精密探头, 测试设备, 暖通空调测试, 楼宇自动化测试"
     },
     "breadcrumb": {
-      "home": "Home",
-      "products": "Products",
+      "home": "首页",
+      "products": "产品",
       "bluTest": "Blu-Test™"
     },
     "hero": {
-      "title": "Precision HVAC Probes You Can Trust.",
-      "description": "A suite of test probes for demanding accuracy requirements across HVAC and refrigeration systems. Seamlessly integrate with the Blu-View App for precise measurement and easy data logging.",
-      "cta": "Explore Probes",
-      "secondaryCta": "Download Blu-View App"
+      "title": "值得信赖的精密暖通空调探头。",
+      "description": "一套满足暖通空调和制冷系统严苛精度要求的测试探头。与 Blu-View 应用程序无缝集成，实现精确测量和便捷数据记录。",
+      "cta": "探索探头",
+      "secondaryCta": "下载 Blu-View 应用"
     },
     "keyFeatures": {
       "precision": {
-        "title": "Precision Measurement",
-        "description": "Highly accurate sensors for temperature, humidity, pressure, dew point, and light level measurements. Ideal for HVAC commissioning and verification."
+        "title": "精密测量",
+        "description": "高精度传感器可测量温度、湿度、压力、露点和光照水平。非常适合暖通空调调试和验证。"
       },
       "dataLogging": {
-        "title": "Onboard Data Logging",
-        "description": "Store measurement data directly on the probes with built-in storage. Download logs anytime using the Blü-Test app for comprehensive analysis."
+        "title": "板载数据记录",
+        "description": "通过内置存储直接将测量数据存储在探头上。随时使用 Blü-Test 应用程序下载日志进行全面分析。"
       },
       "integration": {
-        "title": "Smart Device Integration",
-        "description": "Connect via Bluetooth to view live data on your smartphone or tablet. The Blü-Test app provides real-time monitoring and easy device management."
+        "title": "智能设备集成",
+        "description": "通过蓝牙连接在智能手机或平板电脑上查看实时数据。Blü-Test 应用程序提供实时监控和便捷的设备管理。"
       }
     },
     "accuracy": {
-      "title": "Why Accurate Reference Devices Matter",
-      "subtitle": "In commercial HVAC, precision isn't optional—it's essential. Inaccurate measurements lead to misdiagnosed problems, wasted time, and costly callbacks. Blü-Test probes give you confidence in every reading.",
+      "title": "为什么精确的参考设备至关重要",
+      "subtitle": "在商业暖通空调领域，精确度不是可选项——而是必需品。不准确的测量会导致误诊问题、浪费时间和昂贵的返工。Blü-Test 探头让您对每次读数都充满信心。",
       "temperature": {
-        "title": "Temperature Accuracy",
-        "description": "±0.18°F accuracy ensures precise system diagnostics and optimal equipment performance. Detect temperature differentials that indicate failing components before they cause system failure."
+        "title": "温度精度",
+        "description": "±0.18°F 的精度确保精确的系统诊断和最佳设备性能。在故障组件导致系统故障之前检测到表明组件故障的温差。"
       },
       "humidity": {
-        "title": "Humidity & Dew Point",
-        "description": "±1% RH accuracy prevents condensation issues, mold growth, and comfort complaints. Validate that HVAC systems maintain proper indoor air quality and meet building code requirements."
+        "title": "湿度和露点",
+        "description": "±1% RH 的精度可防止冷凝问题、霉菌生长和舒适度投诉。验证暖通空调系统是否保持适当的室内空气质量并符合建筑规范要求。"
       },
       "pressure": {
-        "title": "Differential Pressure",
-        "description": "±0.25% accuracy reveals duct leakage, filter loading, and airflow restrictions. Optimize system efficiency and identify problems before they impact energy costs or occupant comfort."
+        "title": "差压",
+        "description": "±0.25% 的精度可揭示管道泄漏、过滤器负载和气流限制。优化系统效率并在问题影响能源成本或居住者舒适度之前识别问题。"
       },
       "airflow": {
-        "title": "K-Factor Airflow",
-        "description": "Accurate K-Factor measurements enable precise airflow calculations for system balancing, commissioning, and performance verification. Ensure proper ventilation rates and energy efficient operation."
+        "title": "K 系数气流",
+        "description": "准确的 K 系数测量可实现精确的气流计算，用于系统平衡、调试和性能验证。确保适当的通风率和节能运行。"
       },
       "calibration": {
-        "title": "NIST-Traceable Calibration",
-        "description": "Every probe includes a Certificate of Accuracy traceable to NIST standards. Document compliance for critical facilities, defend your work with certified data, and maintain professional credibility."
+        "title": "NIST 可追溯校准",
+        "description": "每个探头都包含可追溯到 NIST 标准的精度证书。为关键设施记录合规性，用经认证的数据捍卫您的工作，并保持专业信誉。"
       },
       "appIntegration": {
-        "title": "Blü-View App Integration",
-        "description": "Check signal strength for all of your sensors to ensure a strong connection. View live readings, log data, generate reports, and compare readings against wireless sensors right from the app."
+        "title": "Blü-View 应用集成",
+        "description": "检查所有传感器的信号强度以确保稳定连接。直接从应用程序查看实时读数、记录数据、生成报告并将读数与无线传感器进行比较。"
       },
       "baseline": {
-        "title": "The Baseline of Truth",
-        "description": "Using a highly accurate reference device allows you to confidently validate existing building sensors, diagnose complex systemic issues, and ensure regulatory compliance with minimal guesswork."
+        "title": "真值基准",
+        "description": "使用高精度参考设备可让您自信地验证现有楼宇传感器、诊断复杂的系统问题，并以最少的猜测确保符合法规要求。"
       }
     },
     "bluetooth": {
-      "title": "The Bluetooth of Truth",
-      "description": "Wireless connectivity means no more writing down readings. The Blu-View app automatically logs measurements with timestamps, eliminates transcription errors, and generates professional reports.",
-      "feature1": "Real-time wireless data transmission to your smartphone or tablet",
-      "feature2": "Automatic timestamp and location logging for complete documentation",
-      "feature3": "Export to PDF, Excel, or cloud storage for easy sharing and archiving"
+      "title": "真值蓝牙",
+      "description": "无线连接意味着不再需要手写读数。Blu-View 应用程序自动记录带有时间戳的测量值，消除转录错误，并生成专业报告。",
+      "feature1": "实时无线数据传输到您的智能手机或平板电脑",
+      "feature2": "自动时间戳和位置记录，实现完整文档记录",
+      "feature3": "导出为 PDF、Excel 或云存储，便于共享和归档"
     },
     "bluView": {
-      "title": "Blü-View App",
-      "subtitle": "The Blü-View app puts complete control at your fingertips. View live data, download logs, update firmware, and manage multiple devices from one interface.",
+      "title": "Blü-View 应用",
+      "subtitle": "Blü-View 应用程序将完全控制权掌握在您的指尖。查看实时数据、下载日志、更新固件，并从一个界面管理多个设备。",
       "feature1": {
-        "title": "Real-Time Monitoring",
-        "description": "View live sensor data from all connected probes. Monitor temperature, humidity, pressure, and more in real-time with intuitive displays."
+        "title": "实时监控",
+        "description": "查看所有已连接探头的实时传感器数据。通过直观的显示实时监控温度、湿度、压力等。"
       },
       "feature2": {
-        "title": "Download Logs",
-        "description": "Access stored measurement logs from onboard device memory. Export data for analysis, reporting, and compliance documentation."
+        "title": "下载日志",
+        "description": "从板载设备内存访问存储的测量日志。导出数据用于分析、报告和合规性文档。"
       },
       "feature3": {
-        "title": "Device Management",
-        "description": "Manage multiple probes, check battery levels, update firmware, and receive calibration reminders all from one central dashboard."
+        "title": "设备管理",
+        "description": "管理多个探头、检查电池电量、更新固件，并从一个中央仪表板接收校准提醒。"
       },
-      "downloadApp": "Download the App",
-      "learnMore": "Learn More"
+      "downloadApp": "下载应用",
+      "learnMore": "了解更多"
     },
     "testProbes": {
-      "title": "The Blü-Test Suite",
-      "subtitle": "A comprehensive family of intelligent, NIST-certified probes. All feature an onboard data logger, a built-in LCD display on the handle, and seamless Bluetooth connectivity.",
+      "title": "Blü-Test 系列",
+      "subtitle": "一个全面的智能、NIST 认证探头系列。所有探头均配备板载数据记录器、手柄上的内置 LCD 显示屏和无缝蓝牙连接。",
       "tempProbe95": {
-        "name": "9.5\" Temperature Probe",
-        "description": "Extended reach for measuring temperature deep within ducts or large air handlers.",
-        "feature1": "Extended length for deep measurements",
-        "feature2": "10K Type II thermistor",
-        "feature3": "Rugged stainless steel construction"
+        "name": "9.5\" 温度探头",
+        "description": "延长范围，用于测量管道或大型空气处理机组深处的温度。",
+        "feature1": "加长长度，用于深度测量",
+        "feature2": "10K Type II 热敏电阻",
+        "feature3": "坚固的不锈钢结构"
       },
       "tempProbe6": {
-        "name": "6\" Temperature Probe",
-        "description": "Versatile, standard length probe ideal for general purpose HVAC temperature validation.",
-        "feature1": "Compact design for general use",
-        "feature2": "Fast response time",
-        "feature3": "10K Type II thermistor"
+        "name": "6\" 温度探头",
+        "description": "多功能标准长度探头，非常适合通用暖通空调温度验证。",
+        "feature1": "紧凑设计，适用于一般用途",
+        "feature2": "快速响应时间",
+        "feature3": "10K Type II 热敏电阻"
       },
       "piercingProbe": {
-        "name": "4\" Piercing Temperature Probe",
-        "description": "Rugged piercing tip for penetrating insulation or checking surface temperatures.",
-        "feature1": "Penetrates insulation and ductwork",
-        "feature2": "Sharp tip for easy insertion",
-        "feature3": "Ideal for hard-to-reach locations"
+        "name": "4\" 穿刺温度探头",
+        "description": "坚固的穿刺尖端，用于穿透保温材料或检查表面温度。",
+        "feature1": "穿透保温材料和管道",
+        "feature2": "尖锐的尖端便于插入",
+        "feature3": "非常适合难以触及的位置"
       },
       "remoteTemp": {
-        "name": "Remote Temperature Probe",
-        "description": "Flexible wired probe for hard-to-reach areas or continuous monitoring without holding the handle.",
-        "feature1": "Separable probe on cable",
-        "feature2": "Flexible positioning",
-        "feature3": "Extended reach capability"
+        "name": "远程温度探头",
+        "description": "柔性有线探头，用于难以触及的区域或无需手持手柄的连续监控。",
+        "feature1": "电缆上的可分离探头",
+        "feature2": "灵活定位",
+        "feature3": "延长触及能力"
       },
       "tempHumid": {
-        "name": "8\" Temperature & Humidity Probe",
-        "description": "Combined sensor for accurate dry bulb temperature, %RH, and dew point calculations.",
-        "feature1": "Dual measurement capability",
-        "feature2": "Accurate RH sensing",
-        "feature3": "Combined temp/humidity readings"
+        "name": "8\" 温湿度探头",
+        "description": "组合传感器，用于准确的干球温度、%RH 和露点计算。",
+        "feature1": "双重测量能力",
+        "feature2": "准确的 RH 感应",
+        "feature3": "组合温度/湿度读数"
       },
       "standardPress": {
-        "name": "Standard Range Pressure Probe",
-        "description": "Reliable differential pressure measurement (-5 to +5\" WC) for standard commercial HVAC systems.",
-        "feature1": "Measures duct and room pressure",
-        "feature2": "±1\" WC to ±10\" WC ranges",
-        "feature3": "High accuracy differential pressure"
+        "name": "标准范围压力探头",
+        "description": "可靠的差压测量（-5 至 +5\" WC），适用于标准商业暖通空调系统。",
+        "feature1": "测量管道和房间压力",
+        "feature2": "±1\" WC 至 ±10\" WC 范围",
+        "feature3": "高精度差压"
       },
       "lowPress": {
-        "name": "Low Range Pressure Probe",
-        "description": "High-precision differential pressure measurement (-1 to +1\" WC) for sensitive cleanrooms or lab environments.",
-        "feature1": "Ultra-sensitive pressure measurement",
-        "feature2": "±0.1\" WC to ±0.5\" WC ranges",
-        "feature3": "Perfect for clean room and lab applications"
+        "name": "低范围压力探头",
+        "description": "高精度差压测量（-1 至 +1\" WC），适用于敏感的洁净室或实验室环境。",
+        "feature1": "超灵敏压力测量",
+        "feature2": "±0.1\" WC 至 ±0.5\" WC 范围",
+        "feature3": "完美适用于洁净室和实验室应用"
       }
     },
     "specifications": {
-      "title": "Technical Specifications",
-      "subtitle": "Engineered for precision and built to withstand rigorous commercial environments.",
+      "title": "技术规格",
+      "subtitle": "专为精度设计，能够承受严苛的商业环境。",
       "table": {
-        "general": "General",
-        "measurement": "Measurement Range",
-        "accuracy": "Accuracy",
-        "environmental": "Environmental & Certifications"
+        "general": "常规",
+        "measurement": "测量范围",
+        "accuracy": "精度",
+        "environmental": "环境与认证"
       },
       "general": {
         "power": {
-          "label": "Power",
-          "value": "3.7V, 2,600 mAh Rechargeable Battery"
+          "label": "电源",
+          "value": "3.7V, 2,600 mAh 可充电电池"
         },
         "charging": {
-          "label": "Charging",
-          "value": "Standard USB Charger, 1.5A or greater, Micro-USB cable included"
+          "label": "充电",
+          "value": "标准 USB 充电器，1.5A 或更大，包含 Micro-USB 电缆"
         },
         "communication": {
-          "label": "Communication",
+          "label": "通信",
           "value": "Bluetooth LE, Class 2 v4.2"
         },
         "dataLogging": {
-          "label": "Data Logging",
-          "value": "10 second intervals"
+          "label": "数据记录",
+          "value": "10 秒间隔"
         }
       },
       "measurement": {
         "temperature": {
-          "label": "Temperature",
-          "value": "-40 to 185°F (-40 to 85°C)"
+          "label": "温度",
+          "value": "-40 至 185°F (-40 至 85°C)"
         },
         "rh": {
           "label": "%RH",
-          "value": "5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C)"
+          "value": "5 至 95% 非冷凝 @ -40 至 158°F (-40 至 70°C)"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "-1 to +1\" WC (-250 to +250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "差压（低）",
+          "value": "-1 至 +1\" WC (-250 至 +250 Pascal) @ -4 至 158°F (-20 至 70°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "-5 to +5\" WC (-1,250 to +1,250 Pascal) @ -4 to 158°F (-20 to 70°C)"
+          "label": "差压（标准）",
+          "value": "-5 至 +5\" WC (-1,250 至 +1,250 Pascal) @ -4 至 158°F (-20 至 70°C)"
         }
       },
       "accuracy": {
         "tempOnly": {
-          "label": "Temperature Only Probes",
-          "value": "±0.18°F from -13 to 167°F (±0.1°C from -25 to 75°C)"
+          "label": "纯温度探头",
+          "value": "±0.18°F 从 -13 至 167°F (±0.1°C 从 -25 至 75°C)"
         },
         "tempHumid": {
-          "label": "Temp/Humidity Probes",
-          "value": "Temp: ±0.36°F @ 77°F (±0.2°C at 25°C) | %RH: ±1%RH @ 77°F (25°C) from 10 to 85%RH"
+          "label": "温湿度探头",
+          "value": "温度：±0.36°F @ 77°F (±0.2°C at 25°C) | %RH：±1%RH @ 77°F (25°C) 从 10 至 85%RH"
         },
         "diffLow": {
-          "label": "Diff. Pressure (Low)",
-          "value": "±0.25% of FS Span, -1 to +1\" WC (-250 to +250 Pa) @ 77°F (25°C)"
+          "label": "差压（低）",
+          "value": "±0.25% FS 量程，-1 至 +1\" WC (-250 至 +250 Pa) @ 77°F (25°C)"
         },
         "diffStd": {
-          "label": "Diff. Pressure (Std)",
-          "value": "±0.25% of FS Span, -5 to +5\" WC (-1,250 to +1,250 Pa) @ 77°F (25°C)"
+          "label": "差压（标准）",
+          "value": "±0.25% FS 量程，-5 至 +5\" WC (-1,250 至 +1,250 Pa) @ 77°F (25°C)"
         }
       },
       "environmental": {
         "operatingRange": {
-          "label": "Operating Range",
-          "value": "Body: -22 to 158°F (-30 to 70°C) | Temp Probes: -40 to 185°F (-40 to 85°C) | %RH Probe: 5 to 95% Non-condensing @ -40 to 158°F (-40 to 70°C) | Pressure Probe: -4 to 158°F (-20 to 70°C)"
+          "label": "工作范围",
+          "value": "主体：-22 至 158°F (-30 至 70°C) | 温度探头：-40 至 185°F (-40 至 85°C) | %RH 探头：5 至 95% 非冷凝 @ -40 至 158°F (-40 至 70°C) | 压力探头：-4 至 158°F (-20 至 70°C)"
         },
         "burstPressure": {
-          "label": "Burst Pressure",
-          "value": "Low Range: 415\" WC (103 kPa) | Standard Range: 500\" WC (124 kPa)"
+          "label": "爆破压力",
+          "value": "低范围：415\" WC (103 kPa) | 标准范围：500\" WC (124 kPa)"
         },
         "agencyApprovals": {
-          "label": "Agency Approvals",
+          "label": "机构认证",
           "value": "CE EN 61326-1:2013 EMC, RoHS, NSF, FCC ID: 2AA9B04"
         }
       }
     },
     "cta": {
-      "title": "Ready to Upgrade Your HVAC Testing?",
-      "subtitle": "Our test and measurement specialists are ready to help you choose the right probes for your applications. Get expert advice and competitive pricing.",
-      "contactSales": "Contact Sales",
-      "viewProducts": "View All Probes"
+      "title": "准备升级您的暖通空调测试？",
+      "subtitle": "我们的测试与测量专家随时准备帮助您为应用选择合适的探头。获取专家建议和有竞争力的价格。",
+      "contactSales": "联系销售",
+      "viewProducts": "查看所有探头"
     }
   }
 }

--- a/web/scripts/translate-section.js
+++ b/web/scripts/translate-section.js
@@ -33,7 +33,7 @@ config({ path: path.join(__dirname, '..', '.env') });
 // Configuration
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 const MESSAGES_DIR = path.join(__dirname, '..', 'messages');
-const MODEL = 'claude-sonnet-4-20250514'; // Current model (April 2026)
+const MODEL = 'claude-sonnet-4-5'; // Updated June 2026 (claude-sonnet-4 deprecated June 15)
 
 // Target languages (excluding English source)
 const LANGUAGES = [
@@ -123,7 +123,7 @@ Translate to ${targetLanguage.name}:`;
 
   const message = await client.messages.create({
     model: MODEL,
-    max_tokens: 4096,
+    max_tokens: 16000,
     messages: [
       {
         role: 'user',

--- a/web/scripts/translate-section.js
+++ b/web/scripts/translate-section.js
@@ -33,7 +33,7 @@ config({ path: path.join(__dirname, '..', '.env') });
 // Configuration
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
 const MESSAGES_DIR = path.join(__dirname, '..', 'messages');
-const MODEL = 'claude-sonnet-4-5'; // Updated June 2026 (claude-sonnet-4 deprecated June 15)
+const MODEL = process.env.ANTHROPIC_MODEL ?? 'claude-sonnet-4-5'; // Override with ANTHROPIC_MODEL env var
 
 // Target languages (excluding English source)
 const LANGUAGES = [
@@ -123,7 +123,7 @@ Translate to ${targetLanguage.name}:`;
 
   const message = await client.messages.create({
     model: MODEL,
-    max_tokens: 16000,
+    max_tokens: Number(process.env.ANTHROPIC_MAX_TOKENS ?? 16000),
     messages: [
       {
         role: 'user',


### PR DESCRIPTION
- Used Claude Sonnet 4.5 API (upgraded from deprecated claude-sonnet-4)
- Translated: de, fr, es, ja, zh, vi, ar, th, pl, hi
- Updated translate-section.js model to claude-sonnet-4-5
- Increased max_tokens to 16000 to handle large sections without truncation
- Cost: ~$0.084 total for all 10 languages

