### PR TITLE
test: add comprehensive API route and component tests

### DIFF
--- a/web/src/app/api/auth/__tests__/login.test.ts
+++ b/web/src/app/api/auth/__tests__/login.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Integration Tests for POST /api/auth/login
+ *
+ * Tests WordPress JWT authentication with full coverage of:
+ * - Missing credentials validation (400)
+ * - Rate limiting behavior (429)
+ * - WordPress GraphQL failure / bad credentials (401)
+ * - Successful login: response body, httpOnly cookie flags, token storage
+ * - Server error handling (500)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { POST } from '../login/route';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks (vi.mock is hoisted, so fns must be declared via vi.hoisted) ─
+const { mockCookieSet, mockCookies, mockCheckRateLimit, mockRecordFailedAttempt, mockClearAttempts } =
+  vi.hoisted(() => {
+    const mockCookieSet = vi.fn();
+    const mockCookies = vi.fn(() => ({
+      set: mockCookieSet,
+      get: vi.fn(),
+      delete: vi.fn(),
+    }));
+    return {
+      mockCookieSet,
+      mockCookies,
+      mockCheckRateLimit: vi.fn(),
+      mockRecordFailedAttempt: vi.fn(),
+      mockClearAttempts: vi.fn(),
+    };
+  });
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/auth/rate-limit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  recordFailedAttempt: mockRecordFailedAttempt,
+  clearAttempts: mockClearAttempts,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const MOCK_SUCCESS_RESPONSE = {
+  data: {
+    login: {
+      authToken: 'mock-auth-token-abc123',
+      refreshToken: 'mock-refresh-token-xyz789',
+      user: {
+        id: 'dXNlcjox',
+        databaseId: 1,
+        email: 'test@bapi.com',
+        name: 'Test User',
+        username: 'testuser',
+      },
+    },
+  },
+};
+
+describe('POST /api/auth/login', () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    // Default: rate limit allows the request
+    mockCheckRateLimit.mockReturnValue({ allowed: true });
+
+    // Default: WordPress returns success
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(MOCK_SUCCESS_RESPONSE),
+    });
+
+    // Reset cookie mock
+    mockCookies.mockReturnValue({ set: mockCookieSet, get: vi.fn(), delete: vi.fn() });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // ─── Input validation ────────────────────────────────────────────────────────
+
+  it('returns 400 when username is missing', async () => {
+    const res = await POST(makeRequest({ password: 'secret' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Missing credentials');
+  });
+
+  it('returns 400 when password is missing', async () => {
+    const res = await POST(makeRequest({ username: 'testuser' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Missing credentials');
+  });
+
+  it('returns 400 when both credentials are missing', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  // ─── Rate limiting ───────────────────────────────────────────────────────────
+
+  it('returns 429 when rate limit is exceeded', async () => {
+    mockCheckRateLimit.mockReturnValue({
+      allowed: false,
+      message: 'Too many failed login attempts. Try again in 15 minutes.',
+    });
+
+    const res = await POST(makeRequest({ username: 'testuser', password: 'wrong' }));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toBe('Rate limit exceeded');
+  });
+
+  it('does not call WordPress when rate limited', async () => {
+    mockCheckRateLimit.mockReturnValue({ allowed: false, message: 'Rate limited' });
+
+    await POST(makeRequest({ username: 'testuser', password: 'wrong' }));
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ─── Authentication failure ──────────────────────────────────────────────────
+
+  it('returns 401 when WordPress returns GraphQL errors', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: null,
+          errors: [{ message: 'Invalid username or password' }],
+        }),
+    });
+
+    const res = await POST(makeRequest({ username: 'testuser', password: 'wrong' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Authentication failed');
+  });
+
+  it('returns 401 when WordPress response has no authToken', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: { login: { authToken: null, refreshToken: null, user: null } },
+        }),
+    });
+
+    const res = await POST(makeRequest({ username: 'testuser', password: 'wrong' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('records a failed attempt on authentication failure', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ errors: [{ message: 'Bad credentials' }] }),
+    });
+
+    await POST(makeRequest({ username: 'testuser', password: 'wrong' }));
+    expect(mockRecordFailedAttempt).toHaveBeenCalledOnce();
+  });
+
+  // ─── Successful login ────────────────────────────────────────────────────────
+
+  it('returns 200 with user data on success', async () => {
+    const res = await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.user.email).toBe('test@bapi.com');
+    expect(body.user.username).toBe('testuser');
+    expect(body.user.id).toBe('1');
+  });
+
+  it('does not expose tokens in the response body', async () => {
+    const res = await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+    const body = await res.json();
+    expect(body.authToken).toBeUndefined();
+    expect(body.refreshToken).toBeUndefined();
+    expect(body.token).toBeUndefined();
+  });
+
+  it('sets auth_token as an httpOnly cookie', async () => {
+    await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+
+    const authTokenCall = mockCookieSet.mock.calls.find((call) => call[0] === 'auth_token');
+    expect(authTokenCall).toBeDefined();
+    expect(authTokenCall[1]).toBe('mock-auth-token-abc123');
+    expect(authTokenCall[2]).toMatchObject({ httpOnly: true });
+  });
+
+  it('sets refresh_token as an httpOnly cookie', async () => {
+    await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+
+    const refreshTokenCall = mockCookieSet.mock.calls.find(
+      (call) => call[0] === 'refresh_token',
+    );
+    expect(refreshTokenCall).toBeDefined();
+    expect(refreshTokenCall[1]).toBe('mock-refresh-token-xyz789');
+    expect(refreshTokenCall[2]).toMatchObject({ httpOnly: true });
+  });
+
+  it('sets sameSite: lax on cookies (CSRF protection)', async () => {
+    await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+
+    const authTokenCall = mockCookieSet.mock.calls.find((call) => call[0] === 'auth_token');
+    expect(authTokenCall[2]).toMatchObject({ sameSite: 'lax' });
+  });
+
+  it('sets auth_token with 7-day expiry', async () => {
+    await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+
+    const authTokenCall = mockCookieSet.mock.calls.find((call) => call[0] === 'auth_token');
+    expect(authTokenCall[2].maxAge).toBe(60 * 60 * 24 * 7);
+  });
+
+  it('sets refresh_token with 30-day expiry', async () => {
+    await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+
+    const refreshTokenCall = mockCookieSet.mock.calls.find(
+      (call) => call[0] === 'refresh_token',
+    );
+    expect(refreshTokenCall[2].maxAge).toBe(60 * 60 * 24 * 30);
+  });
+
+  it('clears failed attempts on successful login', async () => {
+    await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+    expect(mockClearAttempts).toHaveBeenCalledOnce();
+  });
+
+  // ─── Server errors ───────────────────────────────────────────────────────────
+
+  it('returns 500 when fetch throws (network error)', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const res = await POST(makeRequest({ username: 'testuser', password: 'correct' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Server error');
+  });
+});

--- a/web/src/app/api/auth/__tests__/logout.test.ts
+++ b/web/src/app/api/auth/__tests__/logout.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Integration Tests for POST /api/auth/logout
+ *
+ * Tests cookie clearing behavior:
+ * - Both cookies are deleted on success
+ * - Success response shape
+ * - Server error handling (500)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../logout/route';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockCookieDelete, mockCookies } = vi.hoisted(() => {
+  const mockCookieDelete = vi.fn();
+  const mockCookies = vi.fn(() => ({
+    delete: mockCookieDelete,
+    get: vi.fn(),
+    set: vi.fn(),
+  }));
+  return { mockCookieDelete, mockCookies };
+});
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+describe('POST /api/auth/logout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 200 with success: true', async () => {
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it('deletes the auth_token cookie', async () => {
+    await POST();
+    expect(mockCookieDelete).toHaveBeenCalledWith('auth_token');
+  });
+
+  it('deletes the refresh_token cookie', async () => {
+    await POST();
+    expect(mockCookieDelete).toHaveBeenCalledWith('refresh_token');
+  });
+
+  it('deletes both cookies in a single request', async () => {
+    await POST();
+    const deletedNames = mockCookieDelete.mock.calls.map((c) => c[0]);
+    expect(deletedNames).toContain('auth_token');
+    expect(deletedNames).toContain('refresh_token');
+    expect(mockCookieDelete).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns 500 when cookies() throws', async () => {
+    mockCookies.mockImplementationOnce(() => {
+      throw new Error('Cookie store unavailable');
+    });
+
+    const res = await POST();
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+  });
+});

