### PR TITLE
ci: use existing PREVIEW_INTEGRATION_URL secret for E2E jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,13 +105,13 @@ jobs:
   # Runs on every PR and push. Targets the staging site so no local server is
   # required. Non-blocking (continue-on-error) because staging failures should
   # not block unrelated PRs — this is a canary, not a merge gate.
-  # Entire job is skipped (no runner allocated) when STAGING_URL is unset.
+  # Entire job is skipped (no runner allocated) when PREVIEW_INTEGRATION_URL is unset.
   e2e-smoke:
     name: "E2E: smoke suite (Chromium, @smoke)"
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 15
-    if: ${{ secrets.STAGING_URL != '' }}
+    if: ${{ secrets.PREVIEW_INTEGRATION_URL != '' }}
     defaults:
       run:
         working-directory: web
@@ -156,7 +156,7 @@ jobs:
       - name: Run smoke suite
         env:
           CI: true
-          PLAYWRIGHT_BASE_URL: ${{ secrets.STAGING_URL }}
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PREVIEW_INTEGRATION_URL }}
         run: |
           pnpm exec playwright test \
             --grep @smoke \
@@ -173,15 +173,15 @@ jobs:
 
   # ── E2E authenticated B2B CUJ ─────────────────────────────────────────────
   # Runs only on push to main (post-merge). Tests the full authenticated
-  # order journey against staging. Requires STAGING_URL, E2E_USERNAME, and
-  # E2E_PASSWORD secrets. Entire job is skipped (no runner allocated) when
-  # any of those secrets are absent. On failure, opens a GitHub issue.
+  # order journey against staging. Requires PREVIEW_INTEGRATION_URL,
+  # E2E_USERNAME, and E2E_PASSWORD secrets. Entire job is skipped (no runner
+  # allocated) when any of those secrets are absent. On failure, opens a GitHub issue.
   e2e-auth:
     name: "E2E: B2B auth CUJ (Chromium, main only)"
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 20
-    if: ${{ github.ref == 'refs/heads/main' && secrets.STAGING_URL != '' && secrets.E2E_USERNAME != '' && secrets.E2E_PASSWORD != '' }}
+    if: ${{ github.ref == 'refs/heads/main' && secrets.PREVIEW_INTEGRATION_URL != '' && secrets.E2E_USERNAME != '' && secrets.E2E_PASSWORD != '' }}
     defaults:
       run:
         working-directory: web
@@ -226,7 +226,7 @@ jobs:
       - name: Run B2B auth CUJ
         env:
           CI: true
-          PLAYWRIGHT_BASE_URL: ${{ secrets.STAGING_URL }}
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PREVIEW_INTEGRATION_URL }}
           E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
         run: pnpm run test:e2e:auth


### PR DESCRIPTION
## Summary

The E2E CI jobs added in #574 referenced a `STAGING_URL` secret that needed to be created. This repo already has `PREVIEW_INTEGRATION_URL` configured (used by the preview integration workflow) pointing at the same staging site.

This PR swaps all `STAGING_URL` references to `PREVIEW_INTEGRATION_URL` so no new secret is needed — the smoke suite and auth CUJ jobs activate immediately on merge.

**Only secret still needed:** `E2E_USERNAME` + `E2E_PASSWORD` (regular WordPress login credentials for the auth CUJ).