### PR TITLE
test(lib): add Tier 2 tests for readTime, regionLanguageMapping, imag…

### DIFF
--- a/web/src/lib/__tests__/image.test.ts
+++ b/web/src/lib/__tests__/image.test.ts
@@ -1,0 +1,276 @@
+/**
+ * image.ts tests
+ *
+ * Pure utility functions and configuration constants — no mocking needed.
+ *
+ * Covers:
+ * - getImageDimensions: WxH pattern in filename → {width, height}; no pattern → null
+ * - optimizeImageUrl: appends w/h/quality/format params; relative/invalid URL → as-is
+ * - isExternalImage: http:// and https:// → true; relative/protocol-relative → false
+ * - getOptimizedImagePath: replaces .jpg/.jpeg/.png with .webp; .webp → unchanged;
+ *   no matching extension → unchanged
+ * - getImageProps: returns correct config objects for each image type
+ * - generatePlaceholder: returns base64 data URI
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getImageDimensions,
+  optimizeImageUrl,
+  isExternalImage,
+  getOptimizedImagePath,
+  getImageProps,
+  generatePlaceholder,
+  IMAGE_QUALITY,
+  IMAGE_SIZES,
+  RESPONSIVE_SIZES,
+} from '../utils/image';
+
+// ─── getImageDimensions ───────────────────────────────────────────────────────
+
+describe('getImageDimensions', () => {
+  describe('matches WxH pattern in filename', () => {
+    it('extracts dimensions from dash-separated filename', () => {
+      expect(getImageDimensions('photo-800x600.jpg')).toEqual({ width: 800, height: 600 });
+    });
+
+    it('extracts dimensions from underscore-separated filename', () => {
+      expect(getImageDimensions('photo_1200x900.png')).toEqual({ width: 1200, height: 900 });
+    });
+
+    it('extracts dimensions from full URL path', () => {
+      expect(getImageDimensions('https://cdn.example.com/uploads/sensor-400x400.webp')).toEqual({
+        width: 400,
+        height: 400,
+      });
+    });
+
+    it('handles single-digit dimensions', () => {
+      expect(getImageDimensions('icon-16x16.png')).toEqual({ width: 16, height: 16 });
+    });
+
+    it('handles large dimensions', () => {
+      expect(getImageDimensions('hero-1920x1080.jpg')).toEqual({ width: 1920, height: 1080 });
+    });
+  });
+
+  describe('returns null when no pattern found', () => {
+    it('returns null for filename without dimensions', () => {
+      expect(getImageDimensions('photo.jpg')).toBeNull();
+    });
+
+    it('returns null for URL with no dimension pattern', () => {
+      expect(getImageDimensions('https://cdn.example.com/product-hero.jpg')).toBeNull();
+    });
+
+    it('returns null for empty string', () => {
+      expect(getImageDimensions('')).toBeNull();
+    });
+
+    it('returns null for filename with only one number', () => {
+      expect(getImageDimensions('image-800.jpg')).toBeNull();
+    });
+  });
+});
+
+// ─── optimizeImageUrl ─────────────────────────────────────────────────────────
+
+describe('optimizeImageUrl', () => {
+  const BASE = 'https://cms.example.com/uploads/sensor.jpg';
+
+  it('always adds format=webp', () => {
+    const result = optimizeImageUrl(BASE);
+    expect(result).toContain('format=webp');
+  });
+
+  it('adds width param when provided', () => {
+    const result = optimizeImageUrl(BASE, 400);
+    expect(result).toContain('w=400');
+  });
+
+  it('adds height param when provided', () => {
+    const result = optimizeImageUrl(BASE, undefined, 300);
+    expect(result).toContain('h=300');
+  });
+
+  it('adds quality param when provided', () => {
+    const result = optimizeImageUrl(BASE, undefined, undefined, 85);
+    expect(result).toContain('quality=85');
+  });
+
+  it('adds all params together', () => {
+    const result = optimizeImageUrl(BASE, 800, 600, 75);
+    expect(result).toContain('w=800');
+    expect(result).toContain('h=600');
+    expect(result).toContain('quality=75');
+    expect(result).toContain('format=webp');
+  });
+
+  it('does not add w param when width is undefined', () => {
+    const result = optimizeImageUrl(BASE, undefined, 300);
+    expect(result).not.toContain('w=');
+  });
+
+  it('preserves the original base URL', () => {
+    const result = optimizeImageUrl(BASE, 400);
+    expect(result).toContain('cms.example.com');
+    expect(result).toContain('sensor.jpg');
+  });
+
+  it('returns relative URL unchanged (cannot parse)', () => {
+    const relative = '/uploads/sensor.jpg';
+    expect(optimizeImageUrl(relative, 400)).toBe(relative);
+  });
+
+  it('returns invalid URL unchanged', () => {
+    expect(optimizeImageUrl('not-a-url', 400)).toBe('not-a-url');
+  });
+
+  it('works with URLs that already have query params', () => {
+    const url = 'https://cdn.example.com/img.jpg?v=2';
+    const result = optimizeImageUrl(url, 400);
+    expect(result).toContain('v=2');
+    expect(result).toContain('w=400');
+    expect(result).toContain('format=webp');
+  });
+});
+
+// ─── isExternalImage ──────────────────────────────────────────────────────────
+
+describe('isExternalImage', () => {
+  it('returns true for http:// URL', () => {
+    expect(isExternalImage('http://example.com/image.jpg')).toBe(true);
+  });
+
+  it('returns true for https:// URL', () => {
+    expect(isExternalImage('https://cdn.example.com/image.webp')).toBe(true);
+  });
+
+  it('returns false for root-relative path', () => {
+    expect(isExternalImage('/uploads/image.jpg')).toBe(false);
+  });
+
+  it('returns false for relative path', () => {
+    expect(isExternalImage('images/photo.jpg')).toBe(false);
+  });
+
+  it('returns false for protocol-relative URL', () => {
+    expect(isExternalImage('//cdn.example.com/image.jpg')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isExternalImage('')).toBe(false);
+  });
+});
+
+// ─── getOptimizedImagePath ────────────────────────────────────────────────────
+
+describe('getOptimizedImagePath', () => {
+  it('replaces .jpg extension with .webp', () => {
+    expect(getOptimizedImagePath('/uploads/sensor.jpg')).toBe('/uploads/sensor.webp');
+  });
+
+  it('replaces .jpeg extension with .webp', () => {
+    expect(getOptimizedImagePath('/uploads/photo.jpeg')).toBe('/uploads/photo.webp');
+  });
+
+  it('replaces .png extension with .webp', () => {
+    expect(getOptimizedImagePath('/uploads/logo.png')).toBe('/uploads/logo.webp');
+  });
+
+  it('is case-insensitive for extension', () => {
+    expect(getOptimizedImagePath('/uploads/image.JPG')).toBe('/uploads/image.webp');
+    expect(getOptimizedImagePath('/uploads/image.PNG')).toBe('/uploads/image.webp');
+  });
+
+  it('returns .webp path unchanged', () => {
+    expect(getOptimizedImagePath('/uploads/image.webp')).toBe('/uploads/image.webp');
+  });
+
+  it('returns path unchanged when no matching extension', () => {
+    expect(getOptimizedImagePath('/uploads/image.svg')).toBe('/uploads/image.svg');
+    expect(getOptimizedImagePath('/uploads/image.gif')).toBe('/uploads/image.gif');
+  });
+
+  it('works with full CDN URLs', () => {
+    expect(getOptimizedImagePath('https://cdn.example.com/product.jpg')).toBe(
+      'https://cdn.example.com/product.webp'
+    );
+  });
+});
+
+// ─── getImageProps ────────────────────────────────────────────────────────────
+
+describe('getImageProps', () => {
+  it('returns high quality for product type', () => {
+    expect(getImageProps('product').quality).toBe(IMAGE_QUALITY.high);
+  });
+
+  it('returns high quality and eager loading for hero type', () => {
+    const props = getImageProps('hero');
+    expect(props.quality).toBe(IMAGE_QUALITY.high);
+    expect(props.loading).toBe('eager');
+  });
+
+  it('returns thumbnail quality for thumbnail type', () => {
+    expect(getImageProps('thumbnail').quality).toBe(IMAGE_QUALITY.thumbnail);
+  });
+
+  it('returns lossless quality for logo type', () => {
+    expect(getImageProps('logo').quality).toBe(IMAGE_QUALITY.lossless);
+  });
+
+  it('returns correct sizes string for product', () => {
+    expect(getImageProps('product').sizes).toBe(RESPONSIVE_SIZES.productCard);
+  });
+
+  it('returns correct sizes string for hero', () => {
+    expect(getImageProps('hero').sizes).toBe(RESPONSIVE_SIZES.hero);
+  });
+
+  it('product with priority=true gets eager loading', () => {
+    expect(getImageProps('product', true).loading).toBe('eager');
+  });
+
+  it('product with priority=false (default) gets lazy loading', () => {
+    expect(getImageProps('product', false).loading).toBe('lazy');
+  });
+});
+
+// ─── generatePlaceholder ──────────────────────────────────────────────────────
+
+describe('generatePlaceholder', () => {
+  it('returns a data URI string', () => {
+    const result = generatePlaceholder(400, 300);
+    expect(result).toMatch(/^data:image\/svg\+xml;base64,/);
+  });
+
+  it('produces a non-empty base64 payload', () => {
+    const result = generatePlaceholder(100, 100);
+    const base64 = result.replace('data:image/svg+xml;base64,', '');
+    expect(base64.length).toBeGreaterThan(0);
+  });
+
+  it('produces different output for different dimensions', () => {
+    const a = generatePlaceholder(400, 300);
+    const b = generatePlaceholder(800, 600);
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─── IMAGE_SIZES constants ────────────────────────────────────────────────────
+
+describe('IMAGE_SIZES constants', () => {
+  it('product thumbnail is 80×80', () => {
+    expect(IMAGE_SIZES.product.thumbnail).toEqual({ width: 80, height: 80 });
+  });
+
+  it('product hero is 1200×1200', () => {
+    expect(IMAGE_SIZES.product.hero).toEqual({ width: 1200, height: 1200 });
+  });
+
+  it('category card is 400×225 (16:9)', () => {
+    const { width, height } = IMAGE_SIZES.category.card;
+    expect(width / height).toBeCloseTo(16 / 9, 1);
+  });
+});

--- a/web/src/lib/__tests__/readTime.test.ts
+++ b/web/src/lib/__tests__/readTime.test.ts
@@ -1,0 +1,190 @@
+/**
+ * readTime.ts tests
+ *
+ * Pure utility functions — no mocking needed.
+ *
+ * Covers:
+ * - calculateReadTime: empty/falsy → 1, word counting, 200 WPM default,
+ *   custom WPM, HTML tag stripping, minimum 1 minute, rounding up
+ * - formatReadTime: singular/plural phrasing
+ * - getCategoryColor: all known BAPI categories, unknown → default
+ */
+
+import { describe, it, expect } from 'vitest';
+import { calculateReadTime, formatReadTime, getCategoryColor } from '../utils/readTime';
+
+// ─── calculateReadTime ────────────────────────────────────────────────────────
+
+describe('calculateReadTime', () => {
+  describe('falsy / empty input', () => {
+    it('returns 1 for empty string', () => {
+      expect(calculateReadTime('')).toBe(1);
+    });
+
+    it('returns 1 for whitespace-only string', () => {
+      expect(calculateReadTime('   ')).toBe(1);
+    });
+
+    // Runtime safety: the signature is (string) but guard handles falsy
+    it('returns 1 for falsy value passed at runtime', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(calculateReadTime(null as any)).toBe(1);
+    });
+  });
+
+  describe('word counting with default 200 WPM', () => {
+    it('returns 1 for short content (< 200 words)', () => {
+      const words = Array(100).fill('word').join(' ');
+      expect(calculateReadTime(words)).toBe(1);
+    });
+
+    it('returns 1 for exactly 200 words', () => {
+      const words = Array(200).fill('word').join(' ');
+      expect(calculateReadTime(words)).toBe(1);
+    });
+
+    it('returns 2 for 201 words (rounds up)', () => {
+      const words = Array(201).fill('word').join(' ');
+      expect(calculateReadTime(words)).toBe(2);
+    });
+
+    it('returns 2 for 400 words', () => {
+      const words = Array(400).fill('word').join(' ');
+      expect(calculateReadTime(words)).toBe(2);
+    });
+
+    it('returns 5 for 1000 words', () => {
+      const words = Array(1000).fill('word').join(' ');
+      expect(calculateReadTime(words)).toBe(5);
+    });
+
+    it('returns 10 for 2000 words', () => {
+      const words = Array(2000).fill('word').join(' ');
+      expect(calculateReadTime(words)).toBe(10);
+    });
+  });
+
+  describe('HTML tag stripping', () => {
+    it('strips HTML tags before counting words', () => {
+      // 200 words wrapped in <p> tags — should still be 1 min
+      const words = Array(200).fill('word').join(' ');
+      const html = `<p>${words}</p>`;
+      expect(calculateReadTime(html)).toBe(1);
+    });
+
+    it('does not count tag names as words', () => {
+      const html = '<h1>Title</h1><p>One two three</p>';
+      // Only "Title One two three" = 4 words → 1 min
+      expect(calculateReadTime(html)).toBe(1);
+    });
+
+    it('handles deeply nested HTML', () => {
+      const words = Array(400).fill('word').join(' </span><span>');
+      const html = `<div><p><span>${words}</span></p></div>`;
+      expect(calculateReadTime(html)).toBe(2);
+    });
+  });
+
+  describe('custom wordsPerMinute', () => {
+    it('uses provided WPM when specified', () => {
+      const words = Array(100).fill('word').join(' '); // 100 words
+      // At 100 WPM → ceil(100/100) = 1
+      expect(calculateReadTime(words, 100)).toBe(1);
+      // At 50 WPM → ceil(100/50) = 2
+      expect(calculateReadTime(words, 50)).toBe(2);
+    });
+
+    it('minimum is always 1 even with very slow WPM on very short content', () => {
+      // 1 word at 1 WPM = ceil(1/1) = 1, max(1,1) = 1
+      expect(calculateReadTime('word', 1)).toBe(1);
+    });
+  });
+
+  describe('minimum 1 minute', () => {
+    it('never returns 0 for non-empty content', () => {
+      expect(calculateReadTime('hi')).toBeGreaterThanOrEqual(1);
+    });
+  });
+});
+
+// ─── formatReadTime ───────────────────────────────────────────────────────────
+
+describe('formatReadTime', () => {
+  it('formats 1 minute correctly', () => {
+    expect(formatReadTime(1)).toBe('1 min read');
+  });
+
+  it('formats 5 minutes correctly', () => {
+    expect(formatReadTime(5)).toBe('5 min read');
+  });
+
+  it('formats 10 minutes correctly', () => {
+    expect(formatReadTime(10)).toBe('10 min read');
+  });
+
+  it('uses the number provided without modification', () => {
+    expect(formatReadTime(3)).toBe('3 min read');
+  });
+});
+
+// ─── getCategoryColor ─────────────────────────────────────────────────────────
+
+describe('getCategoryColor', () => {
+  describe('product / announcement', () => {
+    it('returns yellow for "product"', () => {
+      expect(getCategoryColor('product')).toBe('bg-accent-500 text-neutral-900');
+    });
+
+    it('returns yellow for "Product Update"', () => {
+      expect(getCategoryColor('Product Update')).toBe('bg-accent-500 text-neutral-900');
+    });
+
+    it('returns yellow for "announcement"', () => {
+      expect(getCategoryColor('announcement')).toBe('bg-accent-500 text-neutral-900');
+    });
+  });
+
+  describe('news / industry', () => {
+    it('returns blue for "news"', () => {
+      expect(getCategoryColor('news')).toBe('bg-primary-500 text-white');
+    });
+
+    it('returns blue for "Industry Insights"', () => {
+      expect(getCategoryColor('Industry Insights')).toBe('bg-primary-500 text-white');
+    });
+  });
+
+  describe('technical / case study', () => {
+    it('returns gray for "technical"', () => {
+      expect(getCategoryColor('technical')).toBe('bg-neutral-500 text-white');
+    });
+
+    it('returns gray for "Case Study"', () => {
+      expect(getCategoryColor('Case Study')).toBe('bg-neutral-500 text-white');
+    });
+
+    it('returns gray for "case studies"', () => {
+      expect(getCategoryColor('case studies')).toBe('bg-neutral-500 text-white');
+    });
+  });
+
+  describe('events / webinars', () => {
+    it('returns green for "event"', () => {
+      expect(getCategoryColor('event')).toBe('bg-green-500 text-white');
+    });
+
+    it('returns green for "Webinar"', () => {
+      expect(getCategoryColor('Webinar')).toBe('bg-green-500 text-white');
+    });
+  });
+
+  describe('unknown / default', () => {
+    it('returns default for unrecognized category', () => {
+      expect(getCategoryColor('Miscellaneous')).toBe('bg-neutral-200 text-neutral-900');
+    });
+
+    it('returns default for empty string', () => {
+      expect(getCategoryColor('')).toBe('bg-neutral-200 text-neutral-900');
+    });
+  });
+});