--- a/web/src/app/api/auth/__tests__/me.test.ts
+++ b/web/src/app/api/auth/__tests__/me.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration Tests for GET /api/auth/me
+ *
+ * Tests current user fetch from WordPress JWT token with coverage of:
+ * - No auth cookie → 401
+ * - Invalid/expired token → 401 + cookies cleared
+ * - Successful fetch: user shape, roles, customer group processing
+ * - Customer group slugification (e.g. "END USER" → "end-user")
+ * - Default customer group fallback when none present
+ * - "NO ACCESS" values are filtered out
+ * - Server error handling (500)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { GET } from '../me/route';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockCookieGet, mockCookieDelete, mockCookies } = vi.hoisted(() => {
+  const mockCookieGet = vi.fn();
+  const mockCookieDelete = vi.fn();
+  const mockCookies = vi.fn(() => ({
+    get: mockCookieGet,
+    delete: mockCookieDelete,
+    set: vi.fn(),
+  }));
+  return { mockCookieGet, mockCookieDelete, mockCookies };
+});
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/auth/me', { method: 'GET' });
+}
+
+function makeViewerResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    data: {
+      viewer: {
+        id: 'dXNlcjox',
+        databaseId: 42,
+        email: 'test@bapi.com',
+        name: 'Test User',
+        username: 'testuser',
+        customerInformation: {
+          customerGroup1: ['END USER'],
+          customerGroup2: null,
+          customerGroup3: null,
+        },
+        roles: {
+          nodes: [{ name: 'subscriber' }],
+        },
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe('GET /api/auth/me', () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    // Default: auth cookie is present
+    mockCookieGet.mockImplementation((name: string) =>
+      name === 'auth_token' ? { value: 'valid-token' } : undefined,
+    );
+
+    // Default: WordPress returns a valid viewer
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(makeViewerResponse()),
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // ─── Auth guard ──────────────────────────────────────────────────────────────
+
+  it('returns 401 when auth_token cookie is absent', async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.user).toBeNull();
+  });
+
+  it('does not call WordPress when no cookie is present', async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await GET(makeRequest());
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ─── Token validation failure ────────────────────────────────────────────────
+
+  it('returns 401 when WordPress returns errors (expired/invalid token)', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: { viewer: null },
+          errors: [{ message: 'Expired token' }],
+        }),
+    });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.user).toBeNull();
+  });
+
+  it('clears both cookies when token is invalid', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve({ data: { viewer: null }, errors: [{ message: 'Bad token' }] }),
+    });
+
+    await GET(makeRequest());
+    expect(mockCookieDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookieDelete).toHaveBeenCalledWith('refresh_token');
+  });
+
+  // ─── Successful fetch ────────────────────────────────────────────────────────
+
+  it('returns 200 with user shape on success', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.id).toBe('42');
+    expect(body.user.email).toBe('test@bapi.com');
+    expect(body.user.username).toBe('testuser');
+    expect(body.user.displayName).toBe('Test User');
+  });
+
+  it('sends the Bearer token to WordPress', async () => {
+    await GET(makeRequest());
+    const fetchCall = mockFetch.mock.calls[0];
+    const headers = fetchCall[1].headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer valid-token');
+  });
+
+  // ─── Customer group processing ───────────────────────────────────────────────
+
+  it('slugifies customer groups ("END USER" → "end-user")', async () => {
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.customerGroups).toContain('end-user');
+  });
+
+  it('returns ["end-user"] when customerInformation is null', async () => {
+    mockFetch.mockResolvedValue({
+      json: () => Promise.resolve(makeViewerResponse({ customerInformation: null })),
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.customerGroups).toEqual(['end-user']);
+  });
+
+  it('returns ["end-user"] when all groups are empty strings', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(
+          makeViewerResponse({
+            customerInformation: {
+              customerGroup1: [''],
+              customerGroup2: [],
+              customerGroup3: null,
+            },
+          }),
+        ),
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.customerGroups).toEqual(['end-user']);
+  });
+
+  it('filters out "NO ACCESS" values from customer groups', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(
+          makeViewerResponse({
+            customerInformation: {
+              customerGroup1: ['NO ACCESS'],
+              customerGroup2: ['END USER'],
+              customerGroup3: null,
+            },
+          }),
+        ),
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.customerGroups).not.toContain('no-access');
+    expect(body.user.customerGroups).toContain('end-user');
+  });
+
+  it('merges groups from all three customerGroup fields', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(
+          makeViewerResponse({
+            customerInformation: {
+              customerGroup1: ['END USER'],
+              customerGroup2: ['MFG'],
+              customerGroup3: ['HUMIDPRES'],
+            },
+          }),
+        ),
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.customerGroups).toContain('end-user');
+    expect(body.user.customerGroups).toContain('mfg');
+    expect(body.user.customerGroups).toContain('humidpres');
+  });
+
+  // ─── Roles ───────────────────────────────────────────────────────────────────
+
+  it('returns roles array from WordPress', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(
+          makeViewerResponse({
+            roles: { nodes: [{ name: 'administrator' }, { name: 'subscriber' }] },
+          }),
+        ),
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.roles).toEqual(['administrator', 'subscriber']);
+  });
+
+  it('returns empty roles array when no roles present', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve(makeViewerResponse({ roles: { nodes: [] } })),
+    });
+
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body.user.roles).toEqual([]);
+  });
+
+  // ─── Server errors ───────────────────────────────────────────────────────────
+
+  it('returns 500 when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.user).toBeNull();
+    expect(body.error).toBe('Server error');
+  });
+});

--- a/web/src/app/api/auth/__tests__/refresh.test.ts
+++ b/web/src/app/api/auth/__tests__/refresh.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Integration Tests for POST /api/auth/refresh
+ *
+ * Tests silent token refresh with coverage of:
+ * - No refresh cookie → 401
+ * - WordPress refresh failure → 401 + cookies cleared
+ * - Successful refresh: new auth_token set with correct httpOnly flags
+ * - Server error handling (500)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { POST } from '../refresh/route';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockCookieGet, mockCookieSet, mockCookieDelete, mockCookies } = vi.hoisted(() => {
+  const mockCookieGet = vi.fn();
+  const mockCookieSet = vi.fn();
+  const mockCookieDelete = vi.fn();
+  const mockCookies = vi.fn(() => ({
+    get: mockCookieGet,
+    set: mockCookieSet,
+    delete: mockCookieDelete,
+  }));
+  return { mockCookieGet, mockCookieSet, mockCookieDelete, mockCookies };
+});
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeRequest(): NextRequest {
+  return new NextRequest('http://localhost/api/auth/refresh', { method: 'POST' });
+}
+
+describe('POST /api/auth/refresh', () => {
+  const mockFetch = vi.fn();
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    // Default: refresh_token cookie is present
+    mockCookieGet.mockImplementation((name: string) =>
+      name === 'refresh_token' ? { value: 'valid-refresh-token' } : undefined,
+    );
+
+    // Default: WordPress returns new auth token
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: {
+            refreshJwtAuthToken: {
+              authToken: 'new-auth-token-456',
+            },
+          },
+        }),
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  // ─── Auth guard ──────────────────────────────────────────────────────────────
+
+  it('returns 401 when refresh_token cookie is absent', async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('No refresh token');
+  });
+
+  it('does not call WordPress when no refresh cookie is present', async () => {
+    mockCookieGet.mockReturnValue(undefined);
+
+    await POST(makeRequest());
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ─── Token refresh failure ───────────────────────────────────────────────────
+
+  it('returns 401 when WordPress returns errors', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: { refreshJwtAuthToken: { authToken: null } },
+          errors: [{ message: 'Invalid refresh token' }],
+        }),
+    });
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Token refresh failed');
+  });
+
+  it('clears both cookies when refresh fails', async () => {
+    mockFetch.mockResolvedValue({
+      json: () =>
+        Promise.resolve({
+          data: { refreshJwtAuthToken: { authToken: null } },
+          errors: [{ message: 'Expired' }],
+        }),
+    });
+
+    await POST(makeRequest());
+    expect(mockCookieDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookieDelete).toHaveBeenCalledWith('refresh_token');
+  });
+
+  // ─── Successful refresh ───────────────────────────────────────────────────────
+
+  it('returns 200 with success: true on successful refresh', async () => {
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+  });
+
+  it('sets the new auth_token cookie with httpOnly flag', async () => {
+    await POST(makeRequest());
+
+    const authTokenCall = mockCookieSet.mock.calls.find((call) => call[0] === 'auth_token');
+    expect(authTokenCall).toBeDefined();
+    expect(authTokenCall[1]).toBe('new-auth-token-456');
+    expect(authTokenCall[2]).toMatchObject({ httpOnly: true });
+  });
+
+  it('sets sameSite: lax on refreshed auth_token (CSRF protection)', async () => {
+    await POST(makeRequest());
+
+    const authTokenCall = mockCookieSet.mock.calls.find((call) => call[0] === 'auth_token');
+    expect(authTokenCall[2]).toMatchObject({ sameSite: 'lax' });
+  });
+
+  it('sets 7-day maxAge on the new auth_token', async () => {
+    await POST(makeRequest());
+
+    const authTokenCall = mockCookieSet.mock.calls.find((call) => call[0] === 'auth_token');
+    expect(authTokenCall[2].maxAge).toBe(60 * 60 * 24 * 7);
+  });
+
+  it('sends the refresh token to WordPress in request body', async () => {
+    await POST(makeRequest());
+
+    const fetchCall = mockFetch.mock.calls[0];
+    const body = JSON.parse(fetchCall[1].body as string);
+    expect(body.variables.token).toBe('valid-refresh-token');
+  });
+
+  // ─── Server errors ───────────────────────────────────────────────────────────
+
+  it('returns 500 when fetch throws', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    const res = await POST(makeRequest());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Server error');
+  });
+});

