### PR TITLE
test: add cart, chat, detect-region, and posts API route tests

### DIFF
--- a/web/src/app/api/cart/__tests__/cart.test.ts
+++ b/web/src/app/api/cart/__tests__/cart.test.ts
@@ -1,0 +1,366 @@
+/**
+ * /api/cart route tests
+ *
+ * Covers:
+ * - GET /api/cart: success with/without session token, 500 error
+ * - POST /api/cart/add: validation, success, cookie set, 500 error
+ * - DELETE /api/cart/remove: 401 no session, validation, success, 500 error
+ * - PATCH /api/cart/update: 401 no session, validation (quantity ≥ 0), success, 500 error
+ * - DELETE /api/cart/clear: 401 no session, success, 500 error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetCart, mockAddToCart, mockRemoveItem, mockUpdateQuantity, mockEmptyCart } =
+  vi.hoisted(() => ({
+    mockGetCart: vi.fn(),
+    mockAddToCart: vi.fn(),
+    mockRemoveItem: vi.fn(),
+    mockUpdateQuantity: vi.fn(),
+    mockEmptyCart: vi.fn(),
+  }));
+
+vi.mock('@/lib/services/cart', () => ({
+  CartService: {
+    getCart: mockGetCart,
+    addToCart: mockAddToCart,
+    removeItem: mockRemoveItem,
+    updateQuantity: mockUpdateQuantity,
+    emptyCart: mockEmptyCart,
+  },
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+// ─── Import routes after mocks ────────────────────────────────────────────────
+
+import { GET as cartGet } from '../route';
+import { POST as cartAdd } from '../add/route';
+import { DELETE as cartRemove } from '../remove/route';
+import { PATCH as cartUpdate } from '../update/route';
+import { DELETE as cartClear } from '../clear/route';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const MOCK_CART = {
+  isEmpty: false,
+  total: '$150.00',
+  subtotal: '$150.00',
+  contents: { nodes: [{ key: 'abc123', quantity: 2, product: { node: { name: 'BAPI-Stat 4' } } }] },
+};
+
+function makeGet(path: string, cookies: Record<string, string> = {}) {
+  const url = `http://localhost${path}`;
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+  });
+}
+
+function makePost(path: string, body: unknown, cookies: Record<string, string> = {}) {
+  const url = `http://localhost${path}`;
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+  return new NextRequest(url, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(cookieHeader ? { cookie: cookieHeader } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeDelete(path: string, body: unknown, cookies: Record<string, string> = {}) {
+  const url = `http://localhost${path}`;
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+  return new NextRequest(url, {
+    method: 'DELETE',
+    headers: {
+      'content-type': 'application/json',
+      ...(cookieHeader ? { cookie: cookieHeader } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function makePatch(path: string, body: unknown, cookies: Record<string, string> = {}) {
+  const url = `http://localhost${path}`;
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${v}`)
+    .join('; ');
+  return new NextRequest(url, {
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json',
+      ...(cookieHeader ? { cookie: cookieHeader } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── GET /api/cart ─────────────────────────────────────────────────────────────
+
+describe('GET /api/cart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCart.mockResolvedValue({ cart: MOCK_CART });
+  });
+
+  it('returns cart data on success', async () => {
+    const req = makeGet('/api/cart');
+    const res = await cartGet(req);
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.cart).toEqual(MOCK_CART);
+  });
+
+  it('passes woo-session cookie to CartService', async () => {
+    const req = makeGet('/api/cart', { 'woo-session': 'tok123' });
+    await cartGet(req);
+    expect(mockGetCart).toHaveBeenCalledWith('tok123');
+  });
+
+  it('passes woocommerce-session cookie when woo-session absent', async () => {
+    const req = makeGet('/api/cart', { 'woocommerce-session': 'tok456' });
+    await cartGet(req);
+    expect(mockGetCart).toHaveBeenCalledWith('tok456');
+  });
+
+  it('passes undefined when no session cookie present', async () => {
+    const req = makeGet('/api/cart');
+    await cartGet(req);
+    expect(mockGetCart).toHaveBeenCalledWith(undefined);
+  });
+
+  it('returns 500 when CartService throws', async () => {
+    mockGetCart.mockRejectedValue(new Error('WooCommerce unreachable'));
+    const req = makeGet('/api/cart');
+    const res = await cartGet(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBeDefined();
+  });
+});
+
+// ─── POST /api/cart/add ────────────────────────────────────────────────────────
+
+describe('POST /api/cart/add', () => {
+  const CART_RESULT = {
+    addToCart: {
+      cart: MOCK_CART,
+      cartItem: { key: 'item-key-xyz' },
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddToCart.mockResolvedValue(CART_RESULT);
+  });
+
+  it('returns 400 when productId is missing', async () => {
+    const req = makePost('/api/cart/add', { quantity: 1 });
+    const res = await cartAdd(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when productId is not a positive integer', async () => {
+    const req = makePost('/api/cart/add', { productId: -5 });
+    const res = await cartAdd(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when quantity is not positive', async () => {
+    const req = makePost('/api/cart/add', { productId: 42, quantity: 0 });
+    const res = await cartAdd(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with cart and cartItem on success', async () => {
+    const req = makePost('/api/cart/add', { productId: 42, quantity: 2 });
+    const res = await cartAdd(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.cart).toEqual(MOCK_CART);
+    expect(json.cartKey).toBe('item-key-xyz');
+  });
+
+  it('calls CartService.addToCart with correct args including variationId', async () => {
+    const req = makePost('/api/cart/add', { productId: 10, quantity: 3, variationId: 99 });
+    await cartAdd(req);
+    expect(mockAddToCart).toHaveBeenCalledWith(10, 3, 99, undefined);
+  });
+
+  it('passes session token from woo-session cookie', async () => {
+    const req = makePost('/api/cart/add', { productId: 1 }, { 'woo-session': 'sess-abc' });
+    await cartAdd(req);
+    expect(mockAddToCart).toHaveBeenCalledWith(1, 1, undefined, 'sess-abc');
+  });
+
+  it('sets woo-cart-key cookie when cartItem.key is returned', async () => {
+    const req = makePost('/api/cart/add', { productId: 1 });
+    const res = await cartAdd(req);
+    const setCookie = res.headers.get('set-cookie');
+    expect(setCookie).toContain('woo-cart-key');
+    expect(setCookie).toContain('item-key-xyz');
+  });
+
+  it('does NOT set woo-cart-key when no key returned', async () => {
+    mockAddToCart.mockResolvedValue({ addToCart: { cart: MOCK_CART, cartItem: {} } });
+    const req = makePost('/api/cart/add', { productId: 1 });
+    const res = await cartAdd(req);
+    const setCookie = res.headers.get('set-cookie');
+    expect(setCookie).toBeNull();
+  });
+
+  it('returns 500 when CartService throws', async () => {
+    mockAddToCart.mockRejectedValue(new Error('GraphQL error'));
+    const req = makePost('/api/cart/add', { productId: 1 });
+    const res = await cartAdd(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── DELETE /api/cart/remove ───────────────────────────────────────────────────
+
+describe('DELETE /api/cart/remove', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRemoveItem.mockResolvedValue({ removeItemsFromCart: { cart: MOCK_CART } });
+  });
+
+  it('returns 401 when woocommerce-session cookie is absent', async () => {
+    const req = makeDelete('/api/cart/remove', { key: 'abc123' });
+    const res = await cartRemove(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when key is missing', async () => {
+    const req = makeDelete('/api/cart/remove', {}, { 'woocommerce-session': 'sess' });
+    const res = await cartRemove(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 200 with updated cart on success', async () => {
+    const req = makeDelete('/api/cart/remove', { key: 'abc123' }, { 'woocommerce-session': 'sess' });
+    const res = await cartRemove(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.cart).toEqual(MOCK_CART);
+  });
+
+  it('calls CartService.removeItem with correct key and session', async () => {
+    const req = makeDelete('/api/cart/remove', { key: 'key-99' }, { 'woocommerce-session': 'sess-xyz' });
+    await cartRemove(req);
+    expect(mockRemoveItem).toHaveBeenCalledWith('key-99', 'sess-xyz');
+  });
+
+  it('returns 500 when CartService throws', async () => {
+    mockRemoveItem.mockRejectedValue(new Error('network'));
+    const req = makeDelete('/api/cart/remove', { key: 'abc' }, { 'woocommerce-session': 'sess' });
+    const res = await cartRemove(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── PATCH /api/cart/update ────────────────────────────────────────────────────
+
+describe('PATCH /api/cart/update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateQuantity.mockResolvedValue({ updateItemQuantities: { cart: MOCK_CART } });
+  });
+
+  it('returns 401 when woocommerce-session cookie is absent', async () => {
+    const req = makePatch('/api/cart/update', { key: 'abc', quantity: 2 });
+    const res = await cartUpdate(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when key is missing', async () => {
+    const req = makePatch('/api/cart/update', { quantity: 2 }, { 'woocommerce-session': 'sess' });
+    const res = await cartUpdate(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when quantity is negative', async () => {
+    const req = makePatch('/api/cart/update', { key: 'abc', quantity: -1 }, { 'woocommerce-session': 'sess' });
+    const res = await cartUpdate(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('allows quantity 0 (removes item)', async () => {
+    const req = makePatch('/api/cart/update', { key: 'abc', quantity: 0 }, { 'woocommerce-session': 'sess' });
+    const res = await cartUpdate(req);
+    expect(res.status).toBe(200);
+    expect(mockUpdateQuantity).toHaveBeenCalledWith('abc', 0, 'sess');
+  });
+
+  it('returns 200 with updated cart on success', async () => {
+    const req = makePatch('/api/cart/update', { key: 'abc', quantity: 5 }, { 'woocommerce-session': 'sess' });
+    const res = await cartUpdate(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.cart).toEqual(MOCK_CART);
+  });
+
+  it('returns 500 when CartService throws', async () => {
+    mockUpdateQuantity.mockRejectedValue(new Error('timeout'));
+    const req = makePatch('/api/cart/update', { key: 'abc', quantity: 1 }, { 'woocommerce-session': 'sess' });
+    const res = await cartUpdate(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── DELETE /api/cart/clear ────────────────────────────────────────────────────
+
+describe('DELETE /api/cart/clear', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEmptyCart.mockResolvedValue({ emptyCart: { cart: { ...MOCK_CART, isEmpty: true, contents: { nodes: [] } } } });
+  });
+
+  it('returns 401 when woocommerce-session cookie is absent', async () => {
+    const req = new NextRequest('http://localhost/api/cart/clear', { method: 'DELETE' });
+    const res = await cartClear(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with empty cart on success', async () => {
+    const req = makeDelete('/api/cart/clear', {}, { 'woocommerce-session': 'sess' });
+    const res = await cartClear(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(json.cart.isEmpty).toBe(true);
+  });
+
+  it('calls CartService.emptyCart with session token', async () => {
+    const req = makeDelete('/api/cart/clear', {}, { 'woocommerce-session': 'sess-abc' });
+    await cartClear(req);
+    expect(mockEmptyCart).toHaveBeenCalledWith('sess-abc');
+  });
+
+  it('returns 500 when CartService throws', async () => {
+    mockEmptyCart.mockRejectedValue(new Error('WooCommerce error'));
+    const req = makeDelete('/api/cart/clear', {}, { 'woocommerce-session': 'sess' });
+    const res = await cartClear(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/web/src/app/api/chat/__tests__/chat-analytics.test.ts
+++ b/web/src/app/api/chat/__tests__/chat-analytics.test.ts
@@ -1,0 +1,141 @@
+/**
+ * /api/chat/analytics route tests
+ *
+ * Covers:
+ * - GET ?view=metrics: 401 unauthenticated, 403 non-admin, returns metrics
+ * - GET ?view=recent: returns conversations list
+ * - GET ?view=negative-feedback: returns negative feedback conversations
+ * - GET ?view=invalid: 400 invalid view param
+ * - 500 on unexpected error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const {
+  mockRequireAdmin,
+  mockGetChatMetrics,
+  mockGetRecentConversations,
+  mockGetNegativeFeedback,
+} = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockGetChatMetrics: vi.fn(),
+  mockGetRecentConversations: vi.fn(),
+  mockGetNegativeFeedback: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/server', () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+vi.mock('@/lib/chat/analytics', () => ({
+  getChatMetrics: mockGetChatMetrics,
+  getRecentConversations: mockGetRecentConversations,
+  getNegativeFeedbackConversations: mockGetNegativeFeedback,
+  updateChatFeedback: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { GET } from '../analytics/route';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeGet(view?: string, limit?: string) {
+  const params = new URLSearchParams();
+  if (view) params.set('view', view);
+  if (limit) params.set('limit', limit);
+  return new NextRequest(`http://localhost/api/chat/analytics?${params.toString()}`);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/chat/analytics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockRequireAdmin.mockRejectedValue(new Error('Unauthorized: Not authenticated'));
+    const req = makeGet('metrics');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toMatch(/Authentication required/);
+  });
+
+  it('returns 403 when user is not an admin', async () => {
+    mockRequireAdmin.mockRejectedValue(new Error('Forbidden: Admin access required'));
+    const req = makeGet('metrics');
+    const res = await GET(req);
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toMatch(/Admin access required/);
+  });
+
+  it('returns metrics on ?view=metrics (default)', async () => {
+    mockRequireAdmin.mockResolvedValue({ id: 'admin-1', roles: ['administrator'] });
+    const METRICS = { totalConversations: 50, avgRating: 4.2 };
+    mockGetChatMetrics.mockResolvedValue(METRICS);
+
+    const req = makeGet(); // no view param → defaults to metrics
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual(METRICS);
+  });
+
+  it('returns recent conversations on ?view=recent', async () => {
+    mockRequireAdmin.mockResolvedValue({});
+    const CONVOS = [{ id: 'c1' }, { id: 'c2' }];
+    mockGetRecentConversations.mockResolvedValue(CONVOS);
+
+    const req = makeGet('recent', '10');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.conversations).toEqual(CONVOS);
+    expect(mockGetRecentConversations).toHaveBeenCalledWith(10);
+  });
+
+  it('uses default limit of 50 for ?view=recent', async () => {
+    mockRequireAdmin.mockResolvedValue({});
+    mockGetRecentConversations.mockResolvedValue([]);
+    const req = makeGet('recent');
+    await GET(req);
+    expect(mockGetRecentConversations).toHaveBeenCalledWith(50);
+  });
+
+  it('returns negative feedback conversations on ?view=negative-feedback', async () => {
+    mockRequireAdmin.mockResolvedValue({});
+    const NEGATIVE = [{ id: 'n1', feedback: 'negative' }];
+    mockGetNegativeFeedback.mockResolvedValue(NEGATIVE);
+
+    const req = makeGet('negative-feedback');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.conversations).toEqual(NEGATIVE);
+  });
+
+  it('returns 400 for unrecognised view param', async () => {
+    mockRequireAdmin.mockResolvedValue({});
+    const req = makeGet('dashboard');
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid view/);
+  });
+
+  it('returns 500 on unexpected analytics error', async () => {
+    mockRequireAdmin.mockResolvedValue({});
+    mockGetChatMetrics.mockRejectedValue(new Error('DB connection lost'));
+    const req = makeGet('metrics');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+});

--- a/web/src/app/api/chat/__tests__/chat-feedback.test.ts
+++ b/web/src/app/api/chat/__tests__/chat-feedback.test.ts
@@ -1,0 +1,96 @@
+/**
+ * /api/chat/feedback route tests
+ *
+ * Covers:
+ * - POST: 400 for missing fields, 400 for invalid feedback value, 200 success, 500 error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockUpdateChatFeedback } = vi.hoisted(() => ({
+  mockUpdateChatFeedback: vi.fn(),
+}));
+
+vi.mock('@/lib/chat/analytics', () => ({
+  updateChatFeedback: mockUpdateChatFeedback,
+  getChatMetrics: vi.fn(),
+  getRecentConversations: vi.fn(),
+  getNegativeFeedbackConversations: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { POST } from '../feedback/route';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makePost(body: unknown) {
+  return new NextRequest('http://localhost/api/chat/feedback', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/chat/feedback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateChatFeedback.mockResolvedValue(undefined);
+  });
+
+  it('returns 400 when conversationId is missing', async () => {
+    const req = makePost({ feedback: 'positive' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/conversationId/);
+  });
+
+  it('returns 400 when feedback is missing', async () => {
+    const req = makePost({ conversationId: 'conv-1' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/feedback/);
+  });
+
+  it('returns 400 when feedback value is invalid', async () => {
+    const req = makePost({ conversationId: 'conv-1', feedback: 'meh' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/"positive" or "negative"/);
+  });
+
+  it('returns 200 on positive feedback', async () => {
+    const req = makePost({ conversationId: 'conv-1', feedback: 'positive' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(mockUpdateChatFeedback).toHaveBeenCalledWith('conv-1', 'positive', undefined);
+  });
+
+  it('returns 200 on negative feedback with comment', async () => {
+    const req = makePost({ conversationId: 'conv-2', feedback: 'negative', comment: 'Wrong answer' });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    expect(mockUpdateChatFeedback).toHaveBeenCalledWith('conv-2', 'negative', 'Wrong answer');
+  });
+
+  it('returns 500 when updateChatFeedback throws', async () => {
+    mockUpdateChatFeedback.mockRejectedValue(new Error('DB error'));
+    const req = makePost({ conversationId: 'conv-1', feedback: 'positive' });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toMatch(/Failed to submit feedback/);
+  });
+});

--- a/web/src/app/api/chat/__tests__/chat-handoff.test.ts
+++ b/web/src/app/api/chat/__tests__/chat-handoff.test.ts
@@ -1,0 +1,234 @@
+/**
+ * /api/chat/handoff route tests
+ *
+ * Covers:
+ * - POST: 400 for missing required fields, 400 for invalid email, 200 success shape,
+ *   persists to file, sends email notification, 500 on error
+ * - GET: 401 unauthenticated, 403 non-admin, returns sorted handoffs, 500 on error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const {
+  mockRequireAdmin,
+  mockWriteFile,
+  mockMkdir,
+  mockReadFile,
+  mockAccess,
+  mockSendChatHandoffNotification,
+} = vi.hoisted(() => ({
+  mockRequireAdmin: vi.fn(),
+  mockWriteFile: vi.fn(),
+  mockMkdir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockAccess: vi.fn(),
+  mockSendChatHandoffNotification: vi.fn(),
+}));
+
+vi.mock('@/lib/auth/server', () => ({
+  requireAdmin: mockRequireAdmin,
+}));
+
+// The handoff route uses `import { promises as fs } from 'fs'`
+// so we mock the `promises` property of the 'fs' module
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      writeFile: mockWriteFile,
+      mkdir: mockMkdir,
+      readFile: mockReadFile,
+      access: mockAccess,
+    },
+  },
+  promises: {
+    writeFile: mockWriteFile,
+    mkdir: mockMkdir,
+    readFile: mockReadFile,
+    access: mockAccess,
+  },
+}));
+
+vi.mock('@/lib/email', () => ({
+  sendChatHandoffNotification: mockSendChatHandoffNotification,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { POST, GET } from '../handoff/route';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_BODY = {
+  name: 'Jane Engineer',
+  email: 'jane@acme.com',
+  topic: 'technical' as const,
+  message: 'Need help selecting a duct sensor for 40°C environments.',
+  language: 'en',
+};
+
+function makePost(body: unknown) {
+  return new NextRequest('http://localhost/api/chat/handoff', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+function makeGet() {
+  return new NextRequest('http://localhost/api/chat/handoff');
+}
+
+function setupEmptyHandoffs() {
+  mockMkdir.mockResolvedValue(undefined);
+  // access resolves → file exists, no need to create
+  mockAccess.mockResolvedValue(undefined);
+  mockReadFile.mockResolvedValue(JSON.stringify({ handoffs: [] }));
+  mockWriteFile.mockResolvedValue(undefined);
+  mockSendChatHandoffNotification.mockResolvedValue({ success: true, messageId: 'msg-1' });
+}
+
+// ─── POST tests ───────────────────────────────────────────────────────────────
+
+describe('POST /api/chat/handoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupEmptyHandoffs();
+  });
+
+  it.each([
+    [{ ...VALID_BODY, name: undefined }, 'name'],
+    [{ ...VALID_BODY, email: undefined }, 'email'],
+    [{ ...VALID_BODY, topic: undefined }, 'topic'],
+    [{ ...VALID_BODY, message: undefined }, 'message'],
+  ] as const)('returns 400 when %s field is missing', async (body) => {
+    const req = makePost(body);
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Missing required fields/);
+  });
+
+  it('returns 400 when email format is invalid', async () => {
+    const req = makePost({ ...VALID_BODY, email: 'not-an-email' });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/Invalid email/);
+  });
+
+  it('returns 200 with handoffId on success', async () => {
+    const req = makePost(VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.success).toBe(true);
+    expect(typeof json.handoffId).toBe('string');
+    expect(json.handoffId).toMatch(/^handoff-/);
+  });
+
+  it('persists handoff with status "pending" to file', async () => {
+    const req = makePost(VALID_BODY);
+    await POST(req);
+
+    expect(mockWriteFile).toHaveBeenCalled();
+    const writtenContent = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
+    expect(writtenContent.handoffs).toHaveLength(1);
+    expect(writtenContent.handoffs[0].status).toBe('pending');
+    expect(writtenContent.handoffs[0].name).toBe('Jane Engineer');
+    expect(writtenContent.handoffs[0].email).toBe('jane@acme.com');
+  });
+
+  it('sends email notification', async () => {
+    const req = makePost(VALID_BODY);
+    await POST(req);
+    expect(mockSendChatHandoffNotification).toHaveBeenCalledOnce();
+  });
+
+  it('accepts optional phone and conversationContext', async () => {
+    const req = makePost({
+      ...VALID_BODY,
+      phone: '+1-555-1234',
+      conversationContext: 'User: Hello\nAssistant: Hi there',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const written = JSON.parse(mockWriteFile.mock.calls[0][1] as string);
+    expect(written.handoffs[0].phone).toBe('+1-555-1234');
+  });
+
+  it('creates data dir when it does not exist yet', async () => {
+    // access rejects → file does not exist, should write new file
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    const req = makePost(VALID_BODY);
+    await POST(req);
+    // mkdir should be called for ensure
+    expect(mockMkdir).toHaveBeenCalled();
+  });
+
+  it('returns 500 when writeFile throws', async () => {
+    mockWriteFile.mockRejectedValue(new Error('disk full'));
+    const req = makePost(VALID_BODY);
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+  });
+});
+
+// ─── GET tests ────────────────────────────────────────────────────────────────
+
+describe('GET /api/chat/handoff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ id: 'admin-1' });
+    mockMkdir.mockResolvedValue(undefined);
+    mockAccess.mockResolvedValue(undefined);
+  });
+
+  it('returns 401 when user is not authenticated', async () => {
+    mockRequireAdmin.mockRejectedValue(new Error('Unauthorized: Not authenticated'));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockRequireAdmin.mockRejectedValue(new Error('Forbidden: Admin access required'));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns handoffs sorted newest-first', async () => {
+    const HANDOFFS = [
+      { id: 'h1', timestamp: '2026-06-10T10:00:00Z', status: 'pending' },
+      { id: 'h2', timestamp: '2026-06-19T12:00:00Z', status: 'pending' },
+      { id: 'h3', timestamp: '2026-06-15T08:00:00Z', status: 'contacted' },
+    ];
+    mockReadFile.mockResolvedValue(JSON.stringify({ handoffs: HANDOFFS }));
+
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.handoffs[0].id).toBe('h2');
+    expect(json.handoffs[1].id).toBe('h3');
+    expect(json.handoffs[2].id).toBe('h1');
+  });
+
+  it('returns empty array when no handoffs on file', async () => {
+    mockReadFile.mockResolvedValue(JSON.stringify({ handoffs: [] }));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.handoffs).toEqual([]);
+  });
+
+  // Note: readHandoffs() silently catches file-read errors and returns []
+  // The only way to reach the catch block in GET is a non-auth error from requireAdmin
+  it('returns 500 on unexpected non-auth error', async () => {
+    mockRequireAdmin.mockRejectedValue(new Error('DB connection lost'));
+    const res = await GET(makeGet());
+    expect(res.status).toBe(500);
+  });
+});

--- a/web/src/app/api/chat/__tests__/chat-handoff.test.ts
+++ b/web/src/app/api/chat/__tests__/chat-handoff.test.ts
@@ -101,11 +101,11 @@ describe('POST /api/chat/handoff', () => {
   });
 
   it.each([
-    [{ ...VALID_BODY, name: undefined }, 'name'],
-    [{ ...VALID_BODY, email: undefined }, 'email'],
-    [{ ...VALID_BODY, topic: undefined }, 'topic'],
-    [{ ...VALID_BODY, message: undefined }, 'message'],
-  ] as const)('returns 400 when %s field is missing', async (body) => {
+    ['name', { ...VALID_BODY, name: undefined }],
+    ['email', { ...VALID_BODY, email: undefined }],
+    ['topic', { ...VALID_BODY, topic: undefined }],
+    ['message', { ...VALID_BODY, message: undefined }],
+  ] as const)('returns 400 when %s field is missing', async (_field, body) => {
     const req = makePost(body);
     const res = await POST(req);
     expect(res.status).toBe(400);

--- a/web/src/app/api/detect-region/__tests__/detect-region.test.ts
+++ b/web/src/app/api/detect-region/__tests__/detect-region.test.ts
@@ -1,0 +1,119 @@
+/**
+ * /api/detect-region route tests
+ *
+ * Covers:
+ * - Returns correct region and language from x-vercel-ip-country header
+ * - Falls back to US/en for unknown country codes
+ * - Falls back to US/en when header is absent
+ * - Includes city from x-vercel-ip-city header
+ * - Maps EU countries to 'eu' region
+ * - Maps language-specific countries (DE→de, FR→fr, AR→ar, PL→pl)
+ * - Returns detected: true on success, detected: false on fallback
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+import { GET } from '../route';
+
+function makeGet(headers: Record<string, string> = {}) {
+  return new NextRequest('http://localhost/api/detect-region', { headers });
+}
+
+describe('GET /api/detect-region', () => {
+  it('returns us region and en language for US', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'US' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('us');
+    expect(json.language).toBe('en');
+    expect(json.country).toBe('US');
+    expect(json.countryName).toBe('United States');
+    expect(json.detected).toBe(true);
+  });
+
+  it('defaults to US when header is absent', async () => {
+    const req = makeGet();
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('us');
+    expect(json.language).toBe('en');
+    expect(json.country).toBe('US');
+  });
+
+  it('returns eu region for German IP', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'DE' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('eu');
+    expect(json.language).toBe('de');
+    expect(json.countryName).toBe('Germany');
+  });
+
+  it('returns eu region for French IP', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'FR' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('eu');
+    expect(json.language).toBe('fr');
+  });
+
+  it('returns uk region for GB', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'GB' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('uk');
+    expect(json.language).toBe('en'); // GB not in language map → default en
+  });
+
+  it('returns mena region and ar language for UAE', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'AE' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('mena');
+    expect(json.language).toBe('ar');
+  });
+
+  it('returns pl region and pl language for Poland', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'PL' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('pl');
+    expect(json.language).toBe('pl');
+  });
+
+  it('falls back to us/en for unknown country code', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'ZZ' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.region).toBe('us');
+    expect(json.language).toBe('en');
+    // unknown country code returned as-is
+    expect(json.country).toBe('ZZ');
+  });
+
+  it('includes city from x-vercel-ip-city header', async () => {
+    const req = makeGet({ 'x-vercel-ip-country': 'US', 'x-vercel-ip-city': 'Chicago' });
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.city).toBe('Chicago');
+  });
+
+  it('includes a timestamp in the response', async () => {
+    const req = makeGet();
+    const res = await GET(req);
+    const json = await res.json();
+    expect(json.timestamp).toBeDefined();
+    expect(new Date(json.timestamp).getTime()).not.toBeNaN();
+  });
+
+  it('returns 200 status code', async () => {
+    const req = makeGet();
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+  });
+});

--- a/web/src/app/api/detect-region/__tests__/detect-region.test.ts
+++ b/web/src/app/api/detect-region/__tests__/detect-region.test.ts
@@ -8,7 +8,8 @@
  * - Includes city from x-vercel-ip-city header
  * - Maps EU countries to 'eu' region
  * - Maps language-specific countries (DE→de, FR→fr, AR→ar, PL→pl)
- * - Returns detected: true on success, detected: false on fallback
+ * - Returns detected: true on success (even for unknown/missing country fallback)
+ * - Returns detected: false only in the catch/error path
  */
 
 import { describe, it, expect, vi } from 'vitest';

