### PR TITLE
test: lib-utils-3 — icsGenerator, applicationCategories, schema/gener…

### DIFF
--- a/web/src/lib/metadata/__tests__/generators.test.ts
+++ b/web/src/lib/metadata/__tests__/generators.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for metadata generators (SEO and Open Graph metadata)
+ * @module lib/metadata/__tests__/generators
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  LOCALE_TO_OG_LOCALE,
+  LOCALE_TO_HREFLANG,
+  SITE_CONFIG,
+  generateProductMetadata,
+  generateCategoryMetadata,
+  generatePageMetadata,
+  generateDefaultMetadata,
+} from '../generators';
+import type { ProductMetadataInput, CategoryMetadataInput } from '../types';
+
+// Fixture: full product metadata input
+const baseProduct: ProductMetadataInput = {
+  name: 'Temperature Sensor',
+  slug: 'ba-10k-3',
+  sku: 'BA/10K-3',
+  description: '<p>Precision room temperature sensor for building automation.</p>',
+  shortDescription: '<p>Room temp sensor.</p>',
+  price: '$45.00',
+  stockStatus: 'IN_STOCK',
+  categories: [{ name: 'Room Sensors', slug: 'room-sensors' }],
+};
+
+// Fixture: category metadata input
+const baseCategory: CategoryMetadataInput = {
+  name: 'Room Sensors',
+  slug: 'room-sensors',
+  description: 'Sensors for indoor room monitoring.',
+  count: 42,
+};
+
+// Fixture: page metadata input
+const basePage = {
+  title: 'About BAPI',
+  description: 'Learn about Building Automation Products Inc.',
+  path: 'about',
+};
+
+// -------------------------------------------------------------------------
+// LOCALE_TO_OG_LOCALE constant
+// -------------------------------------------------------------------------
+describe('LOCALE_TO_OG_LOCALE', () => {
+  it('maps en to en_US', () => {
+    expect(LOCALE_TO_OG_LOCALE['en']).toBe('en_US');
+  });
+
+  it('maps de to de_DE', () => {
+    expect(LOCALE_TO_OG_LOCALE['de']).toBe('de_DE');
+  });
+
+  it('maps es to es_ES', () => {
+    expect(LOCALE_TO_OG_LOCALE['es']).toBe('es_ES');
+  });
+
+  it('contains all 11 supported locale codes', () => {
+    const expected = ['en', 'de', 'fr', 'es', 'ja', 'zh', 'vi', 'ar', 'th', 'pl', 'hi'];
+    expected.forEach((locale) => expect(LOCALE_TO_OG_LOCALE[locale]).toBeTruthy());
+  });
+});
+
+// -------------------------------------------------------------------------
+// LOCALE_TO_HREFLANG constant
+// -------------------------------------------------------------------------
+describe('LOCALE_TO_HREFLANG', () => {
+  it('maps en to en-US', () => {
+    expect(LOCALE_TO_HREFLANG['en']).toBe('en-US');
+  });
+
+  it('maps fr to fr-FR', () => {
+    expect(LOCALE_TO_HREFLANG['fr']).toBe('fr-FR');
+  });
+
+  it('maps ja to ja-JP', () => {
+    expect(LOCALE_TO_HREFLANG['ja']).toBe('ja-JP');
+  });
+
+  it('contains all 11 supported locale codes', () => {
+    const expected = ['en', 'de', 'fr', 'es', 'ja', 'zh', 'vi', 'ar', 'th', 'pl', 'hi'];
+    expected.forEach((locale) => expect(LOCALE_TO_HREFLANG[locale]).toBeTruthy());
+  });
+});
+
+// -------------------------------------------------------------------------
+// SITE_CONFIG constant
+// -------------------------------------------------------------------------
+describe('SITE_CONFIG', () => {
+  it('has siteName BAPI', () => {
+    expect(SITE_CONFIG.siteName).toBe('BAPI');
+  });
+
+  it('has a valid https siteUrl', () => {
+    expect(SITE_CONFIG.siteUrl).toMatch(/^https:\/\//);
+  });
+
+  it('has a non-empty defaultTitle', () => {
+    expect(SITE_CONFIG.defaultTitle).toBeTruthy();
+  });
+
+  it('has a non-empty defaultDescription', () => {
+    expect(SITE_CONFIG.defaultDescription).toBeTruthy();
+  });
+
+  it('has a keywords array with entries', () => {
+    expect(Array.isArray(SITE_CONFIG.keywords)).toBe(true);
+    expect(SITE_CONFIG.keywords.length).toBeGreaterThan(0);
+  });
+
+  it('organizationName contains BAPI', () => {
+    expect(SITE_CONFIG.organizationName).toContain('BAPI');
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateProductMetadata
+// -------------------------------------------------------------------------
+describe('generateProductMetadata', () => {
+  it('returns title containing the product name', () => {
+    const meta = generateProductMetadata(baseProduct);
+    const titleStr = typeof meta.title === 'string' ? meta.title : JSON.stringify(meta.title);
+    expect(titleStr).toContain('Temperature Sensor');
+  });
+
+  it('title includes SKU suffix when no partNumber provided', () => {
+    const meta = generateProductMetadata(baseProduct);
+    const titleStr = typeof meta.title === 'string' ? meta.title : JSON.stringify(meta.title);
+    expect(titleStr).toContain('BA/10K-3');
+  });
+
+  it('title includes partNumber suffix when provided', () => {
+    const meta = generateProductMetadata({ ...baseProduct, partNumber: 'BA10K3' });
+    const titleStr = typeof meta.title === 'string' ? meta.title : JSON.stringify(meta.title);
+    expect(titleStr).toContain('BA10K3');
+  });
+
+  it('description is a string within 160 character limit', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect(typeof meta.description).toBe('string');
+    expect(meta.description!.length).toBeLessThanOrEqual(160);
+  });
+
+  it('description is AI-friendly and references the product name', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect(meta.description).toContain('Temperature Sensor');
+  });
+
+  it('keywords include product category name', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect(meta.keywords).toContain('Room Sensors');
+  });
+
+  it('openGraph type is website', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect((meta.openGraph as any)?.type).toBe('website');
+  });
+
+  it('openGraph branded title includes BAPI', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect((meta.openGraph as any)?.title).toContain('BAPI');
+  });
+
+  it('openGraph locale maps from locale arg via LOCALE_TO_OG_LOCALE', () => {
+    const meta = generateProductMetadata(baseProduct, 'de');
+    expect((meta.openGraph as any)?.locale).toBe('de_DE');
+  });
+
+  it('openGraph locale falls back to en_US for unknown locale', () => {
+    const meta = generateProductMetadata(baseProduct, 'xx');
+    expect((meta.openGraph as any)?.locale).toBe('en_US');
+  });
+
+  it('openGraph defaults to en_US when no locale argument provided', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect((meta.openGraph as any)?.locale).toBe('en_US');
+  });
+
+  it('canonical alternate contains locale prefix and product slug', () => {
+    const meta = generateProductMetadata(baseProduct, 'en');
+    expect((meta.alternates as any)?.canonical).toContain('/en/products/ba-10k-3');
+  });
+
+  it('language alternates include en-US and de-DE entries', () => {
+    const meta = generateProductMetadata(baseProduct, 'en');
+    const languages = (meta.alternates as any)?.languages;
+    expect(languages?.['en-US']).toBeTruthy();
+    expect(languages?.['de-DE']).toBeTruthy();
+  });
+
+  it('robots index and follow are true', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect((meta.robots as any)?.index).toBe(true);
+    expect((meta.robots as any)?.follow).toBe(true);
+  });
+
+  it('twitter card is summary_large_image', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect((meta.twitter as any)?.card).toBe('summary_large_image');
+  });
+
+  it('other metadata includes product:brand', () => {
+    const meta = generateProductMetadata(baseProduct);
+    expect((meta.other as any)?.['product:brand']).toBeTruthy();
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateCategoryMetadata
+// -------------------------------------------------------------------------
+describe('generateCategoryMetadata', () => {
+  it('title contains the category name', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    const titleStr = typeof meta.title === 'string' ? meta.title : JSON.stringify(meta.title);
+    expect(titleStr).toContain('Room Sensors');
+  });
+
+  it('title includes "Products"', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    const titleStr = typeof meta.title === 'string' ? meta.title : JSON.stringify(meta.title);
+    expect(titleStr).toContain('Products');
+  });
+
+  it('description is within 160 character limit', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    expect(meta.description!.length).toBeLessThanOrEqual(160);
+  });
+
+  it('description references the category name', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    expect(meta.description).toContain('Room Sensors');
+  });
+
+  it('generates fallback description when category description is empty', () => {
+    const meta = generateCategoryMetadata({ ...baseCategory, description: '' });
+    expect(meta.description).toBeTruthy();
+    expect(meta.description).toContain('Room Sensors');
+  });
+
+  it('openGraph type is website', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    expect((meta.openGraph as any)?.type).toBe('website');
+  });
+
+  it('openGraph branded title includes BAPI', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    expect((meta.openGraph as any)?.title).toContain('BAPI');
+  });
+
+  it('canonical alternate contains category slug', () => {
+    const meta = generateCategoryMetadata(baseCategory, 'en');
+    expect((meta.alternates as any)?.canonical).toContain('room-sensors');
+  });
+
+  it('robots index and follow are true', () => {
+    const meta = generateCategoryMetadata(baseCategory);
+    expect((meta.robots as any)?.index).toBe(true);
+    expect((meta.robots as any)?.follow).toBe(true);
+  });
+});
+
+// -------------------------------------------------------------------------
+// generatePageMetadata
+// -------------------------------------------------------------------------
+describe('generatePageMetadata', () => {
+  it('returns the page title as-is', () => {
+    const meta = generatePageMetadata(basePage);
+    expect(meta.title).toBe('About BAPI');
+  });
+
+  it('returns the page description as-is', () => {
+    const meta = generatePageMetadata(basePage);
+    expect(meta.description).toBe('Learn about Building Automation Products Inc.');
+  });
+
+  it('openGraph branded title appends | BAPI', () => {
+    const meta = generatePageMetadata(basePage);
+    expect((meta.openGraph as any)?.title).toBe('About BAPI | BAPI');
+  });
+
+  it('canonical contains locale prefix and path', () => {
+    const meta = generatePageMetadata(basePage, 'en');
+    expect((meta.alternates as any)?.canonical).toContain('/en/about');
+  });
+
+  it('defaults to website OpenGraph type', () => {
+    const meta = generatePageMetadata(basePage);
+    expect((meta.openGraph as any)?.type).toBe('website');
+  });
+
+  it('uses article type when explicitly specified', () => {
+    const meta = generatePageMetadata({ ...basePage, type: 'article' });
+    expect((meta.openGraph as any)?.type).toBe('article');
+  });
+
+  it('includes publishedTime in openGraph when provided', () => {
+    const meta = generatePageMetadata({ ...basePage, publishedTime: '2026-01-15T00:00:00Z' });
+    expect((meta.openGraph as any)?.publishedTime).toBe('2026-01-15T00:00:00Z');
+  });
+
+  it('includes keywords joined as comma-separated string when provided', () => {
+    const meta = generatePageMetadata({ ...basePage, keywords: ['sensors', 'HVAC'] });
+    expect(meta.keywords).toContain('sensors');
+    expect(meta.keywords).toContain('HVAC');
+  });
+
+  it('keywords is undefined when not provided', () => {
+    const meta = generatePageMetadata(basePage);
+    expect(meta.keywords).toBeUndefined();
+  });
+
+  it('twitter card is summary_large_image', () => {
+    const meta = generatePageMetadata(basePage);
+    expect((meta.twitter as any)?.card).toBe('summary_large_image');
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateDefaultMetadata
+// -------------------------------------------------------------------------
+describe('generateDefaultMetadata', () => {
+  it('title template includes the site name', () => {
+    const meta = generateDefaultMetadata();
+    if (typeof meta.title === 'object' && meta.title !== null) {
+      expect((meta.title as any).template).toContain('BAPI');
+    } else {
+      expect(String(meta.title)).toContain('BAPI');
+    }
+  });
+
+  it('title.default is SITE_CONFIG.defaultTitle', () => {
+    const meta = generateDefaultMetadata();
+    if (typeof meta.title === 'object' && meta.title !== null) {
+      expect((meta.title as any).default).toBe(SITE_CONFIG.defaultTitle);
+    }
+  });
+
+  it('description is non-empty', () => {
+    expect(generateDefaultMetadata().description).toBeTruthy();
+  });
+
+  it('keywords is a non-empty string', () => {
+    const meta = generateDefaultMetadata();
+    expect(typeof meta.keywords).toBe('string');
+    expect((meta.keywords as string).length).toBeGreaterThan(0);
+  });
+
+  it('openGraph type is website', () => {
+    const meta = generateDefaultMetadata();
+    expect((meta.openGraph as any)?.type).toBe('website');
+  });
+
+  it('openGraph locale defaults to en_US for default locale', () => {
+    const meta = generateDefaultMetadata('en');
+    expect((meta.openGraph as any)?.locale).toBe('en_US');
+  });
+
+  it('robots index and follow are true', () => {
+    const meta = generateDefaultMetadata();
+    expect((meta.robots as any)?.index).toBe(true);
+    expect((meta.robots as any)?.follow).toBe(true);
+  });
+});

--- a/web/src/lib/navigation/__tests__/applicationCategories.test.ts
+++ b/web/src/lib/navigation/__tests__/applicationCategories.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for application category navigation data and lookup helpers
+ * @module lib/navigation/__tests__/applicationCategories
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  applicationCategories,
+  getApplicationCategorySlugs,
+  getSubcategorySlugs,
+  getWordPressCategoriesForApplication,
+  getFiltersForApplication,
+  productMatchesApplicationFilters,
+  getApplicationBreadcrumbs,
+} from '../applicationCategories';
+
+// -------------------------------------------------------------------------
+// applicationCategories data shape
+// -------------------------------------------------------------------------
+describe('applicationCategories data', () => {
+  it('is a non-empty record', () => {
+    expect(Object.keys(applicationCategories).length).toBeGreaterThan(0);
+  });
+
+  it('every category has required fields matching its key slug', () => {
+    for (const [slug, category] of Object.entries(applicationCategories)) {
+      expect(category.name, `name missing for ${slug}`).toBeTruthy();
+      expect(category.slug, `slug mismatch for ${slug}`).toBe(slug);
+      expect(category.description, `description missing for ${slug}`).toBeTruthy();
+      expect(category.icon, `icon missing for ${slug}`).toBeTruthy();
+      expect(typeof category.subcategories, `subcategories not object for ${slug}`).toBe('object');
+    }
+  });
+
+  it('every subcategory has required fields matching its key slug', () => {
+    for (const category of Object.values(applicationCategories)) {
+      for (const [subSlug, sub] of Object.entries(category.subcategories)) {
+        expect(sub.name, `name missing for ${subSlug}`).toBeTruthy();
+        expect(sub.slug, `slug mismatch for ${subSlug}`).toBe(subSlug);
+        expect(sub.description, `description missing for ${subSlug}`).toBeTruthy();
+        expect(Array.isArray(sub.wpCategories), `wpCategories not array for ${subSlug}`).toBe(true);
+      }
+    }
+  });
+
+  it('contains building-automation category', () => {
+    expect(applicationCategories['building-automation']).toBeDefined();
+  });
+
+  it('building-automation has room-monitoring subcategory', () => {
+    expect(
+      applicationCategories['building-automation'].subcategories['room-monitoring']
+    ).toBeDefined();
+  });
+
+  it('contains industrial-process category', () => {
+    expect(applicationCategories['industrial-process']).toBeDefined();
+  });
+
+  it('contains wireless-remote category', () => {
+    expect(applicationCategories['wireless-remote']).toBeDefined();
+  });
+});
+
+// -------------------------------------------------------------------------
+// getApplicationCategorySlugs
+// -------------------------------------------------------------------------
+describe('getApplicationCategorySlugs', () => {
+  it('returns an array of strings', () => {
+    const slugs = getApplicationCategorySlugs();
+    expect(Array.isArray(slugs)).toBe(true);
+    slugs.forEach((s) => expect(typeof s).toBe('string'));
+  });
+
+  it('includes known top-level category slugs', () => {
+    const slugs = getApplicationCategorySlugs();
+    expect(slugs).toContain('building-automation');
+    expect(slugs).toContain('industrial-process');
+    expect(slugs).toContain('wireless-remote');
+  });
+
+  it('matches the keys of applicationCategories', () => {
+    expect(getApplicationCategorySlugs()).toEqual(Object.keys(applicationCategories));
+  });
+});
+
+// -------------------------------------------------------------------------
+// getSubcategorySlugs
+// -------------------------------------------------------------------------
+describe('getSubcategorySlugs', () => {
+  it('returns subcategory slugs for building-automation', () => {
+    const slugs = getSubcategorySlugs('building-automation');
+    expect(slugs).toContain('room-monitoring');
+    expect(slugs).toContain('hvac-duct');
+    expect(slugs).toContain('indoor-air-quality');
+  });
+
+  it('returns empty array for unknown application slug', () => {
+    expect(getSubcategorySlugs('nonexistent')).toEqual([]);
+  });
+
+  it('returns an array of strings', () => {
+    getSubcategorySlugs('wireless-remote').forEach((s) => expect(typeof s).toBe('string'));
+  });
+
+  it('returns subcategory slugs for wireless-remote', () => {
+    const slugs = getSubcategorySlugs('wireless-remote');
+    expect(slugs).toContain('wireless-temp-humidity');
+    expect(slugs).toContain('wireless-pressure');
+  });
+});
+
+// -------------------------------------------------------------------------
+// getWordPressCategoriesForApplication
+// -------------------------------------------------------------------------
+describe('getWordPressCategoriesForApplication', () => {
+  it('returns wpCategories for a valid application and subcategory', () => {
+    const cats = getWordPressCategoriesForApplication('building-automation', 'room-monitoring');
+    expect(Array.isArray(cats)).toBe(true);
+    expect(cats.length).toBeGreaterThan(0);
+    expect(cats).toContain('room-sensors');
+  });
+
+  it('returns empty array for unknown application slug', () => {
+    expect(
+      getWordPressCategoriesForApplication('unknown-app', 'room-monitoring')
+    ).toEqual([]);
+  });
+
+  it('returns empty array for unknown subcategory slug', () => {
+    expect(
+      getWordPressCategoriesForApplication('building-automation', 'nonexistent-sub')
+    ).toEqual([]);
+  });
+
+  it('returns correct categories for wireless-remote / wireless-temp-humidity', () => {
+    const cats = getWordPressCategoriesForApplication(
+      'wireless-remote',
+      'wireless-temp-humidity'
+    );
+    expect(cats).toContain('wireless-sensors');
+  });
+
+  it('returns an array for industrial-process / manufacturing', () => {
+    const cats = getWordPressCategoriesForApplication('industrial-process', 'manufacturing');
+    expect(Array.isArray(cats)).toBe(true);
+  });
+});
+
+// -------------------------------------------------------------------------
+// getFiltersForApplication
+// -------------------------------------------------------------------------
+describe('getFiltersForApplication', () => {
+  it('returns filters for building-automation / room-monitoring', () => {
+    const filters = getFiltersForApplication('building-automation', 'room-monitoring');
+    expect(filters?.location).toBe('indoor');
+    expect(filters?.mounting).toBe('wall');
+  });
+
+  it('returns empty object for unknown application', () => {
+    expect(getFiltersForApplication('unknown', 'sub')).toEqual({});
+  });
+
+  it('returns empty object for unknown subcategory', () => {
+    expect(getFiltersForApplication('building-automation', 'nonexistent')).toEqual({});
+  });
+
+  it('returns connectivity filter for wireless subcategory', () => {
+    const filters = getFiltersForApplication('wireless-remote', 'wireless-temp-humidity');
+    expect(filters?.connectivity).toBe('wireless');
+  });
+
+  it('returns outdoor location for outdoor-weather subcategory', () => {
+    const filters = getFiltersForApplication('building-automation', 'outdoor-weather');
+    expect(filters?.location).toBe('outdoor');
+  });
+});
+
+// -------------------------------------------------------------------------
+// productMatchesApplicationFilters
+// -------------------------------------------------------------------------
+describe('productMatchesApplicationFilters', () => {
+  it('returns true when filters is empty object', () => {
+    expect(productMatchesApplicationFilters({}, {})).toBe(true);
+  });
+
+  it('returns true when filters is undefined', () => {
+    expect(productMatchesApplicationFilters({ sku: 'BA/10K-3' }, undefined)).toBe(true);
+  });
+
+  it('currently returns true for any product and filter combination (stub)', () => {
+    const filters = { location: 'indoor' as const, mounting: 'wall' as const };
+    expect(productMatchesApplicationFilters({ sku: 'ANY' }, filters)).toBe(true);
+  });
+
+  it('returns true for empty product with non-empty filters', () => {
+    expect(productMatchesApplicationFilters({}, { industry: 'industrial' })).toBe(true);
+  });
+});
+
+// -------------------------------------------------------------------------
+// getApplicationBreadcrumbs
+// -------------------------------------------------------------------------
+describe('getApplicationBreadcrumbs', () => {
+  it('always starts with Home breadcrumb', () => {
+    const crumbs = getApplicationBreadcrumbs('building-automation');
+    expect(crumbs[0]).toEqual({ name: 'Home', href: '/' });
+  });
+
+  it('always includes Applications breadcrumb as second item', () => {
+    const crumbs = getApplicationBreadcrumbs('building-automation');
+    expect(crumbs[1]).toEqual({ name: 'Applications', href: '/applications' });
+  });
+
+  it('returns only Home and Applications for an unknown application slug', () => {
+    const crumbs = getApplicationBreadcrumbs('nonexistent');
+    expect(crumbs.length).toBe(2);
+    expect(crumbs[0].href).toBe('/');
+    expect(crumbs[1].href).toBe('/applications');
+  });
+
+  it('returns three breadcrumbs for a valid top-level category', () => {
+    const crumbs = getApplicationBreadcrumbs('building-automation');
+    expect(crumbs.length).toBe(3);
+    expect(crumbs[2].href).toBe('/applications/building-automation');
+    expect(crumbs[2].name).toBeTruthy();
+  });
+
+  it('returns four breadcrumbs for a valid category + subcategory', () => {
+    const crumbs = getApplicationBreadcrumbs('building-automation', 'room-monitoring');
+    expect(crumbs.length).toBe(4);
+    expect(crumbs[3].href).toBe('/applications/building-automation/room-monitoring');
+    expect(crumbs[3].name).toBeTruthy();
+  });
+
+  it('returns three breadcrumbs when subcategory slug is not found', () => {
+    const crumbs = getApplicationBreadcrumbs('building-automation', 'nonexistent-sub');
+    expect(crumbs.length).toBe(3);
+  });
+
+  it('breadcrumb names are non-empty strings', () => {
+    const crumbs = getApplicationBreadcrumbs('wireless-remote', 'wireless-pressure');
+    crumbs.forEach((c) => expect(typeof c.name).toBe('string') && expect(c.name.length).toBeGreaterThan(0));
+  });
+});

--- a/web/src/lib/navigation/__tests__/applicationCategories.test.ts
+++ b/web/src/lib/navigation/__tests__/applicationCategories.test.ts
@@ -240,6 +240,9 @@ describe('getApplicationBreadcrumbs', () => {
 
   it('breadcrumb names are non-empty strings', () => {
     const crumbs = getApplicationBreadcrumbs('wireless-remote', 'wireless-pressure');
-    crumbs.forEach((c) => expect(typeof c.name).toBe('string') && expect(c.name.length).toBeGreaterThan(0));
+    crumbs.forEach((c) => {
+      expect(typeof c.name).toBe('string');
+      expect(c.name.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/web/src/lib/schema/__tests__/generators.test.ts
+++ b/web/src/lib/schema/__tests__/generators.test.ts
@@ -1,0 +1,346 @@
+/**
+ * Tests for Schema.org JSON-LD structured data generators
+ * @module lib/schema/__tests__/generators
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  generateOrganizationSchema,
+  generateProductSchema,
+  generateBreadcrumbSchema,
+  generateFAQSchema,
+  generateWebSiteSchema,
+  schemaToJsonLd,
+} from '../generators';
+
+const SITE_URL = 'https://www.bapihvac.com';
+
+// -------------------------------------------------------------------------
+// generateOrganizationSchema
+// -------------------------------------------------------------------------
+describe('generateOrganizationSchema', () => {
+  it('returns correct @context and @type', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('Organization');
+  });
+
+  it('sets name and alternateName', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(schema.name).toBe('Building Automation Products Inc.');
+    expect(schema.alternateName).toBe('BAPI');
+  });
+
+  it('uses the provided siteUrl as url', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(schema.url).toBe(SITE_URL);
+  });
+
+  it('sets logo URL derived from siteUrl', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(schema.logo).toContain(SITE_URL);
+    expect(schema.logo).toContain('bapi_logo');
+  });
+
+  it('includes PostalAddress with required fields', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(schema.address?.['@type']).toBe('PostalAddress');
+    expect(schema.address?.addressLocality).toBe('Gays Mills');
+    expect(schema.address?.addressRegion).toBe('WI');
+    expect(schema.address?.addressCountry).toBe('US');
+    expect(schema.address?.postalCode).toBeTruthy();
+  });
+
+  it('includes at least one ContactPoint', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(Array.isArray(schema.contactPoint)).toBe(true);
+    expect(schema.contactPoint!.length).toBeGreaterThan(0);
+    expect(schema.contactPoint![0]['@type']).toBe('ContactPoint');
+    expect(schema.contactPoint![0].telephone).toBeTruthy();
+  });
+
+  it('includes LinkedIn in sameAs social links', () => {
+    const schema = generateOrganizationSchema(SITE_URL);
+    expect(Array.isArray(schema.sameAs)).toBe(true);
+    expect(schema.sameAs?.some((url) => url.includes('linkedin'))).toBe(true);
+  });
+
+  it('sets foundingDate to 1984', () => {
+    expect(generateOrganizationSchema(SITE_URL).foundingDate).toBe('1984');
+  });
+
+  it('includes a description', () => {
+    expect(generateOrganizationSchema(SITE_URL).description).toBeTruthy();
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateProductSchema
+// -------------------------------------------------------------------------
+describe('generateProductSchema', () => {
+  const product = {
+    name: 'Temperature Sensor',
+    sku: 'BA/10K-3',
+    partNumber: 'BA10K3',
+    description: 'Precision room temperature sensor',
+    image: 'https://cms.bapi.com/product.jpg',
+    price: 45,
+    inStock: true,
+    category: 'Room Sensors',
+  };
+  const productUrl = `${SITE_URL}/products/ba-10k-3`;
+
+  it('returns correct @context and @type', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('Product');
+  });
+
+  it('sets name and sku', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.name).toBe('Temperature Sensor');
+    expect(schema.sku).toBe('BA/10K-3');
+  });
+
+  it('sets mpn to partNumber when available', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.mpn).toBe('BA10K3');
+  });
+
+  it('falls back mpn to sku when partNumber is absent', () => {
+    const { partNumber: _, ...noPartNum } = product;
+    const schema = generateProductSchema(noPartNum, productUrl, SITE_URL);
+    expect(schema.mpn).toBe('BA/10K-3');
+  });
+
+  it('sets brand to BAPI', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.brand['@type']).toBe('Brand');
+    expect(schema.brand.name).toBe('BAPI');
+  });
+
+  it('sets InStock availability when inStock is true', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.offers?.availability).toBe('https://schema.org/InStock');
+  });
+
+  it('sets OutOfStock availability when inStock is false', () => {
+    const schema = generateProductSchema({ ...product, inStock: false }, productUrl, SITE_URL);
+    expect(schema.offers?.availability).toBe('https://schema.org/OutOfStock');
+  });
+
+  it('sets offer price and currency', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.offers?.price).toBe(45);
+    expect(schema.offers?.priceCurrency).toBe('USD');
+  });
+
+  it('prefers salePrice over regularPrice and price', () => {
+    const withSale = { ...product, salePrice: 35, regularPrice: 45 };
+    const schema = generateProductSchema(withSale, productUrl, SITE_URL);
+    expect(schema.offers?.price).toBe(35);
+  });
+
+  it('sets priceValidUntil as a future YYYY-MM-DD date', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.offers?.priceValidUntil).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(new Date(schema.offers!.priceValidUntil!).getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('uses provided image URL', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    // image is stored as an array
+    const images = schema.image as string[];
+    expect(images).toContain('https://cms.bapi.com/product.jpg');
+  });
+
+  it('uses placeholder image when no image provided', () => {
+    const { image: _, ...noImage } = product;
+    const schema = generateProductSchema(noImage, productUrl, SITE_URL);
+    const firstImage = Array.isArray(schema.image) ? schema.image[0] : schema.image;
+    expect(firstImage).toContain('placeholder');
+  });
+
+  it('includes offer URL equal to productUrl', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.offers?.url).toBe(productUrl);
+  });
+
+  it('sets manufacturer to BAPI organization', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.manufacturer?.['@type']).toBe('Organization');
+    expect(schema.manufacturer?.name).toContain('Building Automation Products');
+  });
+
+  it('sets itemCondition to NewCondition', () => {
+    const schema = generateProductSchema(product, productUrl, SITE_URL);
+    expect(schema.offers?.itemCondition).toContain('NewCondition');
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateBreadcrumbSchema
+// -------------------------------------------------------------------------
+describe('generateBreadcrumbSchema', () => {
+  const breadcrumbs = [
+    { name: 'Home', url: '/' },
+    { name: 'Products', url: '/products' },
+    { name: 'Room Sensors' }, // last item has no url
+  ];
+
+  it('returns correct @context and @type', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('BreadcrumbList');
+  });
+
+  it('creates itemListElement with correct count', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    expect(schema.itemListElement.length).toBe(3);
+  });
+
+  it('sets @type ListItem on each element', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    schema.itemListElement.forEach((el) => expect(el['@type']).toBe('ListItem'));
+  });
+
+  it('uses 1-based position numbering', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    expect(schema.itemListElement[0].position).toBe(1);
+    expect(schema.itemListElement[1].position).toBe(2);
+    expect(schema.itemListElement[2].position).toBe(3);
+  });
+
+  it('prepends siteUrl to crumb urls', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    expect(schema.itemListElement[0].item).toBe(`${SITE_URL}/`);
+    expect(schema.itemListElement[1].item).toBe(`${SITE_URL}/products`);
+  });
+
+  it('sets item to undefined when crumb has no url (last item)', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    expect(schema.itemListElement[2].item).toBeUndefined();
+  });
+
+  it('returns empty itemListElement for empty breadcrumbs array', () => {
+    const schema = generateBreadcrumbSchema([], SITE_URL);
+    expect(schema.itemListElement).toEqual([]);
+  });
+
+  it('copies name from each breadcrumb', () => {
+    const schema = generateBreadcrumbSchema(breadcrumbs, SITE_URL);
+    expect(schema.itemListElement[0].name).toBe('Home');
+    expect(schema.itemListElement[2].name).toBe('Room Sensors');
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateFAQSchema
+// -------------------------------------------------------------------------
+describe('generateFAQSchema', () => {
+  const faqs = [
+    { question: 'What is BAPI?', answer: 'A sensor manufacturer.' },
+    { question: 'Where are you located?', answer: 'Gays Mills, WI.' },
+  ];
+
+  it('returns correct @context and @type', () => {
+    const schema = generateFAQSchema(faqs);
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('FAQPage');
+  });
+
+  it('creates mainEntity with correct count', () => {
+    const schema = generateFAQSchema(faqs);
+    expect(schema.mainEntity.length).toBe(2);
+  });
+
+  it('sets @type Question on each entity', () => {
+    const schema = generateFAQSchema(faqs);
+    schema.mainEntity.forEach((q) => expect(q['@type']).toBe('Question'));
+  });
+
+  it('maps question name', () => {
+    const schema = generateFAQSchema(faqs);
+    expect(schema.mainEntity[0].name).toBe('What is BAPI?');
+    expect(schema.mainEntity[1].name).toBe('Where are you located?');
+  });
+
+  it('maps answer with @type Answer and text', () => {
+    const schema = generateFAQSchema(faqs);
+    expect(schema.mainEntity[0].acceptedAnswer['@type']).toBe('Answer');
+    expect(schema.mainEntity[0].acceptedAnswer.text).toBe('A sensor manufacturer.');
+  });
+
+  it('returns empty mainEntity for empty faqs array', () => {
+    expect(generateFAQSchema([]).mainEntity).toEqual([]);
+  });
+});
+
+// -------------------------------------------------------------------------
+// generateWebSiteSchema
+// -------------------------------------------------------------------------
+describe('generateWebSiteSchema', () => {
+  it('returns correct @context and @type', () => {
+    const schema = generateWebSiteSchema(SITE_URL, 'BAPI');
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('WebSite');
+  });
+
+  it('sets name and url from arguments', () => {
+    const schema = generateWebSiteSchema(SITE_URL, 'BAPI');
+    expect(schema.name).toBe('BAPI');
+    expect(schema.url).toBe(SITE_URL);
+  });
+
+  it('includes a description', () => {
+    expect(generateWebSiteSchema(SITE_URL, 'BAPI').description).toBeTruthy();
+  });
+
+  it('includes SearchAction as potentialAction', () => {
+    const schema = generateWebSiteSchema(SITE_URL, 'BAPI');
+    expect(schema.potentialAction?.['@type']).toBe('SearchAction');
+    expect(schema.potentialAction?.['query-input']).toContain('search_term_string');
+  });
+
+  it('search URL template contains siteUrl and search_term_string placeholder', () => {
+    const schema = generateWebSiteSchema(SITE_URL, 'BAPI');
+    const urlTemplate = schema.potentialAction?.target?.urlTemplate;
+    expect(urlTemplate).toContain(SITE_URL);
+    expect(urlTemplate).toContain('{search_term_string}');
+  });
+});
+
+// -------------------------------------------------------------------------
+// schemaToJsonLd
+// -------------------------------------------------------------------------
+describe('schemaToJsonLd', () => {
+  it('returns a valid JSON string', () => {
+    const result = schemaToJsonLd({ '@type': 'Organization', name: 'BAPI' });
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('round-trips the schema object correctly', () => {
+    const schema = { '@type': 'Organization', name: 'BAPI', foundingDate: '1984' };
+    const parsed = JSON.parse(schemaToJsonLd(schema));
+    expect(parsed['@type']).toBe('Organization');
+    expect(parsed.name).toBe('BAPI');
+    expect(parsed.foundingDate).toBe('1984');
+  });
+
+  it('produces minified JSON (no extra whitespace)', () => {
+    const result = schemaToJsonLd({ a: 1, b: 2 });
+    expect(result).toBe('{"a":1,"b":2}');
+  });
+
+  it('handles nested objects', () => {
+    const schema = { address: { city: 'Gays Mills', state: 'WI' } };
+    const parsed = JSON.parse(schemaToJsonLd(schema));
+    expect(parsed.address.city).toBe('Gays Mills');
+  });
+
+  it('handles arrays', () => {
+    const schema = { sameAs: ['https://linkedin.com/bapi', 'https://youtube.com/bapi'] };
+    const parsed = JSON.parse(schemaToJsonLd(schema));
+    expect(parsed.sameAs).toHaveLength(2);
+  });
+});

--- a/web/src/lib/utils/__tests__/icsGenerator.test.ts
+++ b/web/src/lib/utils/__tests__/icsGenerator.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for ICS (iCalendar) file generator
+ * @module lib/utils/__tests__/icsGenerator
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { generateICS, downloadICS } from '../icsGenerator';
+import type { TradeShow } from '@/lib/data/tradeShows';
+
+// Remove RFC 5545 CRLF line-folding continuations so assertions work on logical lines
+function unfold(ics: string): string {
+  return ics.replace(/\r\n /g, '');
+}
+
+// Minimal valid trade show fixture
+const baseShow: TradeShow = {
+  id: 'test-show-2026',
+  title: 'Test Show 2026',
+  startDate: '2026-09-15',
+  endDate: '2026-09-17',
+  location: {
+    city: 'Chicago',
+    state: 'IL',
+    country: 'USA',
+    venue: 'McCormick Place',
+  },
+  description: 'A test trade show event.',
+};
+
+// -------------------------------------------------------------------------
+// generateICS
+// -------------------------------------------------------------------------
+describe('generateICS', () => {
+  it('returns null when startDate is empty string', () => {
+    expect(generateICS({ ...baseShow, startDate: '' })).toBeNull();
+  });
+
+  it('returns a string for a valid show', () => {
+    const result = generateICS(baseShow);
+    expect(typeof result).toBe('string');
+  });
+
+  it('contains required iCalendar structure', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toContain('BEGIN:VCALENDAR');
+    expect(result).toContain('VERSION:2.0');
+    expect(result).toContain('CALSCALE:GREGORIAN');
+    expect(result).toContain('METHOD:PUBLISH');
+    expect(result).toContain('BEGIN:VEVENT');
+    expect(result).toContain('END:VEVENT');
+    expect(result).toContain('END:VCALENDAR');
+  });
+
+  it('contains BAPI PRODID', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toContain('PRODID:-//BAPI//Trade Shows Calendar//EN');
+  });
+
+  it('contains DTSTART in YYYYMMDDTHHMMSSZ format', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toMatch(/DTSTART:\d{8}T\d{6}Z/);
+  });
+
+  it('contains DTEND in YYYYMMDDTHHMMSSZ format', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toMatch(/DTEND:\d{8}T\d{6}Z/);
+  });
+
+  it('uses startDate as endDate fallback when endDate is undefined', () => {
+    const show = { ...baseShow, endDate: undefined as unknown as string };
+    const result = generateICS(show);
+    expect(result).not.toBeNull();
+    expect(result).toMatch(/DTEND:\d{8}T\d{6}Z/);
+  });
+
+  it('puts the event title in SUMMARY', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toContain('SUMMARY:Test Show 2026');
+  });
+
+  it('includes city, venue, and country in LOCATION', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toContain('Chicago');
+    expect(result).toContain('McCormick Place');
+    expect(result).toContain('USA');
+  });
+
+  it('includes state in LOCATION when provided', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toContain('IL');
+  });
+
+  it('omits undefined values from LOCATION', () => {
+    const show: TradeShow = {
+      ...baseShow,
+      location: { city: 'London', country: 'UK' },
+    };
+    const result = generateICS(show)!;
+    expect(result).not.toContain('undefined');
+  });
+
+  it('appends booth to DESCRIPTION when provided', () => {
+    // Commas are escaped in iCalendar text per RFC 5545
+    const show: TradeShow = { ...baseShow, booth: 'Hall A, Booth 100' };
+    const result = generateICS(show)!;
+    expect(result).toContain('Booth: Hall A\\, Booth 100');
+  });
+
+  it('appends contact name and email to DESCRIPTION when provided', () => {
+    const show: TradeShow = {
+      ...baseShow,
+      contact: { name: 'Jane Doe', email: 'jane@bapi.com' },
+    };
+    // Unfold CRLF continuations before asserting - long lines get folded at 75 chars
+    const unfolded = unfold(generateICS(show)!);
+    expect(unfolded).toContain('Contact: Jane Doe');
+    expect(unfolded).toContain('Email: jane@bapi.com');
+  });
+
+  it('appends contact phone to DESCRIPTION when provided', () => {
+    const show: TradeShow = {
+      ...baseShow,
+      contact: { name: 'Jane Doe', email: 'jane@bapi.com', phone: '+1-555-0001' },
+    };
+    const result = generateICS(show)!;
+    expect(result).toContain('Phone: +1-555-0001');
+  });
+
+  it('appends registration URL to DESCRIPTION when provided', () => {
+    const show: TradeShow = { ...baseShow, registrationUrl: 'https://example.com/register' };
+    // Unfold CRLF continuations before asserting - long URLs get folded at 75 chars
+    expect(unfold(generateICS(show)!)).toContain('Register: https://example.com/register');
+  });
+
+  it('includes URL field when registrationUrl is provided', () => {
+    const show: TradeShow = { ...baseShow, registrationUrl: 'https://example.com/register' };
+    const result = generateICS(show)!;
+    expect(result).toContain('\r\nURL:https://example.com/register\r\n');
+  });
+
+  it('omits URL field when registrationUrl is not provided', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).not.toMatch(/\r\nURL:/);
+  });
+
+  it('generates UID with @bapihvac.com domain', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toMatch(/UID:.+@bapihvac\.com/);
+  });
+
+  it('generates a stable UID (same result on repeated calls)', () => {
+    const uid1 = generateICS(baseShow)!.match(/UID:([^\r\n]+)/)?.[1];
+    const uid2 = generateICS(baseShow)!.match(/UID:([^\r\n]+)/)?.[1];
+    expect(uid1).toBe(uid2);
+  });
+
+  it('generates different UIDs for different events', () => {
+    const show2: TradeShow = { ...baseShow, title: 'Other Show', id: 'other-show' };
+    const uid1 = generateICS(baseShow)!.match(/UID:([^\r\n]+)/)?.[1];
+    const uid2 = generateICS(show2)!.match(/UID:([^\r\n]+)/)?.[1];
+    expect(uid1).not.toBe(uid2);
+  });
+
+  it('escapes commas in iCalendar text (RFC 5545)', () => {
+    const show: TradeShow = { ...baseShow, title: 'Show, Part Two' };
+    const result = generateICS(show)!;
+    expect(result).toContain('SUMMARY:Show\\, Part Two');
+  });
+
+  it('escapes semicolons in iCalendar text (RFC 5545)', () => {
+    const show: TradeShow = { ...baseShow, description: 'Room A; Hall B' };
+    const result = generateICS(show)!;
+    expect(result).toContain('Room A\\; Hall B');
+  });
+
+  it('escapes backslashes in iCalendar text (RFC 5545)', () => {
+    const show: TradeShow = { ...baseShow, description: 'Path: C:\\Windows' };
+    const result = generateICS(show)!;
+    expect(result).toContain('C:\\\\Windows');
+  });
+
+  it('folds lines exceeding 75 characters (RFC 5545)', () => {
+    const show: TradeShow = { ...baseShow, title: 'A'.repeat(100) };
+    const result = generateICS(show)!;
+    for (const line of result.split('\r\n')) {
+      expect(line.length).toBeLessThanOrEqual(75);
+    }
+  });
+
+  it('uses CRLF line endings throughout', () => {
+    const result = generateICS(baseShow)!;
+    expect(result).toContain('\r\n');
+    // After removing all CRLF pairs, no bare LF should remain
+    expect(result.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+
+  it('contains STATUS:CONFIRMED', () => {
+    expect(generateICS(baseShow)).toContain('STATUS:CONFIRMED');
+  });
+
+  it('contains ORGANIZER with info@bapihvac.com', () => {
+    expect(generateICS(baseShow)).toContain('info@bapihvac.com');
+  });
+});
+
+// -------------------------------------------------------------------------
+// downloadICS (DOM-dependent, mocked)
+// -------------------------------------------------------------------------
+describe('downloadICS', () => {
+  let origCreateObjectURL: typeof URL.createObjectURL;
+  let origRevokeObjectURL: typeof URL.revokeObjectURL;
+
+  beforeEach(() => {
+    origCreateObjectURL = URL.createObjectURL;
+    origRevokeObjectURL = URL.revokeObjectURL;
+    // jsdom does not implement these; assign mocks directly
+    URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    URL.createObjectURL = origCreateObjectURL;
+    URL.revokeObjectURL = origRevokeObjectURL;
+    vi.restoreAllMocks();
+  });
+
+  it('calls URL.createObjectURL with a Blob', () => {
+    downloadICS(baseShow);
+    expect(URL.createObjectURL).toHaveBeenCalledOnce();
+    const arg = (URL.createObjectURL as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(arg).toBeInstanceOf(Blob);
+  });
+
+  it('calls URL.revokeObjectURL to release the object URL after download', () => {
+    downloadICS(baseShow);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
+  it('sets correct .ics download filename on the anchor element', () => {
+    const appendSpy = vi.spyOn(document.body, 'appendChild');
+    downloadICS(baseShow);
+    const link = appendSpy.mock.calls[0][0] as HTMLAnchorElement;
+    expect(link.download).toBe('test-show-2026.ics');
+    appendSpy.mockRestore();
+  });
+
+  it('warns and skips download when show has no startDate', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const show: TradeShow = { ...baseShow, startDate: '' };
+    downloadICS(show);
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no valid dates'));
+    warnSpy.mockRestore();
+  });
+});

--- a/web/src/lib/utils/__tests__/icsGenerator.test.ts
+++ b/web/src/lib/utils/__tests__/icsGenerator.test.ts
@@ -236,11 +236,14 @@ describe('downloadICS', () => {
     expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
   });
 
-  it('sets correct .ics download filename on the anchor element', () => {
+  it('sets correct .ics download filename derived from title (not id)', () => {
+    // Use a title whose slug differs from baseShow.id to prove the filename
+    // comes from title, not from id or a hard-coded value.
+    const show: TradeShow = { ...baseShow, title: 'AHR Expo Chicago 2027' };
     const appendSpy = vi.spyOn(document.body, 'appendChild');
-    downloadICS(baseShow);
+    downloadICS(show);
     const link = appendSpy.mock.calls[0][0] as HTMLAnchorElement;
-    expect(link.download).toBe('test-show-2026.ics');
+    expect(link.download).toBe('ahr-expo-chicago-2027.ics');
     appendSpy.mockRestore();
   });
 


### PR DESCRIPTION
170 new tests across 4 pure-function lib modules:
- lib/utils/__tests__/icsGenerator.test.ts (30 tests) RFC 5545 iCalendar output, line folding, UID stability, escaping, booth/contact/URL fields, downloadICS browser mock (URL.createObjectURL)
- lib/navigation/__tests__/applicationCategories.test.ts (36 tests) Category data shape, all 5 lookup helpers, breadcrumb trail generation
- lib/schema/__tests__/generators.test.ts (47 tests) JSON-LD generators: Organization, Product, BreadcrumbList, FAQPage, WebSite, schemaToJsonLd minification
- lib/metadata/__tests__/generators.test.ts (57 tests) LOCALE_TO_OG_LOCALE, LOCALE_TO_HREFLANG, SITE_CONFIG, generateProductMetadata, generateCategoryMetadata, generatePageMetadata, generateDefaultMetadata

Total test count: 2299 passing (was 2129)