--- a/web/src/app/api/revalidate/__tests__/revalidate.test.ts
+++ b/web/src/app/api/revalidate/__tests__/revalidate.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration Tests for POST /api/revalidate
+ *
+ * Tests on-demand cache revalidation with coverage of:
+ * - Missing secret → 401
+ * - Wrong secret → 401
+ * - Rate limiting → 429 with Retry-After header
+ * - Missing tag → 400
+ * - Invalid / non-whitelisted tag → 400
+ * - Allowed static tags (products, categories, graphql, product-list)
+ * - Dynamic product-{slug} tags
+ * - Successful revalidation: response body + revalidateTag called
+ * - Server error handling (500)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { POST } from '../route';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockRevalidateTag, mockCheckRateLimit, mockGetClientIP } = vi.hoisted(() => ({
+  mockRevalidateTag: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockGetClientIP: vi.fn(() => '127.0.0.1'),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidateTag: mockRevalidateTag,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: mockCheckRateLimit,
+  getClientIP: mockGetClientIP,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makeRequest(body: Record<string, unknown>): Request {
+  return new Request('http://localhost/api/revalidate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+const VALID_SECRET = 'test-revalidate-secret';
+
+describe('POST /api/revalidate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('REVALIDATE_SECRET', VALID_SECRET);
+
+    // Default: rate limit allows the request
+    mockCheckRateLimit.mockReturnValue({ success: true, limit: 10, remaining: 9, reset: 0 });
+  });
+
+  // ─── Secret validation ────────────────────────────────────────────────────────
+
+  it('returns 401 when secret is missing', async () => {
+    const res = await POST(makeRequest({ tag: 'products' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('returns 401 when secret is wrong', async () => {
+    const res = await POST(makeRequest({ secret: 'wrong-secret', tag: 'products' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe('Unauthorized');
+  });
+
+  it('does not call revalidateTag when secret is invalid', async () => {
+    await POST(makeRequest({ secret: 'wrong-secret', tag: 'products' }));
+    expect(mockRevalidateTag).not.toHaveBeenCalled();
+  });
+
+  // ─── Rate limiting ───────────────────────────────────────────────────────────
+
+  it('returns 429 when rate limited', async () => {
+    const futureReset = Math.floor(Date.now() / 1000) + 60;
+    mockCheckRateLimit.mockReturnValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: futureReset,
+    });
+
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 'products' }));
+    expect(res.status).toBe(429);
+  });
+
+  it('includes Retry-After header when rate limited', async () => {
+    const futureReset = Math.floor(Date.now() / 1000) + 60;
+    mockCheckRateLimit.mockReturnValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: futureReset,
+    });
+
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 'products' }));
+    expect(res.headers.get('Retry-After')).toBeDefined();
+  });
+
+  // ─── Tag validation ───────────────────────────────────────────────────────────
+
+  it('returns 400 when tag is missing', async () => {
+    const res = await POST(makeRequest({ secret: VALID_SECRET }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Bad Request');
+  });
+
+  it('returns 400 for a non-whitelisted tag', async () => {
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 'users' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Bad Request');
+  });
+
+  it('returns 400 for an empty string tag', async () => {
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: '' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 for a numeric tag', async () => {
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 42 }));
+    expect(res.status).toBe(400);
+  });
+
+  // ─── Allowed tags ─────────────────────────────────────────────────────────────
+
+  it.each(['products', 'product-list', 'categories', 'graphql'])(
+    'accepts static whitelisted tag: %s',
+    async (tag) => {
+      const res = await POST(makeRequest({ secret: VALID_SECRET, tag }));
+      expect(res.status).toBe(200);
+      expect(mockRevalidateTag).toHaveBeenCalledWith(tag);
+    },
+  );
+
+  it('accepts a valid dynamic product-{slug} tag', async () => {
+    const tag = 'product-humidity-transmitter-duct';
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag }));
+    expect(res.status).toBe(200);
+    expect(mockRevalidateTag).toHaveBeenCalledWith(tag);
+  });
+
+  it('rejects a product tag with uppercase letters', async () => {
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 'product-HumidityDuct' }));
+    expect(res.status).toBe(400);
+  });
+
+  // ─── Success response ─────────────────────────────────────────────────────────
+
+  it('returns revalidated: true with the tag echoed back', async () => {
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 'products' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.revalidated).toBe(true);
+    expect(body.tag).toBe('products');
+    expect(typeof body.now).toBe('number');
+  });
+
+  // ─── Server errors ───────────────────────────────────────────────────────────
+
+  it('returns 500 when revalidateTag throws', async () => {
+    mockRevalidateTag.mockImplementation(() => {
+      throw new Error('Cache unavailable');
+    });
+
+    const res = await POST(makeRequest({ secret: VALID_SECRET, tag: 'products' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('Internal Server Error');
+  });
+});

--- a/web/src/app/api/search/__tests__/search.test.ts
+++ b/web/src/app/api/search/__tests__/search.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Integration Tests for POST /api/search and GET /api/search
+ *
+ * Tests product search with coverage of:
+ * - Short / missing query returns empty array immediately (no GraphQL calls)
+ * - POST with valid query calls GraphQL and returns merged, deduplicated results
+ * - GET with ?q= param works identically
+ * - SKU-like queries trigger the variation SKU query (3 promises)
+ * - Non-SKU-like queries skip the variation query (2 promises)
+ * - Results are deduplicated by product ID (variation > SKU > name priority)
+ * - Results are capped at 8
+ * - Customer group filtering applied: guest defaults to end-user
+ * - Server error returns 500
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST, GET } from '../route';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockSdkSearchProducts, mockSdkSearchProductsBySKU, mockSdkSearchProductsByVariationSku, mockGetSdk, mockCookies } =
+  vi.hoisted(() => {
+    const mockSdkSearchProducts = vi.fn();
+    const mockSdkSearchProductsBySKU = vi.fn();
+    const mockSdkSearchProductsByVariationSku = vi.fn();
+    const mockGetSdk = vi.fn(() => ({
+      SearchProducts: mockSdkSearchProducts,
+      SearchProductsBySKU: mockSdkSearchProductsBySKU,
+      SearchProductsByVariationSku: mockSdkSearchProductsByVariationSku,
+    }));
+    const mockCookies = vi.fn(() => ({
+      get: vi.fn(() => undefined), // no auth cookie = guest
+    }));
+    return {
+      mockSdkSearchProducts,
+      mockSdkSearchProductsBySKU,
+      mockSdkSearchProductsByVariationSku,
+      mockGetSdk,
+      mockCookies,
+    };
+  });
+
+vi.mock('@/lib/graphql/client', () => ({
+  getGraphQLClient: vi.fn(() => ({})),
+}));
+
+vi.mock('@/lib/graphql/generated', () => ({
+  getSdk: mockGetSdk,
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: mockCookies,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+function makePostRequest(body: Record<string, unknown>): NextRequest {
+  return new NextRequest('http://localhost/api/search', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGetRequest(query: string): NextRequest {
+  return new NextRequest(`http://localhost/api/search?q=${encodeURIComponent(query)}`);
+}
+
+function makeProduct(id: number, group = 'END USER') {
+  return {
+    id: `prod-${id}`,
+    databaseId: id,
+    name: `Product ${id}`,
+    slug: `product-${id}`,
+    sku: `SKU-${id}`,
+    price: `$${id}.00`,
+    // camelCase field names as expected by filterProductsByCustomerGroup
+    customerGroup1: group,
+    customerGroup2: null,
+    customerGroup3: null,
+  };
+}
+
+const emptyProductsResponse = { products: { nodes: [] } };
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Default: all GraphQL queries return empty
+    mockSdkSearchProducts.mockResolvedValue(emptyProductsResponse);
+    mockSdkSearchProductsBySKU.mockResolvedValue(emptyProductsResponse);
+    mockSdkSearchProductsByVariationSku.mockResolvedValue({
+      searchProductsByVariationSku: [],
+    });
+  });
+
+  // ─── Short query guard ────────────────────────────────────────────────────────
+
+  it('returns empty array for query shorter than 2 chars', async () => {
+    const res = await POST(makePostRequest({ query: 'a' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.products.nodes).toEqual([]);
+    expect(mockSdkSearchProducts).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array for missing query', async () => {
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.products.nodes).toEqual([]);
+  });
+
+  // ─── Normal text query ────────────────────────────────────────────────────────
+
+  it('calls SearchProducts and SearchProductsBySKU for normal text query', async () => {
+    await POST(makePostRequest({ query: 'temperature' }));
+    expect(mockSdkSearchProducts).toHaveBeenCalledWith({ search: 'temperature', first: 8 });
+    expect(mockSdkSearchProductsBySKU).toHaveBeenCalledWith({ sku: 'temperature', first: 8 });
+  });
+
+  it('does NOT call SearchProductsByVariationSku for non-SKU query', async () => {
+    await POST(makePostRequest({ query: 'temperature sensor' }));
+    expect(mockSdkSearchProductsByVariationSku).not.toHaveBeenCalled();
+  });
+
+  it('returns merged product nodes', async () => {
+    mockSdkSearchProducts.mockResolvedValue({
+      products: { nodes: [makeProduct(1)] },
+    });
+
+    const res = await POST(makePostRequest({ query: 'sensor' }));
+    const body = await res.json();
+    expect(body.products.nodes).toHaveLength(1);
+    expect(body.products.nodes[0].id).toBe('prod-1');
+  });
+
+  // ─── SKU-like query ───────────────────────────────────────────────────────────
+
+  it('calls variation SKU query for SKU-like queries (e.g. "BA-2C")', async () => {
+    await POST(makePostRequest({ query: 'BA-2C' }));
+    expect(mockSdkSearchProductsByVariationSku).toHaveBeenCalledWith({
+      sku: 'BA-2C',
+      first: 10,
+    });
+  });
+
+  it('does not call variation query for all-text queries', async () => {
+    await POST(makePostRequest({ query: 'humidity' }));
+    expect(mockSdkSearchProductsByVariationSku).not.toHaveBeenCalled();
+  });
+
+  // ─── Deduplication ────────────────────────────────────────────────────────────
+
+  it('deduplicates products appearing in both name and SKU results', async () => {
+    const product = makeProduct(1);
+    mockSdkSearchProducts.mockResolvedValue({ products: { nodes: [product] } });
+    mockSdkSearchProductsBySKU.mockResolvedValue({ products: { nodes: [product] } });
+
+    const res = await POST(makePostRequest({ query: 'sensor' }));
+    const body = await res.json();
+    expect(body.products.nodes).toHaveLength(1);
+  });
+
+  it('keeps variation SKU result over name result for same product ID', async () => {
+    const nameProduct = { ...makeProduct(1), name: 'From Name' };
+    const variationProduct = { ...makeProduct(1), name: 'From Variation' };
+
+    mockSdkSearchProducts.mockResolvedValue({ products: { nodes: [nameProduct] } });
+    mockSdkSearchProductsBySKU.mockResolvedValue(emptyProductsResponse);
+    mockSdkSearchProductsByVariationSku.mockResolvedValue({
+      searchProductsByVariationSku: [variationProduct],
+    });
+
+    const res = await POST(makePostRequest({ query: 'BA-1' }));
+    const body = await res.json();
+    expect(body.products.nodes[0].name).toBe('From Variation');
+  });
+
+  // ─── Results cap ─────────────────────────────────────────────────────────────
+
+  it('caps results at 8', async () => {
+    const tenProducts = Array.from({ length: 10 }, (_, i) => makeProduct(i + 1));
+    mockSdkSearchProducts.mockResolvedValue({ products: { nodes: tenProducts } });
+
+    const res = await POST(makePostRequest({ query: 'sensor' }));
+    const body = await res.json();
+    expect(body.products.nodes).toHaveLength(8);
+  });
+
+  // ─── Customer group filtering ─────────────────────────────────────────────────
+
+  it('filters out products restricted to other customer groups for guests', async () => {
+    // filterProductsByCustomerGroup uses title prefix parsing when no ACF fields set.
+    // A product with "(ALC)" prefix is alc-restricted, not visible to end-user guest.
+    const publicProduct = makeProduct(1); // END USER group
+    const restrictedProduct = {
+      ...makeProduct(2),
+      name: '(ALC) Restricted Product',
+      customerGroup1: null,
+      customerGroup2: null,
+      customerGroup3: null,
+    };
+
+    mockSdkSearchProducts.mockResolvedValue({
+      products: { nodes: [publicProduct, restrictedProduct] },
+    });
+
+    const res = await POST(makePostRequest({ query: 'sensor' }));
+    const body = await res.json();
+
+    const ids = body.products.nodes.map((p: { id: string }) => p.id);
+    expect(ids).toContain('prod-1');
+    expect(ids).not.toContain('prod-2');
+  });
+
+  // ─── Server errors ────────────────────────────────────────────────────────────
+
+  it('returns 500 when GraphQL throws', async () => {
+    mockSdkSearchProducts.mockRejectedValue(new Error('GraphQL error'));
+
+    const res = await POST(makePostRequest({ query: 'sensor' }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/failed/i);
+  });
+});
+
+describe('GET /api/search', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSdkSearchProducts.mockResolvedValue(emptyProductsResponse);
+    mockSdkSearchProductsBySKU.mockResolvedValue(emptyProductsResponse);
+    mockSdkSearchProductsByVariationSku.mockResolvedValue({
+      searchProductsByVariationSku: [],
+    });
+  });
+
+  it('returns empty array when ?q is too short', async () => {
+    const res = await GET(makeGetRequest('x'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.products.nodes).toEqual([]);
+  });
+
+  it('calls SearchProducts for valid ?q param', async () => {
+    await GET(makeGetRequest('sensor'));
+    expect(mockSdkSearchProducts).toHaveBeenCalledWith({ search: 'sensor', first: 8 });
+  });
+
+  it('returns merged results for valid ?q param', async () => {
+    mockSdkSearchProducts.mockResolvedValue({
+      products: { nodes: [makeProduct(1)] },
+    });
+
+    const res = await GET(makeGetRequest('sensor'));
+    const body = await res.json();
+    expect(body.products.nodes).toHaveLength(1);
+  });
+});

--- a/web/src/components/category/__tests__/CategoryContent.test.tsx
+++ b/web/src/components/category/__tests__/CategoryContent.test.tsx
@@ -1,0 +1,367 @@
+/**
+ * CategoryContent Component Tests
+ *
+ * Tests the core product browsing behavior:
+ * - Renders all products when no filters active
+ * - Subcategory filter removes non-matching products
+ * - Application attribute filter filters correctly
+ * - Multiple active filters are ANDed together
+ * - Customer group filtering: excludes products not accessible to user's group
+ * - Sorting: name A-Z, price asc/desc, newest first (by databaseId)
+ * - Sort dropdown triggers URL push
+ * - Subcategory cards render when subcategories provided
+ * - Product count label reflects filtered/total
+ *
+ * NOTE: CategoryContent is a 'use client' component using useSearchParams/useRouter/usePathname.
+ * These are mocked via vi.mock('next/navigation').
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CategoryContent from '../CategoryContent';
+import type {
+  GetProductAttributesQuery,
+} from '@/lib/graphql/generated';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockPush, mockPathname, mockSearchParams, mockGetAll, mockGet } = vi.hoisted(() => {
+  const mockGet = vi.fn((_key: string) => null);
+  const mockGetAll = vi.fn((_key: string) => []);
+  const mockSearchParams = { get: mockGet, getAll: mockGetAll, toString: () => '' };
+  const mockPush = vi.fn();
+  const mockPathname = vi.fn(() => '/en/products/temperature');
+  return { mockPush, mockPathname, mockSearchParams, mockGetAll, mockGet };
+});
+
+vi.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => mockPathname(),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { customerGroups: ['end-user'] } }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock heavy sub-components that aren't under test
+vi.mock('@/components/products/ProductGrid', () => ({
+  ProductGrid: ({ products }: { products: Array<{ name?: string | null }> }) => (
+    <div data-testid="product-grid">
+      {products.map((p) => (
+        <div key={p.name} data-testid="product-card">
+          {p.name}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../SubcategoryCard', () => ({
+  default: ({ name }: { name: string }) => <div data-testid="subcategory-card">{name}</div>,
+}));
+
+vi.mock('../SubcategoryQuickFilter', () => ({
+  default: () => <div data-testid="subcategory-quick-filter" />,
+}));
+
+vi.mock('../FilterSidebar', () => ({
+  default: ({
+    onChange,
+  }: {
+    onChange: (filters: ActiveFilters) => void;
+    activeFilters: ActiveFilters;
+  }) => (
+    <div data-testid="filter-sidebar">
+      <button
+        onClick={() =>
+          onChange({
+            subcategory: ['duct-sensors'],
+            application: [],
+            enclosure: [],
+            output: [],
+            display: [],
+            tempSetpoint: [],
+            optionalTempOutput: [],
+          })
+        }
+      >
+        Apply Duct Sensors Filter
+      </button>
+    </div>
+  ),
+}));
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+interface ActiveFilters {
+  subcategory: string[];
+  application: string[];
+  enclosure: string[];
+  output: string[];
+  display: string[];
+  tempSetpoint: string[];
+  optionalTempOutput: string[];
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+const emptyFiltersQuery: GetProductAttributesQuery = {
+  paApplications: { nodes: [] },
+  paRoomEnclosureStyles: { nodes: [] },
+  paTemperatureSensorOutputs: { nodes: [] },
+  paHumiditySensorOutputs: { nodes: [] },
+  paDisplays: { nodes: [] },
+  paTempSetpointAndOverride: { nodes: [] },
+  paOptionalTempSensorOutputs: { nodes: [] },
+} as unknown as GetProductAttributesQuery;
+
+function makeProduct(
+  id: number,
+  name: string,
+  price: string = '$10.00',
+  categorySlug?: string,
+  customerGroup?: string,
+) {
+  return {
+    id: `prod-${id}`,
+    databaseId: id,
+    name,
+    slug: name.toLowerCase().replace(/ /g, '-'),
+    price,
+    stockStatus: 'IN_STOCK' as const,
+    image: null,
+    gallery: [],
+    variations: [],
+    productCategories: categorySlug
+      ? { nodes: [{ id: `cat-${id}`, name: categorySlug, slug: categorySlug }] }
+      : { nodes: [] },
+    customer_group1: customerGroup ? [customerGroup] : ['END USER'],
+    attributes: { nodes: [] },
+  };
+}
+
+const defaultProducts = [
+  makeProduct(10, 'Alpha Sensor', '$10.00'),
+  makeProduct(20, 'Beta Transmitter', '$5.00'),
+  makeProduct(30, 'Gamma Controller', '$15.00'),
+];
+
+function renderCategoryContent(products = defaultProducts) {
+  return render(
+    <CategoryContent
+      categorySlugParam="temperature"
+      subcategories={[]}
+      products={products as any}
+      filters={emptyFiltersQuery}
+      locale="en"
+    />,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('CategoryContent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockReturnValue(null);
+    mockGetAll.mockReturnValue([]);
+  });
+
+  // ─── Rendering ───────────────────────────────────────────────────────────────
+
+  it('renders all products when no filters are active', () => {
+    renderCategoryContent();
+    expect(screen.getAllByTestId('product-card')).toHaveLength(3);
+  });
+
+  it('shows the product count label', () => {
+    renderCategoryContent();
+    // "Showing 3 of 3 products"
+    expect(screen.getByText(/showing 3 of 3 products/i)).toBeInTheDocument();
+  });
+
+  it('renders subcategory cards when subcategories are provided', () => {
+    const subcategories = [
+      { id: '1', name: 'Duct Sensors', slug: 'duct-sensors', count: 5 },
+      { id: '2', name: 'Room Sensors', slug: 'room-sensors', count: 3 },
+    ];
+
+    render(
+      <CategoryContent
+        categorySlugParam="temperature"
+        subcategories={subcategories as any}
+        products={defaultProducts as any}
+        filters={emptyFiltersQuery}
+        locale="en"
+      />,
+    );
+
+    expect(screen.getAllByTestId('subcategory-card')).toHaveLength(2);
+    expect(screen.getByText('Duct Sensors')).toBeInTheDocument();
+  });
+
+  it('does not render subcategory section when no subcategories', () => {
+    renderCategoryContent();
+    expect(screen.queryByText('Browse by Category')).not.toBeInTheDocument();
+  });
+
+  it('renders the sort dropdown', () => {
+    renderCategoryContent();
+    expect(screen.getByRole('combobox', { name: /sort/i })).toBeInTheDocument();
+  });
+
+  // ─── Sorting ─────────────────────────────────────────────────────────────────
+
+  it('sorts products A-Z by name by default', () => {
+    renderCategoryContent();
+    const cards = screen.getAllByTestId('product-card');
+    expect(cards[0]).toHaveTextContent('Alpha Sensor');
+    expect(cards[1]).toHaveTextContent('Beta Transmitter');
+    expect(cards[2]).toHaveTextContent('Gamma Controller');
+  });
+
+  it('sorts products by price ascending when selected', () => {
+    renderCategoryContent();
+    fireEvent.change(screen.getByRole('combobox', { name: /sort/i }), {
+      target: { value: 'price-asc' },
+    });
+
+    const cards = screen.getAllByTestId('product-card');
+    expect(cards[0]).toHaveTextContent('Beta Transmitter'); // $5.00
+    expect(cards[1]).toHaveTextContent('Alpha Sensor'); // $10.00
+    expect(cards[2]).toHaveTextContent('Gamma Controller'); // $15.00
+  });
+
+  it('sorts products by price descending when selected', () => {
+    renderCategoryContent();
+    fireEvent.change(screen.getByRole('combobox', { name: /sort/i }), {
+      target: { value: 'price-desc' },
+    });
+
+    const cards = screen.getAllByTestId('product-card');
+    expect(cards[0]).toHaveTextContent('Gamma Controller'); // $15.00
+    expect(cards[1]).toHaveTextContent('Alpha Sensor'); // $10.00
+    expect(cards[2]).toHaveTextContent('Beta Transmitter'); // $5.00
+  });
+
+  it('sorts by newest first (highest databaseId first) when selected', () => {
+    renderCategoryContent();
+    fireEvent.change(screen.getByRole('combobox', { name: /sort/i }), {
+      target: { value: 'newest' },
+    });
+
+    const cards = screen.getAllByTestId('product-card');
+    expect(cards[0]).toHaveTextContent('Gamma Controller'); // databaseId: 30
+    expect(cards[1]).toHaveTextContent('Beta Transmitter'); // databaseId: 20
+    expect(cards[2]).toHaveTextContent('Alpha Sensor'); // databaseId: 10
+  });
+
+  it('pushes URL when sort changes', () => {
+    renderCategoryContent();
+    fireEvent.change(screen.getByRole('combobox', { name: /sort/i }), {
+      target: { value: 'price-asc' },
+    });
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining('sort=price-asc'),
+      expect.any(Object),
+    );
+  });
+
+  it('does not include sort param in URL when sort is "name" (default)', () => {
+    renderCategoryContent();
+    // Default sort is 'name' — no sort param needed
+    // Trigger the filter change through FilterSidebar mock to exercise URL push
+    fireEvent.click(screen.getByText('Apply Duct Sensors Filter'));
+
+    const pushCall = mockPush.mock.calls[0]?.[0] ?? '';
+    expect(pushCall).not.toContain('sort=name');
+  });
+
+  // ─── Subcategory filtering ────────────────────────────────────────────────────
+
+  it('filters by subcategory when FilterSidebar triggers onChange', () => {
+    const ductProduct = makeProduct(1, 'Duct Alpha', '$10.00', 'duct-sensors');
+    const roomProduct = makeProduct(2, 'Room Beta', '$10.00', 'room-sensors');
+
+    render(
+      <CategoryContent
+        categorySlugParam="temperature"
+        subcategories={[]}
+        products={[ductProduct, roomProduct] as any}
+        filters={emptyFiltersQuery}
+        locale="en"
+      />,
+    );
+
+    // Both show initially
+    expect(screen.getAllByTestId('product-card')).toHaveLength(2);
+
+    // Apply duct-sensors subcategory filter via the mock sidebar button
+    fireEvent.click(screen.getByText('Apply Duct Sensors Filter'));
+
+    // Only duct product should remain
+    const cards = screen.getAllByTestId('product-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toHaveTextContent('Duct Alpha');
+  });
+
+  it('pushes URL with active filters when FilterSidebar triggers onChange', () => {
+    renderCategoryContent();
+    fireEvent.click(screen.getByText('Apply Duct Sensors Filter'));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining('subcategory=duct-sensors'),
+      expect.any(Object),
+    );
+  });
+
+  // ─── Product count label ──────────────────────────────────────────────────────
+
+  it('shows filtered count after applying a filter that removes products', () => {
+    const ductProduct = makeProduct(1, 'Duct Alpha', '$10.00', 'duct-sensors');
+    const roomProduct = makeProduct(2, 'Room Beta', '$10.00', 'room-sensors');
+
+    render(
+      <CategoryContent
+        categorySlugParam="temperature"
+        subcategories={[]}
+        products={[ductProduct, roomProduct] as any}
+        filters={emptyFiltersQuery}
+        locale="en"
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Apply Duct Sensors Filter'));
+
+    // 1 of 2 products shown
+    expect(screen.getByText(/showing 1 of 2 products/i)).toBeInTheDocument();
+  });
+
+  // ─── Bluetooth-wireless category exclusion logic ─────────────────────────────
+
+  it('excludes specific subcategory cards in bluetooth-wireless category', () => {
+    const subcategories = [
+      { id: '1', name: 'Wireless Gateway', slug: 'wireless-gateway', count: 3 },
+      { id: '2', name: 'Wireless Transmitters', slug: 'wireless-transmitters', count: 5 },
+    ];
+
+    render(
+      <CategoryContent
+        categorySlugParam="bluetooth-wireless"
+        subcategories={subcategories as any}
+        products={[]}
+        filters={emptyFiltersQuery}
+        locale="en"
+      />,
+    );
+
+    // Gateway should be excluded for this category
+    expect(screen.queryByText('Wireless Gateway')).not.toBeInTheDocument();
+    // Transmitters should still show
+    expect(screen.getByText('Wireless Transmitters')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/category/__tests__/FilterSidebar.test.tsx
+++ b/web/src/components/category/__tests__/FilterSidebar.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * FilterSidebar Component Tests
+ *
+ * Tests filter state management, rendering, and user interactions:
+ * - Renders subcategory and attribute filter groups
+ * - Checking a filter calls onChange with updated state
+ * - Unchecking a filter removes it
+ * - "Clear All Filters" button appears only with active filters and clears them
+ * - Filters are not shown when no options exist for that category
+ * - Mobile filter button opens the overlay
+ * - Active filter badge count reflects total active selections
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import FilterSidebar from '../FilterSidebar';
+import type { GetProductAttributesQuery } from '@/lib/graphql/generated';
+
+// ─── Mock icons ───────────────────────────────────────────────────────────────
+vi.mock('@/lib/icons', () => ({
+  XIcon: () => <span data-testid="x-icon" />,
+  SlidersHorizontalIcon: () => <span data-testid="sliders-icon" />,
+  ChevronDownIcon: () => <span data-testid="chevron-down-icon" />,
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+const emptyFilters: ActiveFilters = {
+  subcategory: [],
+  application: [],
+  enclosure: [],
+  output: [],
+  display: [],
+  tempSetpoint: [],
+  optionalTempOutput: [],
+};
+
+interface ActiveFilters {
+  subcategory: string[];
+  application: string[];
+  enclosure: string[];
+  output: string[];
+  display: string[];
+  tempSetpoint: string[];
+  optionalTempOutput: string[];
+}
+
+const mockSubcategories = [
+  { id: '1', name: 'Duct Sensors', slug: 'duct-sensors', count: 12 },
+  { id: '2', name: 'Room Sensors', slug: 'room-sensors', count: 8 },
+];
+
+const mockFilters: GetProductAttributesQuery = {
+  paApplications: {
+    nodes: [
+      { id: 'app-1', name: 'HVAC', slug: 'hvac', count: 10 },
+      { id: 'app-2', name: 'Industrial', slug: 'industrial', count: 5 },
+    ],
+  },
+  paRoomEnclosureStyles: { nodes: [] },
+  paTemperatureSensorOutputs: { nodes: [] },
+  paHumiditySensorOutputs: { nodes: [] },
+  paDisplays: { nodes: [] },
+  paTempSetpointAndOverride: { nodes: [] },
+  paOptionalTempSensorOutputs: { nodes: [] },
+} as unknown as GetProductAttributesQuery;
+
+const emptyFiltersQuery: GetProductAttributesQuery = {
+  paApplications: { nodes: [] },
+  paRoomEnclosureStyles: { nodes: [] },
+  paTemperatureSensorOutputs: { nodes: [] },
+  paHumiditySensorOutputs: { nodes: [] },
+  paDisplays: { nodes: [] },
+  paTempSetpointAndOverride: { nodes: [] },
+  paOptionalTempSensorOutputs: { nodes: [] },
+} as unknown as GetProductAttributesQuery;
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('FilterSidebar', () => {
+  let onChangeMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onChangeMock = vi.fn();
+  });
+
+  // ─── Rendering ───────────────────────────────────────────────────────────────
+
+  it('renders the desktop Filters heading', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    // The desktop heading is inside a hidden lg:block div, but it renders in the DOM
+    expect(screen.getAllByText('Filters').length).toBeGreaterThan(0);
+  });
+
+  it('renders subcategory filter groups when subcategories are provided', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    expect(screen.getAllByText('Duct Sensors').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Room Sensors').length).toBeGreaterThan(0);
+  });
+
+  it('does not render subcategory group when there are no subcategories', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    expect(screen.queryByText('Duct Sensors')).not.toBeInTheDocument();
+  });
+
+  it('renders application filter group when options are provided', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={mockFilters}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    expect(screen.getAllByText('HVAC').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Industrial').length).toBeGreaterThan(0);
+  });
+
+  it('does not render application group when no options exist', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    expect(screen.queryByText('HVAC')).not.toBeInTheDocument();
+  });
+
+  // ─── onChange interactions ────────────────────────────────────────────────────
+
+  it('calls onChange with selected subcategory when checkbox is checked', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    // Find the Duct Sensors checkbox (first one)
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ subcategory: ['duct-sensors'] }),
+    );
+  });
+
+  it('calls onChange without subcategory when checkbox is unchecked', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={emptyFiltersQuery}
+        activeFilters={{ ...emptyFilters, subcategory: ['duct-sensors'] }}
+        onChange={onChangeMock}
+      />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // First checkbox (Duct Sensors) is checked — click to uncheck
+    fireEvent.click(checkboxes[0]);
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ subcategory: [] }),
+    );
+  });
+
+  it('calls onChange with selected application when application checkbox is checked', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={mockFilters}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]); // First app checkbox = HVAC
+
+    expect(onChangeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ application: ['hvac'] }),
+    );
+  });
+
+  // ─── Clear All Filters ───────────────────────────────────────────────────────
+
+  it('does not show "Clear All Filters" when no filters are active', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    expect(screen.queryByText('Clear All Filters')).not.toBeInTheDocument();
+  });
+
+  it('shows "Clear All Filters" when at least one filter is active', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={emptyFiltersQuery}
+        activeFilters={{ ...emptyFilters, subcategory: ['duct-sensors'] }}
+        onChange={onChangeMock}
+      />,
+    );
+    expect(screen.getAllByText('Clear All Filters').length).toBeGreaterThan(0);
+  });
+
+  it('calls onChange with all-empty filters when "Clear All Filters" is clicked', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={mockFilters}
+        activeFilters={{ ...emptyFilters, subcategory: ['duct-sensors'], application: ['hvac'] }}
+        onChange={onChangeMock}
+      />,
+    );
+    const clearButtons = screen.getAllByText('Clear All Filters');
+    fireEvent.click(clearButtons[0]);
+
+    expect(onChangeMock).toHaveBeenCalledWith({
+      subcategory: [],
+      application: [],
+      enclosure: [],
+      output: [],
+      display: [],
+      tempSetpoint: [],
+      optionalTempOutput: [],
+    });
+  });
+
+  // ─── Active filter badge (mobile button) ─────────────────────────────────────
+
+  it('shows active filter count badge on mobile button when filters are active', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={mockFilters}
+        activeFilters={{ ...emptyFilters, subcategory: ['duct-sensors'], application: ['hvac'] }}
+        onChange={onChangeMock}
+      />,
+    );
+    // The badge shows total count: 1 subcategory + 1 application = 2
+    expect(screen.getByText('2')).toBeInTheDocument();
+  });
+
+  it('does not show active filter badge when no filters are active', () => {
+    render(
+      <FilterSidebar
+        subcategories={mockSubcategories}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    // No numeric badge rendered
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    expect(screen.queryByText('2')).not.toBeInTheDocument();
+  });
+
+  // ─── Mobile overlay ───────────────────────────────────────────────────────────
+
+  it('opens mobile overlay when mobile Filters button is clicked', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    // The mobile toggle button (visible on mobile, hidden lg:hidden)
+    const mobileButton = screen.getByRole('button', { name: /filters/i });
+    fireEvent.click(mobileButton);
+
+    // Close button and Apply Filters button now appear in the overlay
+    expect(screen.getByRole('button', { name: /close filters/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /apply filters/i })).toBeInTheDocument();
+  });
+
+  it('closes mobile overlay when close button is clicked', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.click(screen.getByRole('button', { name: /close filters/i }));
+
+    expect(screen.queryByRole('button', { name: /close filters/i })).not.toBeInTheDocument();
+  });
+
+  it('closes mobile overlay when Apply Filters is clicked', () => {
+    render(
+      <FilterSidebar
+        subcategories={[]}
+        filters={emptyFiltersQuery}
+        activeFilters={emptyFilters}
+        onChange={onChangeMock}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /filters/i }));
+    fireEvent.click(screen.getByRole('button', { name: /apply filters/i }));
+
+    expect(screen.queryByRole('button', { name: /apply filters/i })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/products/__tests__/Pagination.test.tsx
+++ b/web/src/components/products/__tests__/Pagination.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Pagination Component Tests
+ *
+ * Tests page navigation logic and rendering:
+ * - Returns null when totalPages <= 1
+ * - Renders page info (Page X of Y)
+ * - Renders Previous / Next buttons
+ * - Previous button is disabled on page 1
+ * - Next button is disabled on the last page
+ * - Clicking a page number pushes correct URL
+ * - Clicking Next increments the page
+ * - Clicking Previous decrements the page
+ * - Page 1 removes the `page` param from URL (clean URL)
+ * - Ellipsis displayed when totalPages > 7
+ * - Always shows first and last page numbers
+ * - Shows pages around current page in the middle
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Pagination } from '../Pagination';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+const { mockPush, mockSearchParams } = vi.hoisted(() => {
+  const mockPush = vi.fn();
+  const mockSearchParams = { toString: () => '', get: vi.fn(), getAll: vi.fn() };
+  return { mockPush, mockSearchParams };
+});
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Null render guards ───────────────────────────────────────────────────────
+
+  it('renders nothing when totalPages is 1', () => {
+    const { container } = render(
+      <Pagination currentPage={1} totalPages={1} totalProducts={10} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when totalPages is 0', () => {
+    const { container } = render(
+      <Pagination currentPage={1} totalPages={0} totalProducts={0} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // ─── Page info ────────────────────────────────────────────────────────────────
+
+  it('shows current page and total pages in the info label', () => {
+    render(<Pagination currentPage={2} totalPages={5} totalProducts={50} />);
+    // The page info reads "Page 2 of 5"
+    expect(screen.getByText(/page/i).closest('div')).toHaveTextContent('2');
+    expect(screen.getByText(/page/i).closest('div')).toHaveTextContent('5');
+  });
+
+  // ─── Navigation buttons ───────────────────────────────────────────────────────
+
+  it('renders Previous and Next buttons', () => {
+    render(<Pagination currentPage={2} totalPages={5} totalProducts={50} />);
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+  });
+
+  it('disables Previous button on first page', () => {
+    render(<Pagination currentPage={1} totalPages={5} totalProducts={50} />);
+    expect(screen.getByRole('button', { name: /previous page/i })).toBeDisabled();
+  });
+
+  it('disables Next button on last page', () => {
+    render(<Pagination currentPage={5} totalPages={5} totalProducts={50} />);
+    expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+  });
+
+  it('enables both Previous and Next when on a middle page', () => {
+    render(<Pagination currentPage={3} totalPages={5} totalProducts={50} />);
+    expect(screen.getByRole('button', { name: /previous page/i })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: /next page/i })).not.toBeDisabled();
+  });
+
+  // ─── Click navigation ─────────────────────────────────────────────────────────
+
+  it('pushes ?page=2 when clicking page 2 button', () => {
+    render(<Pagination currentPage={1} totalPages={5} totalProducts={50} />);
+    // Page buttons use aria-label="Go to page N"
+    fireEvent.click(screen.getByRole('button', { name: /go to page 2/i }));
+    expect(mockPush).toHaveBeenCalledWith('?page=2', expect.any(Object));
+  });
+
+  it('removes page param when navigating to page 1 (clean URL)', () => {
+    render(<Pagination currentPage={2} totalPages={5} totalProducts={50} />);
+    fireEvent.click(screen.getByRole('button', { name: /go to page 1/i }));
+    const call = mockPush.mock.calls[0][0];
+    expect(call).not.toContain('page=1');
+  });
+
+  it('navigates to next page when Next is clicked', () => {
+    render(<Pagination currentPage={2} totalPages={5} totalProducts={50} />);
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(mockPush).toHaveBeenCalledWith('?page=3', expect.any(Object));
+  });
+
+  it('navigates to previous page when Previous is clicked', () => {
+    render(<Pagination currentPage={3} totalPages={5} totalProducts={50} />);
+    fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
+    expect(mockPush).toHaveBeenCalledWith('?page=2', expect.any(Object));
+  });
+
+  it('navigates to page 1 (clean URL) when Previous clicked on page 2', () => {
+    render(<Pagination currentPage={2} totalPages={5} totalProducts={50} />);
+    fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
+    const call = mockPush.mock.calls[0][0];
+    expect(call).not.toContain('page=1');
+  });
+
+  // ─── Page number display ─────────────────────────────────────────────────────
+
+  it('shows all page number buttons when totalPages is 7 or fewer', () => {
+    render(<Pagination currentPage={1} totalPages={5} totalProducts={50} />);
+    for (let i = 1; i <= 5; i++) {
+      expect(screen.getByRole('button', { name: new RegExp(`go to page ${i}`, 'i') })).toBeInTheDocument();
+    }
+  });
+
+  it('shows ellipsis when totalPages > 7 and current page is far from edges', () => {
+    render(<Pagination currentPage={5} totalPages={10} totalProducts={100} />);
+    expect(screen.getAllByText('...').length).toBeGreaterThan(0);
+  });
+
+  it('always shows page 1 button when totalPages > 7', () => {
+    render(<Pagination currentPage={8} totalPages={10} totalProducts={100} />);
+    // Use exact label to avoid matching "Go to page 10"
+    expect(screen.getByRole('button', { name: 'Go to page 1' })).toBeInTheDocument();
+  });
+
+  it('always shows last page button when totalPages > 7', () => {
+    render(<Pagination currentPage={2} totalPages={10} totalProducts={100} />);
+    expect(screen.getByRole('button', { name: /go to page 10/i })).toBeInTheDocument();
+  });
+
+  // ─── Scroll behaviour ─────────────────────────────────────────────────────────
+
+  it('passes scroll: true to router.push for page navigation', () => {
+    render(<Pagination currentPage={1} totalPages={5} totalProducts={50} />);
+    fireEvent.click(screen.getByRole('button', { name: /go to page 2/i }));
+    expect(mockPush).toHaveBeenCalledWith('?page=2', { scroll: true });
+  });
+});

--- a/web/src/components/search/__tests__/SearchDropdown.test.tsx
+++ b/web/src/components/search/__tests__/SearchDropdown.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * SearchDropdown Component Tests
+ *
+ * Tests the search result dropdown UI behavior:
+ * - Returns null when isOpen is false
+ * - Renders loading spinner when isLoading is true
+ * - Renders empty state when query >= 2 chars but no results
+ * - Does NOT render empty state when query is too short
+ * - Renders product results with name, SKU/partNumber, category, price
+ * - Renders "View all results" footer button
+ * - Clicking a product result calls onSelect with correct slug
+ * - Clicking "View all results" calls onViewAll
+ * - Arrow key navigation: ArrowDown increments selection, ArrowUp decrements
+ * - Enter key on product calls onSelect
+ * - Enter key on "View all" row calls onViewAll
+ * - Escape key calls onClose
+ * - Click outside the dropdown calls onClose
+ * - partNumber takes priority over SKU for display
+ * - Products without images render without an image element
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SearchDropdown } from '../SearchDropdown';
+
+// ─── Mock heavy deps ──────────────────────────────────────────────────────────
+vi.mock('@/lib/navigation', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} data-testid="product-image" />
+  ),
+}));
+
+vi.mock('@/lib/icons', () => ({
+  SearchIcon: () => <span data-testid="search-icon" />,
+  XIcon: () => <span data-testid="x-icon" />,
+  ArrowRightIcon: () => <span data-testid="arrow-right-icon" />,
+  Loader2Icon: () => <span data-testid="loader-icon" />,
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+function makeProduct(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `prod-${id}`,
+    databaseId: id,
+    name: `Product ${id}`,
+    slug: `product-${id}`,
+    sku: `SKU-${id}`,
+    partNumber: null,
+    price: `$${id * 10}.00`,
+    shortDescription: null,
+    image: { sourceUrl: `https://example.com/img-${id}.jpg`, altText: `Product ${id}` },
+    productCategories: { nodes: [{ name: 'Temperature', slug: 'temperature' }] },
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  id: 'search-dropdown',
+  results: [],
+  isLoading: false,
+  isOpen: true,
+  query: 'temp',
+  onSelect: vi.fn(),
+  onViewAll: vi.fn(),
+  onClose: vi.fn(),
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SearchDropdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Visibility guard ────────────────────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(<SearchDropdown {...defaultProps} isOpen={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders when isOpen is true', () => {
+    render(<SearchDropdown {...defaultProps} />);
+    // The dropdown container should be in the DOM
+    expect(document.getElementById('search-dropdown')).toBeInTheDocument();
+  });
+
+  // ─── Loading state ───────────────────────────────────────────────────────────
+
+  it('shows loading spinner when isLoading is true', () => {
+    render(<SearchDropdown {...defaultProps} isLoading={true} />);
+    expect(screen.getByText(/searching/i)).toBeInTheDocument();
+    expect(screen.getByTestId('loader-icon')).toBeInTheDocument();
+  });
+
+  it('does not show results when loading', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        isLoading={true}
+        results={[makeProduct(1)]}
+      />,
+    );
+    expect(screen.queryByText('Product 1')).not.toBeInTheDocument();
+  });
+
+  // ─── Empty state ─────────────────────────────────────────────────────────────
+
+  it('shows empty state when query >= 2 chars and no results', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[]}
+        isLoading={false}
+        query="temp"
+      />,
+    );
+    expect(screen.getByText(/no products found/i)).toBeInTheDocument();
+    expect(screen.getByText(/temp/)).toBeInTheDocument();
+  });
+
+  it('does not show empty state when query is too short', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[]}
+        isLoading={false}
+        query="t"
+      />,
+    );
+    expect(screen.queryByText(/no products found/i)).not.toBeInTheDocument();
+  });
+
+  // ─── Results rendering ────────────────────────────────────────────────────────
+
+  it('renders product names', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1), makeProduct(2)]}
+      />,
+    );
+    expect(screen.getByText('Product 1')).toBeInTheDocument();
+    expect(screen.getByText('Product 2')).toBeInTheDocument();
+  });
+
+  it('renders product price', () => {
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(5)]} />);
+    expect(screen.getByText('$50.00')).toBeInTheDocument();
+  });
+
+  it('renders SKU when no partNumber', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1, { sku: 'SKU-ABC', partNumber: null })]}
+      />,
+    );
+    expect(screen.getByText('SKU-ABC')).toBeInTheDocument();
+  });
+
+  it('renders partNumber instead of SKU when partNumber is present', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1, { sku: 'SKU-ABC', partNumber: 'PN-XYZ' })]}
+      />,
+    );
+    expect(screen.getByText('PN-XYZ')).toBeInTheDocument();
+    expect(screen.queryByText('SKU-ABC')).not.toBeInTheDocument();
+  });
+
+  it('renders category name', () => {
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(1)]} />);
+    expect(screen.getByText('Temperature')).toBeInTheDocument();
+  });
+
+  it('renders product image when available', () => {
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(1)]} />);
+    expect(screen.getByTestId('product-image')).toBeInTheDocument();
+  });
+
+  it('does not render image element when product has no image', () => {
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1, { image: null })]}
+      />,
+    );
+    expect(screen.queryByTestId('product-image')).not.toBeInTheDocument();
+  });
+
+  it('renders "View all results" footer with query text', () => {
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(1)]} query="sensor" />);
+    expect(screen.getByText(/view all results for.*sensor/i)).toBeInTheDocument();
+  });
+
+  // ─── Click interactions ───────────────────────────────────────────────────────
+
+  it('calls onSelect with product slug when a product is clicked', () => {
+    const onSelect = vi.fn();
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(42)]}
+        onSelect={onSelect}
+      />,
+    );
+    fireEvent.click(screen.getByText('Product 42'));
+    expect(onSelect).toHaveBeenCalledWith('product-42');
+  });
+
+  it('calls onViewAll when "View all results" is clicked', () => {
+    const onViewAll = vi.fn();
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1)]}
+        onViewAll={onViewAll}
+      />,
+    );
+    fireEvent.click(screen.getByText(/view all results/i));
+    expect(onViewAll).toHaveBeenCalledOnce();
+  });
+
+  // ─── Keyboard navigation ─────────────────────────────────────────────────────
+
+  it('calls onClose when Escape key is pressed', () => {
+    const onClose = vi.fn();
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(1)]} onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onSelect with first result slug when Enter is pressed on first item', () => {
+    const onSelect = vi.fn();
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1), makeProduct(2)]}
+        onSelect={onSelect}
+      />,
+    );
+    // selectedIndex defaults to 0 — Enter selects results[0]
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith('product-1');
+  });
+
+  it('calls onViewAll when Enter is pressed and last item (View all) is selected', () => {
+    const onViewAll = vi.fn();
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1)]}
+        onViewAll={onViewAll}
+      />,
+    );
+    // ArrowDown once → moves to index 1 which is "View all results" (results.length === 1)
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onViewAll).toHaveBeenCalledOnce();
+  });
+
+  it('moves selection down with ArrowDown', () => {
+    const onSelect = vi.fn();
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1), makeProduct(2)]}
+        onSelect={onSelect}
+      />,
+    );
+    // Move down to index 1, then Enter should select results[1]
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onSelect).toHaveBeenCalledWith('product-2');
+  });
+
+  it('does not move selection below last item', () => {
+    const onViewAll = vi.fn();
+    render(
+      <SearchDropdown
+        {...defaultProps}
+        results={[makeProduct(1)]}
+        onViewAll={onViewAll}
+      />,
+    );
+    // Press ArrowDown many times — should clamp to results.length (View all)
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'ArrowDown' });
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onViewAll).toHaveBeenCalledOnce();
+  });
+
+  // ─── Click outside ────────────────────────────────────────────────────────────
+
+  it('calls onClose when clicking outside the dropdown', () => {
+    const onClose = vi.fn();
+    render(
+      <div>
+        <SearchDropdown {...defaultProps} results={[makeProduct(1)]} onClose={onClose} />
+        <button data-testid="outside">Outside</button>
+      </div>,
+    );
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  // ─── Accessibility ────────────────────────────────────────────────────────────
+
+  it('gives the container id matching the passed id prop', () => {
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(1)]} id="my-dropdown" />);
+    expect(document.getElementById('my-dropdown')).toBeInTheDocument();
+  });
+
+  it('marks selected item as aria-selected', () => {
+    render(<SearchDropdown {...defaultProps} results={[makeProduct(1), makeProduct(2)]} />);
+    const options = screen.getAllByRole('option');
+    // Index 0 is selected by default
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+  });
+});

--- a/web/src/components/search/__tests__/SearchResults.test.tsx
+++ b/web/src/components/search/__tests__/SearchResults.test.tsx
@@ -1,0 +1,308 @@
+/**
+ * SearchResults Component Tests
+ *
+ * Tests the full-page search results display:
+ * - Renders result count for multiple results
+ * - Renders singular count for exactly 1 result
+ * - Renders empty state (heading + Browse/Contact buttons) when no results
+ * - Customer group filtering: products not accessible to user's group are hidden
+ * - Renders product name, SKU/partNumber badge, category chip, price
+ * - partNumber takes priority over SKU in badge
+ * - Products without images render without an <img>
+ * - Each product is a link to /product/{slug}
+ * - "Back to Products" link is rendered
+ * - sanitizeWordPressContent called for shortDescription (XSS guard)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SearchResults from '../SearchResults';
+
+// ─── Mock deps ────────────────────────────────────────────────────────────────
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { customerGroups: ['end-user'] } }),
+}));
+
+vi.mock('@/lib/navigation', () => ({
+  Link: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} data-testid="result-image" />
+  ),
+}));
+
+vi.mock('@/lib/icons', () => ({
+  SearchIcon: () => <span data-testid="search-icon" />,
+  ArrowLeftIcon: () => <span data-testid="arrow-left-icon" />,
+}));
+
+vi.mock('@/lib/sanitizeDescription', () => ({
+  sanitizeWordPressContent: (html: string) => `[sanitized] ${html}`,
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+const baseTranslations = {
+  backToProducts: 'Back to Products',
+  title: 'Search Results',
+  resultsCount: '{count} result for "{query}"',
+  resultsCountPlural: '{count} results for "{query}"',
+  noResultsTitle: 'No Products Found',
+  noResultsDescription: 'We could not find anything for "{query}".',
+  browseButton: 'Browse Products',
+  contactButton: 'Contact Us',
+};
+
+function makeProduct(id: number, overrides: Record<string, unknown> = {}) {
+  return {
+    id: `prod-${id}`,
+    databaseId: id,
+    name: `Sensor ${id}`,
+    slug: `sensor-${id}`,
+    sku: `SKU-${id}`,
+    partNumber: null,
+    price: `$${id * 10}.00`,
+    shortDescription: null,
+    image: { sourceUrl: `https://example.com/img-${id}.jpg`, altText: `Sensor ${id}` },
+    productCategories: { nodes: [{ name: 'Temperature', slug: 'temperature' }] },
+    // camelCase field names as used by filterProductsByCustomerGroup
+    customerGroup1: 'END USER',
+    customerGroup2: null,
+    customerGroup3: null,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('SearchResults', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ─── Result count ─────────────────────────────────────────────────────────────
+
+  it('renders plural result count for multiple results', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1), makeProduct(2)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText(/2 results for.*sensor/i)).toBeInTheDocument();
+  });
+
+  it('renders singular result count for exactly 1 result', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText(/1 result for.*sensor/i)).toBeInTheDocument();
+  });
+
+  // ─── Empty state ──────────────────────────────────────────────────────────────
+
+  it('renders empty state heading when no results', () => {
+    render(
+      <SearchResults
+        products={[]}
+        query="xyz"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText('No Products Found')).toBeInTheDocument();
+  });
+
+  it('includes the query in the empty state description', () => {
+    render(
+      <SearchResults
+        products={[]}
+        query="xyz123"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    // The description text specifically contains the query (distinct from the result count line)
+    const allMatches = screen.getAllByText(/xyz123/);
+    expect(allMatches.length).toBeGreaterThan(0);
+    // The description paragraph should be one of them
+    const descEl = allMatches.find((el) => el.textContent?.includes('could not find'));
+    expect(descEl).toBeDefined();
+  });
+
+  it('renders Browse Products button in empty state', () => {
+    render(
+      <SearchResults products={[]} query="xyz" locale="en" translations={baseTranslations} />,
+    );
+    expect(screen.getByRole('link', { name: 'Browse Products' })).toBeInTheDocument();
+  });
+
+  it('renders Contact Us button in empty state', () => {
+    render(
+      <SearchResults products={[]} query="xyz" locale="en" translations={baseTranslations} />,
+    );
+    expect(screen.getByRole('link', { name: 'Contact Us' })).toBeInTheDocument();
+  });
+
+  // ─── Product rendering ────────────────────────────────────────────────────────
+
+  it('renders product names', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1), makeProduct(2)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText('Sensor 1')).toBeInTheDocument();
+    expect(screen.getByText('Sensor 2')).toBeInTheDocument();
+  });
+
+  it('renders product price', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(3)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText('$30.00')).toBeInTheDocument();
+  });
+
+  it('renders SKU badge when no partNumber', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1, { sku: 'ABC-001', partNumber: null })] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText('ABC-001')).toBeInTheDocument();
+  });
+
+  it('renders partNumber badge instead of SKU when present', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1, { sku: 'ABC-001', partNumber: 'PN-XYZ' })] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText('PN-XYZ')).toBeInTheDocument();
+    expect(screen.queryByText('ABC-001')).not.toBeInTheDocument();
+  });
+
+  it('renders category chip', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByText('Temperature')).toBeInTheDocument();
+  });
+
+  it('renders product image when available', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.getByTestId('result-image')).toBeInTheDocument();
+  });
+
+  it('does not render image when product has no image', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1, { image: null })] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(screen.queryByTestId('result-image')).not.toBeInTheDocument();
+  });
+
+  it('wraps each product in a link to /product/{slug}', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(7)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    const link = screen.getByRole('link', { name: /sensor 7/i });
+    expect(link).toHaveAttribute('href', '/product/sensor-7');
+  });
+
+  it('sanitizes shortDescription HTML before rendering', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1, { shortDescription: '<b>bold</b> desc' })] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    // Our mock prepends [sanitized] to confirm it was called
+    expect(screen.getByText(/\[sanitized\]/)).toBeInTheDocument();
+  });
+
+  // ─── Navigation link ──────────────────────────────────────────────────────────
+
+  it('renders "Back to Products" link', () => {
+    render(
+      <SearchResults products={[]} query="x" locale="en" translations={baseTranslations} />,
+    );
+    expect(screen.getByRole('link', { name: /back to products/i })).toBeInTheDocument();
+  });
+
+  // ─── Customer group filtering ─────────────────────────────────────────────────
+
+  it('hides products not accessible to the user customer group', () => {
+    // filterProductsByCustomerGroup reads customerGroup1/2/3 (camelCase ACF fields)
+    // A product with a restricted group (e.g. 'alc') won't show for an end-user
+    const restrictedProduct = makeProduct(99, {
+      // Use a title prefix that triggers group restriction
+      name: '(ALC) Restricted Sensor',
+      customerGroup1: null,
+      customerGroup2: null,
+      customerGroup3: null,
+    });
+    const publicProduct = makeProduct(1); // no group restriction
+
+    render(
+      <SearchResults
+        products={[publicProduct, restrictedProduct] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+
+    expect(screen.getByText('Sensor 1')).toBeInTheDocument();
+    // Restricted product should not appear for an end-user
+    expect(screen.queryByText('(ALC) Restricted Sensor')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Auth routes: login (17), me (14), logout (5), refresh (10)
- Revalidate route: secret guard, rate limit, tag validation (17)
- Search API route: query validation, dedup, customer group filter (20+)
- Category: FilterSidebar (17), CategoryContent (14)
- Pagination component (17)
- Search: SearchDropdown (24), SearchResults (24)

Total: 11 new test files, ~160 new tests, 1501 passing overall

