### PR TITLE
test(hooks): add tests for useAuth, useSearch, useRecentlyViewed, use…

### DIFF
--- a/web/src/hooks/__tests__/useAuth.test.ts
+++ b/web/src/hooks/__tests__/useAuth.test.ts
@@ -1,0 +1,186 @@
+/**
+ * useAuth hook tests
+ *
+ * Uses vi.spyOn(global, 'fetch') to intercept calls before Node.js URL
+ * parsing (which rejects relative URLs). MSW remains active for other tests.
+ *
+ * Covers:
+ * - Initial state: user null, isLoaded false, isSignedIn false
+ * - 200 response → user populated, isSignedIn true
+ * - 401/403 response → user null, isSignedIn false, isLoaded true
+ * - Network error → graceful fallback, isLoaded true
+ * - No state update after unmount
+ *
+ * signIn: success, body passthrough, server error, network failure
+ * signOut: POSTs to logout endpoint, redirects to /
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuth, signIn, signOut } from '../useAuth';
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchSpy = vi.spyOn(global, 'fetch');
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: { reload: vi.fn(), href: '' },
+  });
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_USER = {
+  id: 'user-1',
+  email: 'jane@example.com',
+  displayName: 'Jane Doe',
+  username: 'janedoe',
+  customerGroups: ['reseller'],
+};
+
+// ─── useAuth ─────────────────────────────────────────────────────────────────
+
+describe('useAuth', () => {
+  it('starts with loading state: user null, isLoaded false, isSignedIn false', () => {
+    fetchSpy.mockImplementation(() => new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useAuth());
+    expect(result.current.user).toBeNull();
+    expect(result.current.isLoaded).toBe(false);
+    expect(result.current.isSignedIn).toBe(false);
+  });
+
+  it('sets user and isSignedIn true on 200 response', async () => {
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse({ user: MOCK_USER }));
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.user).toEqual(MOCK_USER);
+    expect(result.current.isSignedIn).toBe(true);
+  });
+
+  it('sets isSignedIn false on 401 response', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.user).toBeNull();
+    expect(result.current.isSignedIn).toBe(false);
+  });
+
+  it('sets isSignedIn false on 403 response', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 403 }));
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.user).toBeNull();
+    expect(result.current.isSignedIn).toBe(false);
+  });
+
+  it('sets isLoaded true and user null on network error', async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const { result } = renderHook(() => useAuth());
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+    expect(result.current.user).toBeNull();
+    expect(result.current.isSignedIn).toBe(false);
+  });
+
+  it('does not update state after unmount', async () => {
+    let resolveRequest!: (r: Response) => void;
+    fetchSpy.mockImplementationOnce(
+      () => new Promise<Response>((res) => { resolveRequest = res; })
+    );
+    const { result, unmount } = renderHook(() => useAuth());
+    unmount();
+    resolveRequest(makeJsonResponse({ user: MOCK_USER }));
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.isLoaded).toBe(false); // unchanged after unmount
+  });
+});
+
+// ─── signIn ──────────────────────────────────────────────────────────────────
+
+describe('signIn', () => {
+  it('returns success: true on 200 response', async () => {
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse({ token: 'abc' }));
+    const result = await signIn('janedoe', 'password123');
+    expect(result.success).toBe(true);
+  });
+
+  it('sends username and password in request body', async () => {
+    let capturedBody: unknown;
+    fetchSpy.mockImplementationOnce((_url: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = JSON.parse(init?.body as string);
+      return Promise.resolve(makeJsonResponse({ token: 'abc' }));
+    });
+    await signIn('janedoe', 'pass123');
+    expect(capturedBody).toEqual({ username: 'janedoe', password: 'pass123' });
+  });
+
+  it('calls /api/auth/login with POST', async () => {
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse({ token: 'abc' }));
+    await signIn('janedoe', 'pass123');
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/login', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('returns success: false with server error message', async () => {
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse({ message: 'Invalid credentials' }, 401));
+    const result = await signIn('janedoe', 'wrong');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Invalid credentials');
+  });
+
+  it('returns success: false with fallback when no message in response', async () => {
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse({}, 401));
+    const result = await signIn('janedoe', 'wrong');
+    expect(result.success).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns success: false with Network error on fetch failure', async () => {
+    fetchSpy.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const result = await signIn('janedoe', 'password');
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Network error');
+  });
+
+  it('reloads window on success', async () => {
+    fetchSpy.mockResolvedValueOnce(makeJsonResponse({ token: 'abc' }));
+    await signIn('janedoe', 'password123');
+    expect(window.location.reload).toHaveBeenCalledOnce();
+  });
+});
+
+// ─── signOut ─────────────────────────────────────────────────────────────────
+
+describe('signOut', () => {
+  it('POSTs to /api/auth/logout', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await signOut();
+    expect(fetchSpy).toHaveBeenCalledWith('/api/auth/logout', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('sets window.location.href to / after logout', async () => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status: 200 }));
+    await signOut();
+    expect(window.location.href).toBe('/');
+  });
+});

--- a/web/src/hooks/__tests__/useAuth.test.ts
+++ b/web/src/hooks/__tests__/useAuth.test.ts
@@ -35,10 +35,12 @@ function makeJsonResponse(body: unknown, status = 200): Response {
 // ─── Setup ───────────────────────────────────────────────────────────────────
 
 let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>;
+let locationDescriptor: PropertyDescriptor | undefined;
 
 beforeEach(() => {
   vi.clearAllMocks();
   fetchSpy = vi.spyOn(global, 'fetch');
+  locationDescriptor = Object.getOwnPropertyDescriptor(window, 'location');
   Object.defineProperty(window, 'location', {
     configurable: true,
     writable: true,
@@ -48,6 +50,9 @@ beforeEach(() => {
 
 afterEach(() => {
   fetchSpy.mockRestore();
+  if (locationDescriptor) {
+    Object.defineProperty(window, 'location', locationDescriptor);
+  }
 });
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────

--- a/web/src/hooks/__tests__/useProductComparison.test.ts
+++ b/web/src/hooks/__tests__/useProductComparison.test.ts
@@ -1,0 +1,193 @@
+/**
+ * useProductComparison hook tests
+ *
+ * Pure localStorage hook – no fetch calls.
+ *
+ * Covers:
+ * - Initializes empty when localStorage is empty
+ * - Loads existing items from localStorage on mount
+ * - addToComparison: adds product, no-op if already present, no-op at max
+ * - removeFromComparison: removes by id
+ * - clearComparison: resets to []
+ * - isInComparison: returns true/false
+ * - canAddMore: true when < 3, false at max
+ * - count: correct length
+ * - Syncs to localStorage on change
+ * - Handles corrupt localStorage gracefully
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useProductComparison } from '../useProductComparison';
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const STORAGE_KEY = 'bapi-product-comparison';
+
+function makeProduct(id: string, name = `Product ${id}`) {
+  return {
+    id,
+    databaseId: Number(id),
+    name,
+    slug: `product-${id}`,
+    __typename: 'SimpleProduct' as const,
+    price: '$10.00',
+    stockStatus: 'IN_STOCK' as const,
+    shortDescription: null,
+    description: null,
+    image: null,
+    galleryImages: { nodes: [] },
+    variations: { nodes: [] },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('useProductComparison – initialization', () => {
+  it('starts empty when localStorage has no data', () => {
+    const { result } = renderHook(() => useProductComparison());
+    expect(result.current.comparisonProducts).toEqual([]);
+    expect(result.current.count).toBe(0);
+    expect(result.current.canAddMore).toBe(true);
+  });
+
+  it('loads existing items from localStorage on mount', () => {
+    const products = [makeProduct('1'), makeProduct('2')];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(products));
+
+    const { result } = renderHook(() => useProductComparison());
+    expect(result.current.comparisonProducts).toHaveLength(2);
+    expect(result.current.count).toBe(2);
+  });
+
+  it('handles corrupt localStorage data gracefully', () => {
+    localStorage.setItem(STORAGE_KEY, 'invalid-json{{{');
+    const { result } = renderHook(() => useProductComparison());
+    // Hook should start empty without throwing
+    expect(result.current.comparisonProducts).toEqual([]);
+  });
+});
+
+describe('useProductComparison – addToComparison', () => {
+  it('adds a product', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    expect(result.current.comparisonProducts).toHaveLength(1);
+    expect(result.current.comparisonProducts[0].id).toBe('1');
+  });
+
+  it('is a no-op when product is already in list', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    expect(result.current.comparisonProducts).toHaveLength(1);
+  });
+
+  it('is a no-op when max of 3 is reached', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.addToComparison(makeProduct('2')); });
+    act(() => { result.current.addToComparison(makeProduct('3')); });
+    act(() => { result.current.addToComparison(makeProduct('4')); }); // should be ignored
+    expect(result.current.comparisonProducts).toHaveLength(3);
+  });
+
+  it('does not add the 4th product even when different', () => {
+    const { result } = renderHook(() => useProductComparison());
+    ['1', '2', '3', '4'].forEach((id) => {
+      act(() => { result.current.addToComparison(makeProduct(id)); });
+    });
+    const ids = result.current.comparisonProducts.map((p) => p.id);
+    expect(ids).not.toContain('4');
+  });
+});
+
+describe('useProductComparison – removeFromComparison', () => {
+  it('removes a product by id', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.addToComparison(makeProduct('2')); });
+    act(() => { result.current.removeFromComparison('1'); });
+    expect(result.current.comparisonProducts).toHaveLength(1);
+    expect(result.current.comparisonProducts[0].id).toBe('2');
+  });
+
+  it('is a no-op when id is not in list', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.removeFromComparison('999'); });
+    expect(result.current.comparisonProducts).toHaveLength(1);
+  });
+});
+
+describe('useProductComparison – clearComparison', () => {
+  it('clears all products', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.addToComparison(makeProduct('2')); });
+    act(() => { result.current.clearComparison(); });
+    expect(result.current.comparisonProducts).toEqual([]);
+  });
+});
+
+describe('useProductComparison – isInComparison', () => {
+  it('returns true when product is in comparison', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    expect(result.current.isInComparison('1')).toBe(true);
+  });
+
+  it('returns false when product is not in comparison', () => {
+    const { result } = renderHook(() => useProductComparison());
+    expect(result.current.isInComparison('999')).toBe(false);
+  });
+});
+
+describe('useProductComparison – canAddMore', () => {
+  it('is true when below max', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    expect(result.current.canAddMore).toBe(true);
+  });
+
+  it('is false when at max of 3', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.addToComparison(makeProduct('2')); });
+    act(() => { result.current.addToComparison(makeProduct('3')); });
+    expect(result.current.canAddMore).toBe(false);
+  });
+});
+
+describe('useProductComparison – localStorage persistence', () => {
+  it('saves to localStorage after adding', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('1');
+  });
+
+  it('updates localStorage after removing', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.addToComparison(makeProduct('2')); });
+    act(() => { result.current.removeFromComparison('1'); });
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('2');
+  });
+
+  it('clears localStorage after clearComparison', () => {
+    const { result } = renderHook(() => useProductComparison());
+    act(() => { result.current.addToComparison(makeProduct('1')); });
+    act(() => { result.current.clearComparison(); });
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    expect(stored).toEqual([]);
+  });
+});

--- a/web/src/hooks/__tests__/useRecentlyViewed.test.ts
+++ b/web/src/hooks/__tests__/useRecentlyViewed.test.ts
@@ -6,7 +6,7 @@
  * Covers:
  * - Initializes empty when localStorage is empty
  * - Loads existing items from localStorage on mount
- * - addToRecentlyViewed: appends, deduplicates (moves to front), enforces max 5
+ * - addToRecentlyViewed: prepends to front, deduplicates (moves to front), enforces max 5
  * - clearRecentlyViewed: resets to []
  * - Syncs to localStorage on change
  * - Handles corrupt localStorage gracefully (clears bad data)

--- a/web/src/hooks/__tests__/useRecentlyViewed.test.ts
+++ b/web/src/hooks/__tests__/useRecentlyViewed.test.ts
@@ -1,0 +1,144 @@
+/**
+ * useRecentlyViewed hook tests
+ *
+ * Pure localStorage hook – no fetch calls.
+ *
+ * Covers:
+ * - Initializes empty when localStorage is empty
+ * - Loads existing items from localStorage on mount
+ * - addToRecentlyViewed: appends, deduplicates (moves to front), enforces max 5
+ * - clearRecentlyViewed: resets to []
+ * - Syncs to localStorage on change
+ * - Handles corrupt localStorage gracefully (clears bad data)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRecentlyViewed } from '../useRecentlyViewed';
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const STORAGE_KEY = 'bapi-recently-viewed';
+
+// Minimal Product shape required by the hook
+function makeProduct(id: string, name = `Product ${id}`) {
+  return {
+    id,
+    databaseId: Number(id),
+    name,
+    slug: `product-${id}`,
+    __typename: 'SimpleProduct' as const,
+    price: '$10.00',
+    stockStatus: 'IN_STOCK' as const,
+    shortDescription: null,
+    description: null,
+    image: null,
+    galleryImages: { nodes: [] },
+    variations: { nodes: [] },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('useRecentlyViewed – initialization', () => {
+  it('starts empty when localStorage has no data', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    expect(result.current.recentlyViewed).toEqual([]);
+    expect(result.current.count).toBe(0);
+  });
+
+  it('loads existing items from localStorage on mount', () => {
+    const products = [makeProduct('1'), makeProduct('2')];
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(products));
+
+    const { result } = renderHook(() => useRecentlyViewed());
+    expect(result.current.recentlyViewed).toHaveLength(2);
+    expect(result.current.recentlyViewed[0].id).toBe('1');
+  });
+
+  it('handles corrupt localStorage data gracefully', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{');
+    const { result } = renderHook(() => useRecentlyViewed());
+    // Hook should start empty without throwing
+    expect(result.current.recentlyViewed).toEqual([]);
+  });
+});
+
+describe('useRecentlyViewed – addToRecentlyViewed', () => {
+  it('adds a product to an empty list', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    expect(result.current.recentlyViewed).toHaveLength(1);
+    expect(result.current.recentlyViewed[0].id).toBe('1');
+  });
+
+  it('prepends new products to front of list', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    act(() => { result.current.addToRecentlyViewed(makeProduct('2')); });
+    expect(result.current.recentlyViewed[0].id).toBe('2');
+    expect(result.current.recentlyViewed[1].id).toBe('1');
+  });
+
+  it('moves existing product to front (deduplication)', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    act(() => { result.current.addToRecentlyViewed(makeProduct('2')); });
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); }); // re-add '1'
+    expect(result.current.recentlyViewed).toHaveLength(2);
+    expect(result.current.recentlyViewed[0].id).toBe('1'); // moved to front
+    expect(result.current.recentlyViewed[1].id).toBe('2');
+  });
+
+  it('enforces max 5 items (FIFO – oldest dropped)', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    for (let i = 1; i <= 6; i++) {
+      act(() => { result.current.addToRecentlyViewed(makeProduct(String(i))); });
+    }
+    expect(result.current.recentlyViewed).toHaveLength(5);
+    expect(result.current.recentlyViewed[0].id).toBe('6'); // newest at front
+    // Product '1' should be dropped
+    expect(result.current.recentlyViewed.find((p) => p.id === '1')).toBeUndefined();
+  });
+
+  it('increments count correctly', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    act(() => { result.current.addToRecentlyViewed(makeProduct('2')); });
+    expect(result.current.count).toBe(2);
+  });
+});
+
+describe('useRecentlyViewed – clearRecentlyViewed', () => {
+  it('clears all items', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    act(() => { result.current.addToRecentlyViewed(makeProduct('2')); });
+    act(() => { result.current.clearRecentlyViewed(); });
+    expect(result.current.recentlyViewed).toEqual([]);
+    expect(result.current.count).toBe(0);
+  });
+});
+
+describe('useRecentlyViewed – localStorage persistence', () => {
+  it('saves to localStorage after adding a product', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('1');
+  });
+
+  it('clears localStorage after clearRecentlyViewed', () => {
+    const { result } = renderHook(() => useRecentlyViewed());
+    act(() => { result.current.addToRecentlyViewed(makeProduct('1')); });
+    act(() => { result.current.clearRecentlyViewed(); });
+    const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+    expect(stored).toEqual([]);
+  });
+});

--- a/web/src/hooks/__tests__/useSearch.test.ts
+++ b/web/src/hooks/__tests__/useSearch.test.ts
@@ -11,11 +11,11 @@
  * - Successful search → results populated
  * - API error → results cleared
  * - Network error → results cleared
- * - AbortController: rapid typing cancels previous request
+ * - AbortController: rapid typing aborts in-flight request
+ * - Unmount: aborts any pending in-flight request
  * - handleSelect → navigates to /product/{slug}, clears state
  * - handleViewAll → navigates to /search?q=..., clears state
  * - clear() → resets all state
- * - Cleanup on unmount: aborts pending requests
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -56,6 +56,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.clearAllTimers();
   fetchSpy.mockRestore();
   vi.useRealTimers();
 });
@@ -253,5 +254,50 @@ describe('useSearch – clear', () => {
     expect(result.current.results).toEqual([]);
     expect(result.current.isOpen).toBe(false);
     expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe('useSearch – AbortController', () => {
+  it('aborts in-flight request when a new search fires', async () => {
+    let firstSignal!: AbortSignal;
+    fetchSpy.mockImplementation((_url, init) => {
+      if (!firstSignal) {
+        firstSignal = (init as RequestInit).signal as AbortSignal;
+        // Keep first request hanging so it stays in-flight
+        return new Promise<Response>(() => {});
+      }
+      return Promise.resolve(makeSearchResponse(MOCK_PRODUCTS));
+    });
+
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    // First search fires
+    act(() => { result.current.handleQueryChange('se'); });
+    await act(() => vi.advanceTimersByTimeAsync(150));
+    expect(firstSignal.aborted).toBe(false);
+
+    // Second search fires → first should be aborted
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(150));
+    expect(firstSignal.aborted).toBe(true);
+  });
+});
+
+describe('useSearch – unmount cleanup', () => {
+  it('aborts pending in-flight request on unmount', async () => {
+    let capturedSignal!: AbortSignal;
+    fetchSpy.mockImplementation((_url, init) => {
+      capturedSignal = (init as RequestInit).signal as AbortSignal;
+      return new Promise<Response>(() => {}); // never resolves
+    });
+
+    const { result, unmount } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(150));
+    expect(capturedSignal.aborted).toBe(false);
+
+    unmount();
+    expect(capturedSignal.aborted).toBe(true);
   });
 });

--- a/web/src/hooks/__tests__/useSearch.test.ts
+++ b/web/src/hooks/__tests__/useSearch.test.ts
@@ -1,0 +1,257 @@
+/**
+ * useSearch hook tests
+ *
+ * Uses vi.spyOn(global, 'fetch') (relative URL fix) + vi.useFakeTimers() for debounce.
+ * Mocks @/lib/navigation to capture router.push calls.
+ *
+ * Covers:
+ * - Initial state
+ * - Queries below minChars → no fetch, results cleared
+ * - Debounce: fetch fires after delay, not before
+ * - Successful search → results populated
+ * - API error → results cleared
+ * - Network error → results cleared
+ * - AbortController: rapid typing cancels previous request
+ * - handleSelect → navigates to /product/{slug}, clears state
+ * - handleViewAll → navigates to /search?q=..., clears state
+ * - clear() → resets all state
+ * - Cleanup on unmount: aborts pending requests
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSearch } from '../useSearch';
+
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+
+const mockPush = vi.fn();
+vi.mock('@/lib/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeSearchResponse(products: object[]) {
+  return new Response(
+    JSON.stringify({ products: { nodes: products } }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } }
+  );
+}
+
+const MOCK_PRODUCTS = [
+  { id: '1', databaseId: 1, name: 'Sensor A', slug: 'sensor-a', price: '$10.00' },
+  { id: '2', databaseId: 2, name: 'Sensor B', slug: 'sensor-b', price: '$20.00' },
+];
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+  fetchSpy = vi.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+  vi.useRealTimers();
+});
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useSearch – initial state', () => {
+  it('starts with empty query, no results, not loading, not open', () => {
+    const { result } = renderHook(() => useSearch());
+    expect(result.current.query).toBe('');
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isOpen).toBe(false);
+  });
+});
+
+describe('useSearch – minChars guard', () => {
+  it('does not fetch when query is below minChars', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 300, minChars: 2 }));
+
+    act(() => { result.current.handleQueryChange('a'); });
+    await act(() => vi.advanceTimersByTimeAsync(500));
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.current.results).toEqual([]);
+  });
+
+  it('clears results and closes dropdown when query drops below minChars', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    // First get results
+    act(() => { result.current.handleQueryChange('ab'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    // Then clear
+    act(() => { result.current.handleQueryChange('a'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isOpen).toBe(false);
+  });
+});
+
+describe('useSearch – debounce', () => {
+  it('does not fetch before debounce delay', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 300 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+
+    // Before debounce fires
+    await act(() => vi.advanceTimersByTimeAsync(100));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches after debounce delay', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 300 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(400));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.results).toEqual(MOCK_PRODUCTS);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('resets debounce on rapid typing (only fires once)', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 300 }));
+
+    act(() => { result.current.handleQueryChange('se'); });
+    await act(() => vi.advanceTimersByTimeAsync(100));
+    act(() => { result.current.handleQueryChange('sen'); });
+    await act(() => vi.advanceTimersByTimeAsync(100));
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(400));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useSearch – fetch results', () => {
+  it('populates results and sets isLoading false on success', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(result.current.results).toEqual(MOCK_PRODUCTS);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sends query in POST body', async () => {
+    let capturedBody: unknown;
+    fetchSpy.mockImplementation((_url, init) => {
+      capturedBody = JSON.parse(init?.body as string);
+      return Promise.resolve(makeSearchResponse([]));
+    });
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(capturedBody).toEqual({ query: 'sensor' });
+  });
+
+  it('clears results on API error response', async () => {
+    fetchSpy.mockResolvedValue(new Response(null, { status: 500 }));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('clears results on network error', async () => {
+    fetchSpy.mockRejectedValue(new TypeError('Failed to fetch'));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles empty products.nodes gracefully', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse([]));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('zzz'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    expect(result.current.results).toEqual([]);
+  });
+});
+
+describe('useSearch – handleSelect', () => {
+  it('navigates to /product/{slug}', async () => {
+    const { result } = renderHook(() => useSearch());
+    act(() => { result.current.handleSelect('sensor-a'); });
+    expect(mockPush).toHaveBeenCalledWith('/product/sensor-a');
+  });
+
+  it('closes dropdown and clears query on select', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+    act(() => { result.current.handleSelect('sensor-a'); });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.query).toBe('');
+  });
+});
+
+describe('useSearch – handleViewAll', () => {
+  it('navigates to /search?q= with encoded query', async () => {
+    const { result } = renderHook(() => useSearch({ minChars: 2 }));
+
+    act(() => { result.current.handleQueryChange('sensor x'); });
+    act(() => { result.current.handleViewAll(); });
+
+    expect(mockPush).toHaveBeenCalledWith('/search?q=sensor%20x');
+  });
+
+  it('does not navigate when query is below minChars', () => {
+    const { result } = renderHook(() => useSearch({ minChars: 2 }));
+
+    act(() => { result.current.handleQueryChange('s'); });
+    act(() => { result.current.handleViewAll(); });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSearch – clear', () => {
+  it('resets query, results, isOpen, and isLoading', async () => {
+    fetchSpy.mockResolvedValue(makeSearchResponse(MOCK_PRODUCTS));
+    const { result } = renderHook(() => useSearch({ debounceMs: 100 }));
+
+    act(() => { result.current.handleQueryChange('sensor'); });
+    await act(() => vi.advanceTimersByTimeAsync(200));
+
+    act(() => { result.current.clear(); });
+
+    expect(result.current.query).toBe('');
+    expect(result.current.results).toEqual([]);
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+});

--- a/web/src/hooks/__tests__/useUserProfile.test.ts
+++ b/web/src/hooks/__tests__/useUserProfile.test.ts
@@ -1,0 +1,138 @@
+/**
+ * useUserProfile hook tests
+ *
+ * useUserProfile is a thin wrapper over useAuth() that conditionally
+ * injects mock profile data when isMockDataEnabled() returns true.
+ *
+ * Strategy: mock @/hooks/useAuth and @/lib/mock-user-data.
+ *
+ * Covers:
+ * - Not loaded → isLoaded false, profile null
+ * - Loaded but not signed in → isSignedIn false, profile null
+ * - Signed in, mock data enabled, user has mock profile → profile populated, isMockData true
+ * - Signed in, mock data enabled, user has NO mock profile → profile null, isMockData false
+ * - Signed in, mock data disabled → profile null, isMockData false
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useUserProfile } from '../useUserProfile';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockUseAuth = vi.fn();
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }));
+
+const mockIsMockDataEnabled = vi.fn();
+const mockGetMockUserData = vi.fn();
+vi.mock('@/lib/mock-user-data', () => ({
+  isMockDataEnabled: () => mockIsMockDataEnabled(),
+  getMockUserData: (id: string) => mockGetMockUserData(id),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_AUTH_USER = {
+  id: 'user-1',
+  email: 'jane@example.com',
+  displayName: 'Jane Doe',
+  username: 'janedoe',
+  customerGroups: ['reseller'],
+};
+
+const MOCK_PROFILE = {
+  userId: 'user-1',
+  companyName: 'Acme Corp',
+  accountNumber: 'ACC-001',
+  billingAddress: { street: '1 Main St', city: 'Anytown', state: 'CA', zip: '90210', country: 'US' },
+  shippingAddresses: [],
+  paymentMethods: [],
+  orderHistory: [],
+  preferences: { currency: 'USD', language: 'en', measurementSystem: 'imperial' },
+};
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+beforeEach(() => { vi.clearAllMocks(); });
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('useUserProfile – not yet loaded', () => {
+  it('returns isLoaded false and profile null while auth is loading', () => {
+    mockUseAuth.mockReturnValue({ user: null, isLoaded: false, isSignedIn: false });
+    mockIsMockDataEnabled.mockReturnValue(false);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    expect(result.current.isLoaded).toBe(false);
+    expect(result.current.isSignedIn).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.profile).toBeNull();
+    expect(result.current.isMockData).toBe(false);
+  });
+});
+
+describe('useUserProfile – loaded, not signed in', () => {
+  it('returns isSignedIn false and profile null', () => {
+    mockUseAuth.mockReturnValue({ user: null, isLoaded: true, isSignedIn: false });
+    mockIsMockDataEnabled.mockReturnValue(false);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    expect(result.current.isLoaded).toBe(true);
+    expect(result.current.isSignedIn).toBe(false);
+    expect(result.current.profile).toBeNull();
+  });
+});
+
+describe('useUserProfile – signed in with mock data', () => {
+  it('returns mock profile and isMockData true when mock data is enabled', () => {
+    mockUseAuth.mockReturnValue({ user: MOCK_AUTH_USER, isLoaded: true, isSignedIn: true });
+    mockIsMockDataEnabled.mockReturnValue(true);
+    mockGetMockUserData.mockReturnValue(MOCK_PROFILE);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    expect(result.current.isLoaded).toBe(true);
+    expect(result.current.isSignedIn).toBe(true);
+    expect(result.current.user).toEqual(MOCK_AUTH_USER);
+    expect(result.current.profile).toEqual(MOCK_PROFILE);
+    expect(result.current.isMockData).toBe(true);
+  });
+
+  it('calls getMockUserData with the user id', () => {
+    mockUseAuth.mockReturnValue({ user: MOCK_AUTH_USER, isLoaded: true, isSignedIn: true });
+    mockIsMockDataEnabled.mockReturnValue(true);
+    mockGetMockUserData.mockReturnValue(MOCK_PROFILE);
+
+    renderHook(() => useUserProfile());
+
+    expect(mockGetMockUserData).toHaveBeenCalledWith('user-1');
+  });
+});
+
+describe('useUserProfile – signed in, mock enabled, no mock profile for user', () => {
+  it('falls through to real data path (profile null, isMockData false)', () => {
+    mockUseAuth.mockReturnValue({ user: MOCK_AUTH_USER, isLoaded: true, isSignedIn: true });
+    mockIsMockDataEnabled.mockReturnValue(true);
+    mockGetMockUserData.mockReturnValue(null); // no mock data for this user
+
+    const { result } = renderHook(() => useUserProfile());
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.isMockData).toBe(false);
+  });
+});
+
+describe('useUserProfile – signed in, mock data disabled', () => {
+  it('returns profile null and isMockData false in production mode', () => {
+    mockUseAuth.mockReturnValue({ user: MOCK_AUTH_USER, isLoaded: true, isSignedIn: true });
+    mockIsMockDataEnabled.mockReturnValue(false);
+
+    const { result } = renderHook(() => useUserProfile());
+
+    expect(result.current.profile).toBeNull();
+    expect(result.current.isMockData).toBe(false);
+    expect(mockGetMockUserData).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…ProductComparison, useUserProfile

- useAuth (15 tests): initial state, 200/401/403/network error paths, unmount cleanup, signIn success/error/body passthrough, signOut POST + redirect. Uses vi.spyOn(global, 'fetch') to bypass Node.js relative-URL limitation while MSW remains active for other test files.

- useSearch (16 tests): initial state, minChars guard, debounce timing, fetch success/error/network, request body passthrough, handleSelect/ handleViewAll navigation, clear() reset.

- useRecentlyViewed (11 tests): init empty/from localStorage/corrupt, add/prepend/dedup/max-5, clear, localStorage sync.

- useProductComparison (17 tests): init empty/from localStorage/corrupt, add/no-op-duplicate/no-op-at-max, remove, clear, isInComparison, canAddMore, localStorage sync.

- useUserProfile (6 tests): not loaded, signed out, mock data enabled+found, mock data enabled+not found, mock data disabled.

Total: 65 new tests → suite now 1,758 passing across 68 files.


