### PR TITLE
test(lib): add tests for wordpress-content, attributeDetection, produ…

### DIFF
--- a/web/src/lib/__tests__/attributeDetection.test.ts
+++ b/web/src/lib/__tests__/attributeDetection.test.ts
@@ -1,0 +1,166 @@
+/**
+ * attributeDetection.ts tests
+ *
+ * Pure attribute UI-type detection — no mocking needed.
+ *
+ * Covers:
+ * - detectAttributeType: color -> swatch, binary yes/no -> toggle,
+ *   binary with/without -> toggle, 2-4 short options -> radio,
+ *   5+ options -> dropdown, 2 non-binary options -> radio
+ * - isPositiveOption: yes/display/included/with .../included ... -> true; others -> false
+ * - getColorHex: named colors -> correct hex, case/trim insensitive,
+ *   partial match, unknown -> default gray
+ */
+
+import { describe, it, expect } from 'vitest';
+import { detectAttributeType, isPositiveOption, getColorHex } from '../attributeDetection';
+import type { ProductAttribute } from '@/types/variations';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function attr(name: string, options: string[], label = name): ProductAttribute {
+  return { id: '1', name, label, options, variation: true };
+}
+
+// ─── detectAttributeType ──────────────────────────────────────────────────────
+
+describe('detectAttributeType', () => {
+  describe('color-swatch', () => {
+    it('returns color-swatch for attribute with "color" in name', () => {
+      expect(detectAttributeType(attr('Housing Color', ['White', 'Black']))).toBe('color-swatch');
+    });
+
+    it('returns color-swatch for attribute with "color" in label', () => {
+      expect(detectAttributeType(attr('pa_color', ['Red', 'Blue'], 'Select Color'))).toBe('color-swatch');
+    });
+
+    it('is case-insensitive for color detection', () => {
+      expect(detectAttributeType(attr('HOUSING COLOR', ['White']))).toBe('color-swatch');
+    });
+  });
+
+  describe('binary-toggle', () => {
+    it('returns binary-toggle for Yes/No pair', () => {
+      expect(detectAttributeType(attr('Display', ['Yes', 'No']))).toBe('binary-toggle');
+    });
+
+    it('returns binary-toggle for Display/No Display pair', () => {
+      expect(detectAttributeType(attr('LCD', ['Display', 'No Display']))).toBe('binary-toggle');
+    });
+
+    it('returns binary-toggle for Included/Not Included pair', () => {
+      expect(detectAttributeType(attr('Accessory', ['Included', 'Not Included']))).toBe('binary-toggle');
+    });
+
+    it('returns binary-toggle when one option starts with "with "', () => {
+      expect(detectAttributeType(attr('Option', ['With Keypad', 'Standard']))).toBe('binary-toggle');
+    });
+
+    it('returns binary-toggle when one option starts with "without "', () => {
+      expect(detectAttributeType(attr('Option', ['Without LCD', 'Basic']))).toBe('binary-toggle');
+    });
+
+    it('is case-insensitive for binary detection', () => {
+      expect(detectAttributeType(attr('Display', ['YES', 'NO']))).toBe('binary-toggle');
+    });
+  });
+
+  describe('radio-group', () => {
+    it('returns radio-group for 2 non-binary short options', () => {
+      expect(detectAttributeType(attr('Range', ['0-10V', '4-20mA']))).toBe('radio-group');
+    });
+
+    it('returns radio-group for 3 short options', () => {
+      expect(detectAttributeType(attr('Type', ['A', 'B', 'C']))).toBe('radio-group');
+    });
+
+    it('returns radio-group for 4 short options', () => {
+      expect(detectAttributeType(attr('Size', ['XS', 'S', 'M', 'L']))).toBe('radio-group');
+    });
+  });
+
+  describe('dropdown', () => {
+    it('returns dropdown for 5 or more options', () => {
+      const options = ['A', 'B', 'C', 'D', 'E'];
+      expect(detectAttributeType(attr('Model', options))).toBe('dropdown');
+    });
+
+    it('returns dropdown for 0 options', () => {
+      expect(detectAttributeType(attr('Empty', []))).toBe('dropdown');
+    });
+
+    it('returns dropdown for long option text even with ≤4 options', () => {
+      const longOptions = [
+        'This is a very long option name exceeding fifty characters total here',
+        'Another long option name that also exceeds fifty chars exactly',
+      ];
+      expect(detectAttributeType(attr('Long', longOptions))).toBe('dropdown');
+    });
+  });
+});
+
+// ─── isPositiveOption ─────────────────────────────────────────────────────────
+
+describe('isPositiveOption', () => {
+  it('returns true for "yes"', () => expect(isPositiveOption('yes')).toBe(true));
+  it('returns true for "Yes" (case-insensitive)', () => expect(isPositiveOption('Yes')).toBe(true));
+  it('returns true for "YES"', () => expect(isPositiveOption('YES')).toBe(true));
+  it('returns true for "display"', () => expect(isPositiveOption('display')).toBe(true));
+  it('returns true for "Display"', () => expect(isPositiveOption('Display')).toBe(true));
+  it('returns true for "included"', () => expect(isPositiveOption('included')).toBe(true));
+  it('returns true for "with keypad"', () => expect(isPositiveOption('with keypad')).toBe(true));
+  it('returns true for "included accessory"', () => expect(isPositiveOption('included accessory')).toBe(true));
+
+  it('returns false for "no"', () => expect(isPositiveOption('no')).toBe(false));
+  it('returns false for "No Display"', () => expect(isPositiveOption('No Display')).toBe(false));
+  it('returns false for "Not Included"', () => expect(isPositiveOption('Not Included')).toBe(false));
+  it('returns false for "without lcd"', () => expect(isPositiveOption('without lcd')).toBe(false));
+  it('returns false for "standard"', () => expect(isPositiveOption('standard')).toBe(false));
+  it('returns false for empty string', () => expect(isPositiveOption('')).toBe(false));
+});
+
+// ─── getColorHex ──────────────────────────────────────────────────────────────
+
+describe('getColorHex', () => {
+  describe('direct color name matches', () => {
+    it('returns correct hex for white', () => expect(getColorHex('white')).toBe('#FFFFFF'));
+    it('returns correct hex for black', () => expect(getColorHex('black')).toBe('#000000'));
+    it('returns correct hex for gray', () => expect(getColorHex('gray')).toBe('#808080'));
+    it('returns correct hex for grey (alternate spelling)', () => expect(getColorHex('grey')).toBe('#808080'));
+    it('returns BAPI blue', () => expect(getColorHex('blue')).toBe('#166fb9'));
+    it('returns BAPI yellow', () => expect(getColorHex('yellow')).toBe('#FFC843'));
+    it('returns correct hex for bright white', () => expect(getColorHex('bright white')).toBe('#FFFFFF'));
+    it('returns correct hex for off white', () => expect(getColorHex('off white')).toBe('#F5F5DC'));
+  });
+
+  describe('case insensitivity and trimming', () => {
+    it('is case-insensitive', () => {
+      expect(getColorHex('White')).toBe('#FFFFFF');
+      expect(getColorHex('BLACK')).toBe('#000000');
+      expect(getColorHex('Blue')).toBe('#166fb9');
+    });
+
+    it('trims leading/trailing whitespace', () => {
+      expect(getColorHex(' white ')).toBe('#FFFFFF');
+    });
+  });
+
+  describe('partial match', () => {
+    it('matches color name when it appears anywhere in the input', () => {
+      // "bright white" contains "white", so partial match returns #FFFFFF
+      const result = getColorHex('Gloss White');
+      // partial match on "white" → #FFFFFF
+      expect(result).toBe('#FFFFFF');
+    });
+  });
+
+  describe('unknown colors', () => {
+    it('returns default gray #9CA3AF for unknown color', () => {
+      expect(getColorHex('ultraviolet')).toBe('#9CA3AF');
+    });
+
+    it('returns default gray for empty string', () => {
+      expect(getColorHex('')).toBe('#9CA3AF');
+    });
+  });
+});

