### PR TITLE
ci: add E2E smoke + auth CUJ jobs to CI pipeline (#574)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Open GitHub issue on CUJ failure
         if: ${{ failure() }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
     name: "E2E: smoke suite (Chromium, @smoke)"
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: web
@@ -171,6 +172,7 @@ jobs:
           name: playwright-smoke-${{ github.run_id }}
           path: web/playwright-report/
           retention-days: 7
+          if-no-files-found: ignore
 
   # ── E2E authenticated B2B CUJ ─────────────────────────────────────────────
   # Runs only on push to main (post-merge). Tests the full authenticated
@@ -181,6 +183,7 @@ jobs:
     name: "E2E: B2B auth CUJ (Chromium, main only)"
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 20
     if: ${{ github.ref == 'refs/heads/main' }}
     defaults:
       run:
@@ -243,3 +246,4 @@ jobs:
           name: playwright-auth-${{ github.run_id }}
           path: web/playwright-report/
           retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,12 +105,13 @@ jobs:
   # Runs on every PR and push. Targets the staging site so no local server is
   # required. Non-blocking (continue-on-error) because staging failures should
   # not block unrelated PRs — this is a canary, not a merge gate.
-  # Skips gracefully when STAGING_URL secret is not configured.
+  # Entire job is skipped (no runner allocated) when STAGING_URL is unset.
   e2e-smoke:
     name: "E2E: smoke suite (Chromium, @smoke)"
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 15
+    if: ${{ secrets.STAGING_URL != '' }}
     defaults:
       run:
         working-directory: web
@@ -155,13 +156,9 @@ jobs:
       - name: Run smoke suite
         env:
           CI: true
-          STAGING_URL: ${{ secrets.STAGING_URL }}
+          PLAYWRIGHT_BASE_URL: ${{ secrets.STAGING_URL }}
         run: |
-          if [ -z "$STAGING_URL" ]; then
-            echo "STAGING_URL secret not configured — skipping smoke suite"
-            exit 0
-          fi
-          PLAYWRIGHT_BASE_URL="$STAGING_URL" pnpm exec playwright test \
+          pnpm exec playwright test \
             --grep @smoke \
             --project=chromium
 
@@ -176,15 +173,15 @@ jobs:
 
   # ── E2E authenticated B2B CUJ ─────────────────────────────────────────────
   # Runs only on push to main (post-merge). Tests the full authenticated
-  # order journey against staging. Requires E2E_USERNAME, E2E_PASSWORD, and
-  # STAGING_URL secrets. Skips gracefully when any of these are missing.
-  # Non-blocking: a failed CUJ after merge opens a bug, does not revert.
+  # order journey against staging. Requires STAGING_URL, E2E_USERNAME, and
+  # E2E_PASSWORD secrets. Entire job is skipped (no runner allocated) when
+  # any of those secrets are absent. On failure, opens a GitHub issue.
   e2e-auth:
     name: "E2E: B2B auth CUJ (Chromium, main only)"
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 20
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' && secrets.STAGING_URL != '' && secrets.E2E_USERNAME != '' && secrets.E2E_PASSWORD != '' }}
     defaults:
       run:
         working-directory: web
@@ -229,15 +226,33 @@ jobs:
       - name: Run B2B auth CUJ
         env:
           CI: true
-          STAGING_URL: ${{ secrets.STAGING_URL }}
+          PLAYWRIGHT_BASE_URL: ${{ secrets.STAGING_URL }}
           E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
-        run: |
-          if [ -z "$STAGING_URL" ] || [ -z "$E2E_USERNAME" ] || [ -z "$E2E_PASSWORD" ]; then
-            echo "STAGING_URL / E2E_USERNAME / E2E_PASSWORD not fully configured — skipping auth CUJ"
-            exit 0
-          fi
-          PLAYWRIGHT_BASE_URL="$STAGING_URL" pnpm run test:e2e:auth
+        run: pnpm run test:e2e:auth
+
+      - name: Open GitHub issue on CUJ failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI: B2B auth CUJ failed on main (${context.sha.substring(0, 7)})`,
+              body: [
+                '## B2B Auth CUJ Failure',
+                '',
+                'The authenticated order-journey E2E suite failed after merging to `main`.',
+                '',
+                `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                `- **Commit:** ${context.sha}`,
+                '',
+                `Download the Playwright report artifact (screenshots + traces): \`playwright-auth-${context.runId}\``,
+              ].join('\n'),
+              labels: ['bug'],
+            });
 
       - name: Upload Playwright auth report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,146 @@ jobs:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
         run: pnpm run build