--- a/web/src/lib/__tests__/readTime.test.ts
+++ b/web/src/lib/__tests__/readTime.test.ts
@@ -6,7 +6,7 @@
  * Covers:
  * - calculateReadTime: empty/falsy → 1, word counting, 200 WPM default,
  *   custom WPM, HTML tag stripping, minimum 1 minute, rounding up
- * - formatReadTime: singular/plural phrasing
+ * - formatReadTime: returns '${minutes} min read' (no pluralization)
  * - getCategoryColor: all known BAPI categories, unknown → default
  */
 

--- a/web/src/lib/__tests__/regionLanguageMapping.test.ts
+++ b/web/src/lib/__tests__/regionLanguageMapping.test.ts
@@ -1,0 +1,89 @@
+/**
+ * regionLanguageMapping.ts tests
+ *
+ * Pure lookup utilities — no mocking needed.
+ *
+ * Covers:
+ * - REGION_LANGUAGE_MAP: every region maps to the expected language
+ * - getSuggestedLanguage: returns correct LanguageCode for each RegionCode
+ * - getLanguageSuggestionMessage: correct message templates per region,
+ *   languageName interpolation, MENA-specific phrasing
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  REGION_LANGUAGE_MAP,
+  getSuggestedLanguage,
+  getLanguageSuggestionMessage,
+} from '../utils/regionLanguageMapping';
+import type { RegionCode } from '@/types/region';
+
+// ─── REGION_LANGUAGE_MAP ──────────────────────────────────────────────────────
+
+describe('REGION_LANGUAGE_MAP', () => {
+  it('maps us → en', () => expect(REGION_LANGUAGE_MAP.us).toBe('en'));
+  it('maps uk → en', () => expect(REGION_LANGUAGE_MAP.uk).toBe('en'));
+  it('maps eu → en', () => expect(REGION_LANGUAGE_MAP.eu).toBe('en'));
+  it('maps pl → pl', () => expect(REGION_LANGUAGE_MAP.pl).toBe('pl'));
+  it('maps mena → ar', () => expect(REGION_LANGUAGE_MAP.mena).toBe('ar'));
+
+  it('covers all 5 defined RegionCodes', () => {
+    const keys = Object.keys(REGION_LANGUAGE_MAP);
+    expect(keys).toHaveLength(5);
+    expect(keys).toContain('us');
+    expect(keys).toContain('uk');
+    expect(keys).toContain('eu');
+    expect(keys).toContain('pl');
+    expect(keys).toContain('mena');
+  });
+});
+
+// ─── getSuggestedLanguage ─────────────────────────────────────────────────────
+
+describe('getSuggestedLanguage', () => {
+  const cases: Array<[RegionCode, string]> = [
+    ['us', 'en'],
+    ['uk', 'en'],
+    ['eu', 'en'],
+    ['pl', 'pl'],
+    ['mena', 'ar'],
+  ];
+
+  for (const [region, expected] of cases) {
+    it(`returns '${expected}' for region '${region}'`, () => {
+      expect(getSuggestedLanguage(region)).toBe(expected);
+    });
+  }
+});
+
+// ─── getLanguageSuggestionMessage ─────────────────────────────────────────────
+
+describe('getLanguageSuggestionMessage', () => {
+  describe('standard "Switch to X?" regions', () => {
+    const standardRegions: RegionCode[] = ['us', 'uk', 'eu', 'pl'];
+
+    for (const region of standardRegions) {
+      it(`returns "Switch to English?" for region '${region}'`, () => {
+        expect(getLanguageSuggestionMessage(region, 'English')).toBe('Switch to English?');
+      });
+    }
+
+    it('interpolates any language name correctly', () => {
+      expect(getLanguageSuggestionMessage('pl', 'Polish')).toBe('Switch to Polish?');
+    });
+  });
+
+  describe('MENA region — distinct phrasing', () => {
+    it('returns "Switch to Arabic for this region?"', () => {
+      expect(getLanguageSuggestionMessage('mena', 'Arabic')).toBe(
+        'Switch to Arabic for this region?'
+      );
+    });
+
+    it('interpolates any language name for mena', () => {
+      expect(getLanguageSuggestionMessage('mena', 'French')).toBe(
+        'Switch to French for this region?'
+      );
+    });
+  });
+});

--- a/web/src/lib/__tests__/regionLanguageMapping.test.ts
+++ b/web/src/lib/__tests__/regionLanguageMapping.test.ts
@@ -16,7 +16,7 @@ import {
   getSuggestedLanguage,
   getLanguageSuggestionMessage,
 } from '../utils/regionLanguageMapping';
-import type { RegionCode } from '@/types/region';
+import type { RegionCode, LanguageCode } from '@/types/region';
 
 // ─── REGION_LANGUAGE_MAP ──────────────────────────────────────────────────────
 
@@ -41,7 +41,7 @@ describe('REGION_LANGUAGE_MAP', () => {
 // ─── getSuggestedLanguage ─────────────────────────────────────────────────────
 
 describe('getSuggestedLanguage', () => {
-  const cases: Array<[RegionCode, string]> = [
+  const cases: Array<[RegionCode, LanguageCode]> = [
     ['us', 'en'],
     ['uk', 'en'],
     ['eu', 'en'],


### PR DESCRIPTION
- readTime.ts (31 tests): calculateReadTime — falsy/empty→1, word counting at default 200 WPM (100/200/201/400/1000/2000 words), HTML tag stripping before count, custom WPM, minimum 1 guarantee; formatReadTime — correct 'N min read' format; getCategoryColor — product/announcement→yellow, news/industry→blue, technical/case-study→gray, event/webinar→green, unknown/empty→default neutral.

- regionLanguageMapping.ts (18 tests): REGION_LANGUAGE_MAP — all 5 region→ language pairs (us/uk/eu→en, pl→pl, mena→ar), key count; getSuggestedLanguage — all 5 RegionCodes; getLanguageSuggestionMessage — standard 'Switch to X?' phrasing for us/uk/eu/pl, distinct 'Switch to X for this region?' for mena, language name interpolation.

- image.ts (46 tests): getImageDimensions — dash/underscore/URL patterns, large dimensions, no-pattern→null, single number→null; optimizeImageUrl — always adds format=webp, w/h/quality params, no param when undefined, preserves base URL, relative/invalid→as-is, pre-existing query params preserved; isExternalImage — http/https→true, relative/root-relative/ protocol-relative→false; getOptimizedImagePath — jpg/jpeg/png→webp (case-insensitive), .webp unchanged, unrecognized extension unchanged, full CDN URL; getImageProps — quality/loading/sizes per type, priority flag effect; generatePlaceholder — data URI format, non-empty payload, dimension-sensitive output; IMAGE_SIZES constant spot-checks.

Total: 95 new tests → suite now 2,013 passing across 75 files.