--- a/web/src/lib/__tests__/productAttributeTranslations.test.ts
+++ b/web/src/lib/__tests__/productAttributeTranslations.test.ts
@@ -1,0 +1,156 @@
+/**
+ * productAttributeTranslations.ts tests
+ *
+ * Pure i18n mapping — no mocking needed.
+ *
+ * Covers:
+ * - getAttributeTranslationKey: exact match, all-caps variant, case-insensitive,
+ *   unknown label → original label returned (not null)
+ * - hasAttributeTranslation: true for known, false for unknown/empty
+ * - getSupportedAttributeLabels: returns array with expected entries
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  getAttributeTranslationKey,
+  hasAttributeTranslation,
+  getSupportedAttributeLabels,
+} from '../productAttributeTranslations';
+
+// ─── getAttributeTranslationKey ───────────────────────────────────────────────
+
+describe('getAttributeTranslationKey', () => {
+  describe('exact matches — temperature', () => {
+    it('maps Temperature Application', () => {
+      expect(getAttributeTranslationKey('Temperature Application')).toBe('temperature.application');
+    });
+
+    it('maps APPLICATION (all-caps variant)', () => {
+      expect(getAttributeTranslationKey('APPLICATION')).toBe('temperature.application');
+    });
+
+    it('maps Room Enclosure Style', () => {
+      expect(getAttributeTranslationKey('Room Enclosure Style')).toBe('temperature.roomEnclosure');
+    });
+
+    it('maps Temperature Sensor/Output', () => {
+      expect(getAttributeTranslationKey('Temperature Sensor/Output')).toBe('temperature.sensorOutput');
+    });
+
+    it('maps TEMPERATURE SENSOR (all-caps)', () => {
+      expect(getAttributeTranslationKey('TEMPERATURE SENSOR')).toBe('temperature.sensorOutput');
+    });
+  });
+
+  describe('exact matches — humidity', () => {
+    it('maps Humidity Application', () => {
+      expect(getAttributeTranslationKey('Humidity Application')).toBe('humidity.application');
+    });
+
+    it('maps HUMIDITY APPLICATION (all-caps)', () => {
+      expect(getAttributeTranslationKey('HUMIDITY APPLICATION')).toBe('humidity.application');
+    });
+
+    it('maps Humidity Sensor Output', () => {
+      expect(getAttributeTranslationKey('Humidity Sensor Output')).toBe('humidity.sensorOutput');
+    });
+
+    it('maps Humidity Output (title case variation)', () => {
+      expect(getAttributeTranslationKey('Humidity Output')).toBe('humidity.sensorOutput');
+    });
+  });
+
+  describe('exact matches — general', () => {
+    it('maps Display', () => {
+      expect(getAttributeTranslationKey('Display')).toBe('general.display');
+    });
+
+    it('maps DISPLAY (all-caps)', () => {
+      expect(getAttributeTranslationKey('DISPLAY')).toBe('general.display');
+    });
+
+    it('maps Voltage Range', () => {
+      expect(getAttributeTranslationKey('Voltage Range')).toBe('general.voltage');
+    });
+
+    it('maps Communication Protocol', () => {
+      expect(getAttributeTranslationKey('Communication Protocol')).toBe('general.protocol');
+    });
+  });
+
+  describe('case-insensitive fallback', () => {
+    it('matches "temperature application" (lowercase)', () => {
+      expect(getAttributeTranslationKey('temperature application')).toBe('temperature.application');
+    });
+
+    it('matches mixed-case variant not directly in map', () => {
+      expect(getAttributeTranslationKey('HUMIDITY ROOM ENCLOSURE')).toBe('humidity.roomEnclosure');
+    });
+  });
+
+  describe('unknown labels — returns original', () => {
+    it('returns the original label for an unmapped attribute', () => {
+      expect(getAttributeTranslationKey('Unknown Attribute')).toBe('Unknown Attribute');
+    });
+
+    it('returns the original label for empty string', () => {
+      // Edge case: empty string has no mapping — returns ''
+      expect(getAttributeTranslationKey('')).toBe('');
+    });
+  });
+});
+
+// ─── hasAttributeTranslation ──────────────────────────────────────────────────
+
+describe('hasAttributeTranslation', () => {
+  it('returns true for a known attribute label', () => {
+    expect(hasAttributeTranslation('Temperature Application')).toBe(true);
+  });
+
+  it('returns true for all-caps known variant', () => {
+    expect(hasAttributeTranslation('DISPLAY')).toBe(true);
+  });
+
+  it('returns true for case-insensitive match', () => {
+    expect(hasAttributeTranslation('humidity application')).toBe(true);
+  });
+
+  it('returns false for unknown attribute', () => {
+    expect(hasAttributeTranslation('Unknown Attribute XYZ')).toBe(false);
+  });
+
+  it('returns false for empty string (maps to itself)', () => {
+    expect(hasAttributeTranslation('')).toBe(false);
+  });
+});
+
+// ─── getSupportedAttributeLabels ─────────────────────────────────────────────
+
+describe('getSupportedAttributeLabels', () => {
+  it('returns an array', () => {
+    expect(Array.isArray(getSupportedAttributeLabels())).toBe(true);
+  });
+
+  it('includes key temperature labels', () => {
+    const labels = getSupportedAttributeLabels();
+    expect(labels).toContain('Temperature Application');
+    expect(labels).toContain('Temperature Sensor/Output');
+    expect(labels).toContain('Room Enclosure Style');
+  });
+
+  it('includes key humidity labels', () => {
+    const labels = getSupportedAttributeLabels();
+    expect(labels).toContain('Humidity Application');
+    expect(labels).toContain('Humidity Sensor Output');
+  });
+
+  it('includes general labels', () => {
+    const labels = getSupportedAttributeLabels();
+    expect(labels).toContain('Display');
+    expect(labels).toContain('Voltage Range');
+  });
+
+  it('has a non-zero count', () => {
+    expect(getSupportedAttributeLabels().length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/lib/__tests__/productVideos.test.ts
+++ b/web/src/lib/__tests__/productVideos.test.ts
@@ -1,0 +1,128 @@
+/**
+ * productVideos.ts tests
+ *
+ * Mocks the @/data/product-videos.json import to control video data.
+ *
+ * Covers:
+ * - getProductVideos: SKU lookup, productId fallback, SKU takes priority,
+ *   unknown SKU + unknown ID → [], null/undefined inputs → []
+ * - hasProductVideos: true when videos exist, false otherwise
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// ─── Mock the JSON data module ────────────────────────────────────────────────
+
+vi.mock('@/data/product-videos.json', () => ({
+  default: {
+    'BA/3324VC': [
+      {
+        id: 'vid-1',
+        title: 'Installation Guide',
+        url: 'https://youtube.com/watch?v=abc',
+        publishedAt: '2024-01-01',
+        duration: '5:30',
+        category: 'Installation',
+      },
+      {
+        id: 'vid-2',
+        title: 'Product Overview',
+        url: 'https://youtube.com/watch?v=def',
+        publishedAt: '2024-02-01',
+        duration: '3:15',
+      },
+    ],
+    '418359': [
+      {
+        id: 'vid-3',
+        title: 'ID Lookup Video',
+        url: 'https://youtube.com/watch?v=ghi',
+        publishedAt: '2024-03-01',
+        duration: '2:00',
+      },
+    ],
+  },
+}));
+
+// ─── Import after mock ─────────────────────────────────────────────────────────
+
+import { getProductVideos, hasProductVideos } from '../productVideos';
+
+// ─── getProductVideos ─────────────────────────────────────────────────────────
+
+describe('getProductVideos', () => {
+  describe('SKU lookup', () => {
+    it('returns videos for a known SKU', () => {
+      const videos = getProductVideos('BA/3324VC');
+      expect(videos).toHaveLength(2);
+      expect(videos[0].id).toBe('vid-1');
+      expect(videos[1].id).toBe('vid-2');
+    });
+
+    it('returns correct video properties', () => {
+      const [first] = getProductVideos('BA/3324VC');
+      expect(first.title).toBe('Installation Guide');
+      expect(first.url).toBe('https://youtube.com/watch?v=abc');
+      expect(first.duration).toBe('5:30');
+      expect(first.category).toBe('Installation');
+    });
+  });
+
+  describe('productId fallback', () => {
+    it('returns videos by productId when SKU has no match', () => {
+      const videos = getProductVideos('UNKNOWN-SKU', '418359');
+      expect(videos).toHaveLength(1);
+      expect(videos[0].id).toBe('vid-3');
+    });
+
+    it('does NOT use productId fallback when SKU already matched', () => {
+      // SKU matches → productId should be ignored
+      const videos = getProductVideos('BA/3324VC', '418359');
+      expect(videos).toHaveLength(2); // SKU results, not productId results
+      expect(videos.every((v) => v.id !== 'vid-3')).toBe(true);
+    });
+  });
+
+  describe('no match', () => {
+    it('returns empty array for unknown SKU and no productId', () => {
+      expect(getProductVideos('UNKNOWN-SKU')).toEqual([]);
+    });
+
+    it('returns empty array for unknown SKU and unknown productId', () => {
+      expect(getProductVideos('UNKNOWN', '999')).toEqual([]);
+    });
+
+    it('returns empty array for null SKU and null productId', () => {
+      expect(getProductVideos(null, null)).toEqual([]);
+    });
+
+    it('returns empty array for undefined SKU and undefined productId', () => {
+      expect(getProductVideos(undefined, undefined)).toEqual([]);
+    });
+
+    it('returns empty array when both args omitted', () => {
+      expect(getProductVideos()).toEqual([]);
+    });
+  });
+});
+
+// ─── hasProductVideos ─────────────────────────────────────────────────────────
+
+describe('hasProductVideos', () => {
+  it('returns true when SKU has videos', () => {
+    expect(hasProductVideos('BA/3324VC')).toBe(true);
+  });
+
+  it('returns true when productId has videos (SKU not found)', () => {
+    expect(hasProductVideos('UNKNOWN', '418359')).toBe(true);
+  });
+
+  it('returns false when neither SKU nor productId has videos', () => {
+    expect(hasProductVideos('UNKNOWN', '999')).toBe(false);
+  });
+
+  it('returns false for null/undefined inputs', () => {
+    expect(hasProductVideos(null, null)).toBe(false);
+    expect(hasProductVideos(undefined, undefined)).toBe(false);
+  });
+});

--- a/web/src/lib/__tests__/wordpress-content.test.ts
+++ b/web/src/lib/__tests__/wordpress-content.test.ts
@@ -1,0 +1,214 @@
+/**
+ * wordpress-content.ts tests
+ *
+ * Pure content-cleaning utilities — no mocking needed.
+ *
+ * Covers:
+ * - stripShortcodes: removes vc_*, et_pb_*, fusion_*, elementor, generic […]
+ *   patterns; collapses excess blank lines; falsy → ''
+ * - extractCleanText: strips shortcodes + HTML tags + decodes entities + trims whitespace
+ * - hasVisualComposerContent: detects [vc_ pattern presence
+ * - cleanWordPressContent: strips shortcodes when VC present; returns as-is otherwise
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  stripShortcodes,
+  extractCleanText,
+  hasVisualComposerContent,
+  cleanWordPressContent,
+} from '../utils/wordpress-content';
+
+// ─── stripShortcodes ──────────────────────────────────────────────────────────
+
+describe('stripShortcodes', () => {
+  describe('falsy / empty input', () => {
+    it('returns empty string for empty string', () => {
+      expect(stripShortcodes('')).toBe('');
+    });
+
+    it('returns empty string for falsy value at runtime', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(stripShortcodes(null as any)).toBe('');
+    });
+  });
+
+  describe('Visual Composer (vc_) shortcodes', () => {
+    it('removes opening vc_ tags', () => {
+      expect(stripShortcodes('[vc_row]Content[/vc_row]')).not.toContain('[vc_');
+    });
+
+    it('removes closing vc_ tags', () => {
+      expect(stripShortcodes('[vc_row]Content[/vc_row]')).not.toContain('[/vc_');
+    });
+
+    it('preserves text content after removing vc_ tags', () => {
+      const result = stripShortcodes('[vc_row][vc_column]Hello world[/vc_column][/vc_row]');
+      expect(result).toContain('Hello world');
+    });
+
+    it('removes vc_ tags with attributes', () => {
+      const result = stripShortcodes('[vc_column width="1/2"]Content[/vc_column]');
+      expect(result).not.toContain('vc_column');
+      expect(result).toContain('Content');
+    });
+  });
+
+  describe('Divi (et_pb_) shortcodes', () => {
+    it('removes et_pb_ opening and closing tags', () => {
+      const result = stripShortcodes('[et_pb_section]Content[/et_pb_section]');
+      expect(result).not.toContain('et_pb_');
+      expect(result).toContain('Content');
+    });
+  });
+
+  describe('Fusion Builder shortcodes', () => {
+    it('removes fusion_ shortcodes', () => {
+      const result = stripShortcodes('[fusion_builder_container]Text[/fusion_builder_container]');
+      expect(result).not.toContain('fusion_');
+      expect(result).toContain('Text');
+    });
+  });
+
+  describe('Elementor shortcodes', () => {
+    it('removes elementor shortcodes', () => {
+      const result = stripShortcodes('[elementor-template id="123"]');
+      expect(result).not.toContain('elementor');
+    });
+  });
+
+  describe('generic shortcodes', () => {
+    it('removes arbitrary [shortcode] patterns', () => {
+      const result = stripShortcodes('[gallery ids="1,2,3"]Some text[/gallery]');
+      expect(result).not.toContain('[gallery');
+      expect(result).not.toContain('[/gallery]');
+      expect(result).toContain('Some text');
+    });
+
+    it('removes self-closing shortcodes', () => {
+      const result = stripShortcodes('Before [caption id="1"] After');
+      expect(result).not.toContain('[caption');
+    });
+  });
+
+  describe('plain content without shortcodes', () => {
+    it('returns plain text unchanged', () => {
+      expect(stripShortcodes('No shortcodes here.')).toBe('No shortcodes here.');
+    });
+
+    it('returns HTML content unchanged', () => {
+      const html = '<p>Hello <strong>world</strong></p>';
+      expect(stripShortcodes(html)).toBe(html);
+    });
+  });
+
+  describe('whitespace normalisation', () => {
+    it('collapses 3+ consecutive blank lines to 2', () => {
+      const result = stripShortcodes('Line1\n\n\n\nLine2');
+      expect(result).not.toMatch(/\n\s*\n\s*\n/);
+      expect(result).toContain('Line1');
+      expect(result).toContain('Line2');
+    });
+  });
+});
+
+// ─── extractCleanText ─────────────────────────────────────────────────────────
+
+describe('extractCleanText', () => {
+  it('returns empty string for empty input', () => {
+    expect(extractCleanText('')).toBe('');
+  });
+
+  it('strips HTML tags', () => {
+    expect(extractCleanText('<p>Hello <strong>world</strong></p>')).toBe('Hello world');
+  });
+
+  it('strips shortcodes before HTML tags', () => {
+    const result = extractCleanText('[vc_row]<p>Clean</p>[/vc_row]');
+    expect(result).toBe('Clean');
+  });
+
+  it('decodes &nbsp; to space', () => {
+    const result = extractCleanText('Hello&nbsp;World');
+    expect(result).toBe('Hello World');
+  });
+
+  it('decodes &amp;', () => {
+    expect(extractCleanText('Fish &amp; Chips')).toBe('Fish & Chips');
+  });
+
+  it('decodes &lt; and &gt;', () => {
+    expect(extractCleanText('&lt;tag&gt;')).toBe('<tag>');
+  });
+
+  it('decodes &quot;', () => {
+    expect(extractCleanText('She said &quot;hello&quot;')).toBe('She said "hello"');
+  });
+
+  it('decodes &#039;', () => {
+    expect(extractCleanText("It&#039;s fine")).toBe("It's fine");
+  });
+
+  it('collapses multiple spaces to single space', () => {
+    expect(extractCleanText('too   many    spaces')).toBe('too many spaces');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(extractCleanText('  hello  ')).toBe('hello');
+  });
+
+  it('handles mixed HTML and shortcodes', () => {
+    const input = '[vc_row]<h2>Title</h2><p>Body text here.</p>[/vc_row]';
+    const result = extractCleanText(input);
+    // Tags are replaced with empty string (not spaces), then whitespace collapsed
+    expect(result).toBe('TitleBody text here.');
+  });
+});
+
+// ─── hasVisualComposerContent ─────────────────────────────────────────────────
+
+describe('hasVisualComposerContent', () => {
+  it('returns true when content contains [vc_ pattern', () => {
+    expect(hasVisualComposerContent('[vc_row]Content[/vc_row]')).toBe(true);
+  });
+
+  it('returns true for partial vc_ match', () => {
+    expect(hasVisualComposerContent('Some text [vc_column]...')).toBe(true);
+  });
+
+  it('returns false for content without [vc_', () => {
+    expect(hasVisualComposerContent('<p>Regular HTML</p>')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasVisualComposerContent('')).toBe(false);
+  });
+
+  it('returns false for content with other shortcodes', () => {
+    expect(hasVisualComposerContent('[gallery ids="1"]')).toBe(false);
+  });
+});
+
+// ─── cleanWordPressContent ────────────────────────────────────────────────────
+
+describe('cleanWordPressContent', () => {
+  it('returns empty string for empty input', () => {
+    expect(cleanWordPressContent('')).toBe('');
+  });
+
+  it('strips shortcodes when VC content is detected', () => {
+    const input = '[vc_row][vc_column]<p>Real content</p>[/vc_column][/vc_row]';
+    const result = cleanWordPressContent(input);
+    expect(result).not.toContain('[vc_');
+    expect(result).toContain('Real content');
+  });
+
+  it('returns content as-is when no VC shortcodes present', () => {
+    const html = '<p>Standard <strong>HTML</strong> content.</p>';
+    expect(cleanWordPressContent(html)).toBe(html);
+  });
+
+  it('returns plain text as-is when no VC shortcodes', () => {
+    expect(cleanWordPressContent('Plain text')).toBe('Plain text');
+  });
+});


### PR DESCRIPTION
Note: cart sub-routes (add/remove/update/clear) are already fully covered by the existing web/src/app/api/cart/__tests__/cart.test.ts (29 tests).

- wordpress-content.ts (34 tests): stripShortcodes — falsy/empty, vc_/et_pb_/ fusion_/elementor/generic shortcode removal, content preservation, whitespace collapsing; extractCleanText — HTML tag stripping, shortcode stripping, entity decoding (&nbsp; &amp; &lt; &gt; &quot; &#039;), whitespace collapsing, trim; hasVisualComposerContent — true/false detection; cleanWordPressContent — strips on VC content, pass-through for plain HTML and plain text.

- attributeDetection.ts (42 tests): detectAttributeType — color-swatch (name/ label contains 'color'), binary-toggle (yes/no, display/no-display, included/ not-included, with.../without...), radio-group (2-4 short options), dropdown (5+ options, 0 options, long option text); isPositiveOption — all positive values (yes/display/included/with.../included...) case-insensitively, all negative values; getColorHex — direct named colors (white/black/gray/blue/ yellow/BAPI-specific), case-insensitivity, trim, partial match, unknown default.

- productAttributeTranslations.ts (27 tests): getAttributeTranslationKey — exact matches across temperature/humidity/general namespaces, all-caps variants, case-insensitive fallback, unknown label returns original string (not null); hasAttributeTranslation — known/case-insensitive/unknown/empty; getSupportedAttributeLabels — array type, expected keys present, non-zero.

- productVideos.ts (13 tests): getProductVideos — SKU lookup, video properties, productId fallback when SKU not found, SKU takes priority over productId, unknown SKU + unknown ID, null/undefined/no-args; hasProductVideos — true/ false for SKU/productId/no-match/null.

Total: 116 new tests -> suite now 2,129 passing across 79 files.