+
+  # ── E2E smoke suite ────────────────────────────────────────────────────────
+  # Runs on every PR and push. Targets the staging site so no local server is
+  # required. Non-blocking (continue-on-error) because staging failures should
+  # not block unrelated PRs — this is a canary, not a merge gate.
+  # Skips gracefully when STAGING_URL secret is not configured.
+  e2e-smoke:
+    name: "E2E: smoke suite (Chromium, @smoke)"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Playwright Chromium (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run smoke suite
+        env:
+          CI: true
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+        run: |
+          if [ -z "$STAGING_URL" ]; then
+            echo "STAGING_URL secret not configured — skipping smoke suite"
+            exit 0
+          fi
+          PLAYWRIGHT_BASE_URL="$STAGING_URL" pnpm exec playwright test \
+            --grep @smoke \
+            --project=chromium
+
+      - name: Upload Playwright smoke report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-${{ github.run_id }}
+          path: web/playwright-report/
+          retention-days: 7
+
+  # ── E2E authenticated B2B CUJ ─────────────────────────────────────────────
+  # Runs only on push to main (post-merge). Tests the full authenticated
+  # order journey against staging. Requires E2E_USERNAME, E2E_PASSWORD, and
+  # STAGING_URL secrets. Skips gracefully when any of these are missing.
+  # Non-blocking: a failed CUJ after merge opens a bug, does not revert.
+  e2e-auth:
+    name: "E2E: B2B auth CUJ (Chromium, main only)"
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    if: ${{ github.ref == 'refs/heads/main' }}
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Playwright Chromium (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run B2B auth CUJ
+        env:
+          CI: true
+          STAGING_URL: ${{ secrets.STAGING_URL }}
+          E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+        run: |
+          if [ -z "$STAGING_URL" ] || [ -z "$E2E_USERNAME" ] || [ -z "$E2E_PASSWORD" ]; then
+            echo "STAGING_URL / E2E_USERNAME / E2E_PASSWORD not fully configured — skipping auth CUJ"
+            exit 0
+          fi
+          PLAYWRIGHT_BASE_URL="$STAGING_URL" pnpm run test:e2e:auth
+
+      - name: Upload Playwright auth report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-auth-${{ github.run_id }}
+          path: web/playwright-report/
+          retention-days: 7

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -124,11 +124,15 @@ export default defineConfig({
     },
   ],
 
-  // Run local dev server before starting the tests
-  webServer: {
-    command: 'pnpm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-    timeout: 120 * 1000,
-  },
+  // Run local dev server before starting the tests.
+  // Skip when PLAYWRIGHT_BASE_URL points at a remote host (staging / preview)
+  // so CI jobs that target staging don't waste time booting a dev server.
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'pnpm run dev',
+        url: 'http://localhost:3000',
+        reuseExistingServer: !process.env.CI,
+        timeout: 120 * 1000,
+      },
 });

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -125,8 +125,9 @@ export default defineConfig({
   ],
 
   // Run local dev server before starting the tests.
-  // Skip when PLAYWRIGHT_BASE_URL points at a remote host (staging / preview)
-  // so CI jobs that target staging don't waste time booting a dev server.
+  // Skipped whenever PLAYWRIGHT_BASE_URL is set — the tests will hit that
+  // URL directly (staging, preview, or any other external host) and no
+  // local server is needed.
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {


### PR DESCRIPTION
## Summary

Re-enables E2E testing in CI, fixing the old "1.5 hour" problem that caused E2E to be commented out.

**Root cause of the original problem:** Running `playwright test --project=chromium` spawned all 5 browser projects against a locally-started dev server. Full matrix × cold Next.js startup = 90+ minutes.

**Solution:** Two focused, fast jobs that target the already-running staging site.

---

## Two new CI jobs

### `e2e-smoke` — every PR and push
- Runs only the `@smoke`-tagged tests (17 tests) against `STAGING_URL`
- Chromium only, browser binary cached by `pnpm-lock.yaml` hash
- Estimated runtime: ~2 minutes
- `continue-on-error: true` — canary signal, not a merge blocker
- Skips with `exit 0` when `STAGING_URL` secret is unset

### `e2e-auth` — push to main only (post-merge)
- Runs the full B2B authenticated order-journey CUJ (`pnpm run test:e2e:auth`)
- Requires `STAGING_URL` + `E2E_USERNAME` + `E2E_PASSWORD` secrets
- Shares the same Playwright Chromium cache as `e2e-smoke`
- `continue-on-error: true` — post-merge signal, opens a bug on failure
- Skips gracefully if any secret is missing

Both jobs upload `playwright-report/` as a 7-day artifact for debugging.

---

## Secrets needed (add in GitHub → Settings → Secrets)

| Secret | Used by |
|--------|---------|
| `STAGING_URL` | both jobs |
| `E2E_USERNAME` | `e2e-auth` only |
| `E2E_PASSWORD` | `e2e-auth` only |

Until these are added, both jobs exit 0 (graceful skip) so existing CI is unaffected.

---

## What was NOT changed
- The existing commented-out E2E block in `web-ci` is preserved as documentation
- The full 5-browser cross-browser matrix remains a local / manual concern
- Unit tests, Storybook a11y, and build steps are untouched