--- a/web/src/app/api/posts/__tests__/posts.test.ts
+++ b/web/src/app/api/posts/__tests__/posts.test.ts
@@ -1,0 +1,93 @@
+/**
+ * /api/posts route tests
+ *
+ * Covers:
+ * - POST: success with default perPage, custom perPage, cursor pagination, clamps large perPage, 500 error
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetPosts } = vi.hoisted(() => ({
+  mockGetPosts: vi.fn(),
+}));
+
+vi.mock('@/lib/wordpress', () => ({
+  getPosts: mockGetPosts,
+}));
+
+import { POST } from '../route';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const MOCK_POSTS = [{ id: 1, title: 'Post One' }, { id: 2, title: 'Post Two' }];
+const MOCK_PAGE_INFO = { hasNextPage: true, endCursor: 'cursor-abc' };
+
+function makePost(body: unknown) {
+  return new NextRequest('http://localhost/api/posts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('POST /api/posts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPosts.mockResolvedValue({ posts: MOCK_POSTS, pageInfo: MOCK_PAGE_INFO });
+  });
+
+  it('returns posts with default perPage of 12', async () => {
+    const req = makePost({});
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.posts).toEqual(MOCK_POSTS);
+    expect(json.pageInfo).toEqual(MOCK_PAGE_INFO);
+    expect(mockGetPosts).toHaveBeenCalledWith({ perPage: 12, after: undefined });
+  });
+
+  it('passes custom perPage to getPosts', async () => {
+    const req = makePost({ perPage: 24 });
+    await POST(req);
+    expect(mockGetPosts).toHaveBeenCalledWith({ perPage: 24, after: undefined });
+  });
+
+  it('passes after cursor for pagination', async () => {
+    const req = makePost({ perPage: 12, after: 'cursor-abc' });
+    await POST(req);
+    expect(mockGetPosts).toHaveBeenCalledWith({ perPage: 12, after: 'cursor-abc' });
+  });
+
+  it('clamps perPage to max 100', async () => {
+    const req = makePost({ perPage: 999 });
+    await POST(req);
+    expect(mockGetPosts).toHaveBeenCalledWith({ perPage: 100, after: undefined });
+  });
+
+  // perPage: 0 is falsy so `Number(0) || 12` evaluates to 12 (not 0)
+  it('treats perPage 0 as falsy — defaults to 12', async () => {
+    const req = makePost({ perPage: 0 });
+    await POST(req);
+    expect(mockGetPosts).toHaveBeenCalledWith({ perPage: 12, after: undefined });
+  });
+
+  it('handles non-numeric perPage gracefully (defaults to 12)', async () => {
+    const req = makePost({ perPage: 'lots' });
+    await POST(req);
+    expect(mockGetPosts).toHaveBeenCalledWith({ perPage: 12, after: undefined });
+  });
+
+  it('returns 500 when getPosts throws', async () => {
+    mockGetPosts.mockRejectedValue(new Error('GraphQL error'));
+    const req = makePost({});
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
- cart (29 tests): GET cart, POST add-to-cart (validation, cookie, session), DELETE remove (401 guard, zod validation), PATCH update (qty≥0 rule), DELETE clear (401 guard, success, 500)
- chat/feedback (6 tests): 400 missing fields, 400 invalid value, 200 positive/negative, 500
- chat/analytics (8 tests): 401/403 auth guards, metrics/recent/negative-feedback views, 400 invalid view, 500
- chat/handoff (16 tests): POST 400 validation + email regex, success shape, file persistence, email notification, dir creation, 500; GET 401/403 guards, sorted newest-first, 500 via non-auth error
  - Fixed: route uses `import { promises as fs } from 'fs'` so mock targets the `promises` property of 'fs' module (not 'fs/promises')
- detect-region (11 tests): US default, EU/UK/MENA/PL regions, language mapping, unknown country fallback, city header, timestamp
- posts (7 tests): default perPage=12, custom perPage, cursor pagination, clamp to 100, perPage=0 falsy → 12, 500

Total: 1,693 tests passing (63 files + 1 skipped)

