### PR TITLE
test: fix E2E locators — /categories/ → /products/ URL pattern (#577)

### DIFF
--- a/web/tests/e2e/cart-checkout.spec.ts
+++ b/web/tests/e2e/cart-checkout.spec.ts
@@ -360,19 +360,19 @@ async function addProductToCart(page: Page) {
   
   // Wait for either category links OR product links to appear
   await Promise.race([
-    page.locator('a[href*="/categories/"]').first().waitFor({ state: 'attached', timeout: 10000 }),
-    page.locator('a[href*="/product/"]').first().waitFor({ state: 'attached', timeout: 10000 })
+    page.locator('a[href*="/products/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
+    page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 })
   ]).catch(() => {
     // If neither appears, continue anyway and let the assertions catch it
   });
 
   // Try to find a direct product link on the products page
-  let productLinks = page.locator('a[href*="/product/"]');
+  let productLinks = page.locator('a[href*="/product/"]:visible');
   let productCount = await productLinks.count();
   
   // If no products on main page, navigate into categories to find products
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/categories/"]');
+    const categoryLinks = page.locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {

--- a/web/tests/e2e/cart-checkout.spec.ts
+++ b/web/tests/e2e/cart-checkout.spec.ts
@@ -372,7 +372,7 @@ async function addProductToCart(page: Page) {
   
   // If no products on main page, navigate into categories to find products
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/products/"]:visible');
+    const categoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {
@@ -384,15 +384,15 @@ async function addProductToCart(page: Page) {
         // Wait for either product links or subcategory links to appear
         try {
           await Promise.race([
-            page.locator('a[href*="/product/"]').first().waitFor({ state: 'attached', timeout: 5000 }),
-            page.locator('a[href*="/products/"]').first().waitFor({ state: 'attached', timeout: 5000 }),
+            page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 5000 }),
+            page.locator('main').locator('a[href*="/products/"]:visible').first().waitFor({ state: 'visible', timeout: 5000 }),
           ]);
         } catch {
           // Neither found, wait a bit more for React
           await waitAfterNavigation(page);
         }
         
-        productLinks = page.locator('a[href*="/product/"]');
+        productLinks = page.locator('a[href*="/product/"]:visible');
         productCount = await productLinks.count();
       }
     }
@@ -401,7 +401,7 @@ async function addProductToCart(page: Page) {
   // If still no products, try navigating to first subcategory (up to 3 times)
   let attempts = 0;
   while (productCount === 0 && attempts < 3) {
-    const subcategoryLinks = page.locator('a[href*="/products/"]');
+    const subcategoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const subCount = await subcategoryLinks.count();
     
     if (subCount === 0) break;
@@ -413,13 +413,13 @@ async function addProductToCart(page: Page) {
       
       // Wait for product links to appear
       try {
-        await page.locator('a[href*="/product/"]').first().waitFor({ state: 'attached', timeout: 8000 });
+        await page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 8000 });
       } catch {
         // Products not found, wait a bit
         await waitAfterNavigation(page);
       }
       
-      productLinks = page.locator('a[href*="/product/"]');
+      productLinks = page.locator('a[href*="/product/"]:visible');
       productCount = await productLinks.count();
     }
     attempts++;

--- a/web/tests/e2e/cart-management.spec.ts
+++ b/web/tests/e2e/cart-management.spec.ts
@@ -570,11 +570,11 @@ async function addProductToCart(page: Page, forceDifferent: boolean = false): Pr
   let productCount = await productLinks.count();
   
   if (productCount === 0) {
-    const categoryLink = page.locator('a[href*="/products/"]:visible').first();
+    const categoryLink = page.locator('main').locator('a[href*="/products/"]:visible').first();
     if (await categoryLink.isVisible({ timeout: 3000 })) {
       await safeClick(categoryLink);
       await waitAfterNavigation(page);
-      productLinks = page.locator('a[href*="/product/"]');
+      productLinks = page.locator('a[href*="/product/"]:visible');
       productCount = await productLinks.count();
     }
   }

--- a/web/tests/e2e/cart-management.spec.ts
+++ b/web/tests/e2e/cart-management.spec.ts
@@ -566,11 +566,11 @@ async function addProductToCart(page: Page, forceDifferent: boolean = false): Pr
   await page.goto(routes.products(), { waitUntil: 'commit', timeout: 60000 });
   await waitAfterNavigation(page);
   
-  let productLinks = page.locator('a[href*="/product/"]');
+  let productLinks = page.locator('a[href*="/product/"]:visible');
   let productCount = await productLinks.count();
   
   if (productCount === 0) {
-    const categoryLink = page.locator('a[href*="/categories/"], a[href*="/category/"]').first();
+    const categoryLink = page.locator('a[href*="/products/"]:visible').first();
     if (await categoryLink.isVisible({ timeout: 3000 })) {
       await safeClick(categoryLink);
       await waitAfterNavigation(page);

--- a/web/tests/e2e/checkout-multi-locale.spec.ts
+++ b/web/tests/e2e/checkout-multi-locale.spec.ts
@@ -326,7 +326,7 @@ async function setupCheckoutWithProduct(page: Page, locale: string): Promise<voi
   
   // Navigate through categories if needed
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/products/"]:visible');
+    const categoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {
@@ -335,7 +335,7 @@ async function setupCheckoutWithProduct(page: Page, locale: string): Promise<voi
         await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
         await waitAfterNavigation(page);
         
-        productLinks = page.locator('a[href*="/product/"]');
+        productLinks = page.locator('a[href*="/product/"]:visible');
         productCount = await productLinks.count();
       }
     }

--- a/web/tests/e2e/checkout-multi-locale.spec.ts
+++ b/web/tests/e2e/checkout-multi-locale.spec.ts
@@ -321,12 +321,12 @@ async function setupCheckoutWithProduct(page: Page, locale: string): Promise<voi
   let productAdded = false;
   
   // Look for product links
-  let productLinks = page.locator('a[href*="/product/"]');
+  let productLinks = page.locator('a[href*="/product/"]:visible');
   let productCount = await productLinks.count();
   
   // Navigate through categories if needed
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/categories/"]');
+    const categoryLinks = page.locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {

--- a/web/tests/e2e/discount-coupons.spec.ts
+++ b/web/tests/e2e/discount-coupons.spec.ts
@@ -485,13 +485,13 @@ async function setupCheckoutWithProduct(page: Page, locale: string = 'en'): Prom
   let productCount = await productLinks.count();
   
   if (productCount === 0) {
-    const categoryLink = page.locator('a[href*="/products/"]:visible').first();
+    const categoryLink = page.locator('main').locator('a[href*="/products/"]:visible').first();
     if (await categoryLink.isVisible({ timeout: 3000 })) {
       const categoryHref = await categoryLink.getAttribute('href');
       if (categoryHref) {
         await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
         await waitAfterNavigation(page);
-        productLinks = page.locator('a[href*="/product/"]');
+        productLinks = page.locator('a[href*="/product/"]:visible');
         productCount = await productLinks.count();
       }
     }

--- a/web/tests/e2e/discount-coupons.spec.ts
+++ b/web/tests/e2e/discount-coupons.spec.ts
@@ -481,11 +481,11 @@ async function setupCheckoutWithProduct(page: Page, locale: string = 'en'): Prom
   
   // Find and add product
   let productAdded = false;
-  let productLinks = page.locator('a[href*="/product/"]');
+  let productLinks = page.locator('a[href*="/product/"]:visible');
   let productCount = await productLinks.count();
   
   if (productCount === 0) {
-    const categoryLink = page.locator('a[href*="/categories/"], a[href*="/category/"]').first();
+    const categoryLink = page.locator('a[href*="/products/"]:visible').first();
     if (await categoryLink.isVisible({ timeout: 3000 })) {
       const categoryHref = await categoryLink.getAttribute('href');
       if (categoryHref) {

--- a/web/tests/e2e/payment-flows.spec.ts
+++ b/web/tests/e2e/payment-flows.spec.ts
@@ -489,7 +489,7 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
   
   // If no products, navigate to first category
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/products/"]:visible');
+    const categoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {
@@ -498,7 +498,7 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
         await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
         await waitAfterNavigation(page);
         
-        productLinks = page.locator('a[href*="/product/"]');
+        productLinks = page.locator('a[href*="/product/"]:visible');
         productCount = await productLinks.count();
       }
     }
@@ -506,7 +506,7 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
   
   // Still no products? Try navigating through subcategories
   if (productCount === 0) {
-    const subcategoryLinks = page.locator('main a[href*="/products/"], article a[href*="/products/"]');
+    const subcategoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const subCount = await subcategoryLinks.count();
     
     if (subCount > 0) {
@@ -515,7 +515,7 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
         await page.goto(subHref, { waitUntil: 'commit', timeout: 60000 });
         await waitAfterNavigation(page);
         
-        productLinks = page.locator('a[href*="/product/"]');
+        productLinks = page.locator('a[href*="/product/"]:visible');
         productCount = await productLinks.count();
       }
     }

--- a/web/tests/e2e/payment-flows.spec.ts
+++ b/web/tests/e2e/payment-flows.spec.ts
@@ -475,8 +475,8 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
   
   // Wait for content to load
   await Promise.race([
-    page.locator('a[href*="/categories/"]').first().waitFor({ state: 'attached', timeout: 10000 }),
-    page.locator('a[href*="/product/"]').first().waitFor({ state: 'attached', timeout: 10000 }),
+    page.locator('a[href*="/products/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
+    page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
   ]).catch(() => {
     // Continue anyway
   });
@@ -484,12 +484,12 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
   let productAdded = false;
   
   // Try to find direct product links first
-  let productLinks = page.locator('a[href*="/product/"]');
+  let productLinks = page.locator('a[href*="/product/"]:visible');
   let productCount = await productLinks.count();
   
   // If no products, navigate to first category
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/categories/"]');
+    const categoryLinks = page.locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {

--- a/web/tests/e2e/products.spec.ts
+++ b/web/tests/e2e/products.spec.ts
@@ -32,19 +32,19 @@ import {
 async function navigateToAnyProduct(page: any): Promise<void> {
   // Wait for either category links OR product links to appear
   await Promise.race([
-    page.locator('a[href*="/categories/"]').first().waitFor({ state: 'attached', timeout: 10000 }),
-    page.locator('a[href*="/product/"]').first().waitFor({ state: 'attached', timeout: 10000 })
+    page.locator('a[href*="/products/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
+    page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 })
   ]).catch(() => {
     // If neither appears, continue anyway and let the assertions catch it
   });
 
   // Try to find a direct product link on the products page
-  let productLinks = page.locator('a[href*="/product/"]');
+  let productLinks = page.locator('a[href*="/product/"]:visible');
   let productCount = await productLinks.count();
   
   // If no products on main page, navigate into categories to find products
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/categories/"]');
+    const categoryLinks = page.locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {
@@ -101,7 +101,7 @@ test.describe('Product Pages', () => {
       
       // Wait for first category card to be visible and stable
       const firstCategoryCard = page
-        .locator('a[href*="/categories/"]')
+        .locator('a[href*="/products/"]:visible')
         .filter({ has: page.getByRole('heading', { level: 2 }) })
         .first();
       await waitForStableElement(firstCategoryCard);
@@ -113,9 +113,9 @@ test.describe('Product Pages', () => {
       const heading = page.getByRole('heading', { name: /products/i, level: 1 });
       await expect(heading).toBeVisible();
       
-      // On /products we expect category cards that link to /categories/{slug}
+      // On /products we expect category cards that link to /products/{slug}
       const categoryLinks = page
-        .locator('a[href*="/categories/"]')
+        .locator('a[href*="/products/"]:visible')
         .filter({ has: page.getByRole('heading', { level: 2 }) });
       const count = await categoryLinks.count();
       
@@ -126,7 +126,7 @@ test.describe('Product Pages', () => {
     test('should navigate from landing to category page', async ({ page }) => {
       // Click the first category card/link on the products landing page
       const firstCategory = page
-        .locator('a[href*="/categories/"]')
+        .locator('a[href*="/products/"]:visible')
         .filter({ has: page.getByRole('heading', { level: 2 }) })
         .first();
 

--- a/web/tests/e2e/products.spec.ts
+++ b/web/tests/e2e/products.spec.ts
@@ -44,7 +44,7 @@ async function navigateToAnyProduct(page: any): Promise<void> {
   
   // If no products on main page, navigate into categories to find products
   if (productCount === 0) {
-    const categoryLinks = page.locator('a[href*="/products/"]:visible');
+    const categoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const categoryCount = await categoryLinks.count();
     
     if (categoryCount > 0) {
@@ -54,7 +54,7 @@ async function navigateToAnyProduct(page: any): Promise<void> {
         await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
         await waitAfterNavigation(page);
         
-        productLinks = page.locator('a[href*="/product/"]');
+        productLinks = page.locator('a[href*="/product/"]:visible');
         productCount = await productLinks.count();
       }
     }
@@ -63,7 +63,7 @@ async function navigateToAnyProduct(page: any): Promise<void> {
   // If still no products, try navigating to first subcategory (up to 3 attempts)
   let attempts = 0;
   while (productCount === 0 && attempts < 3) {
-    const subcategoryLinks = page.locator('a[href*="/products/"]');
+    const subcategoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
     const subCount = await subcategoryLinks.count();
     
     if (subCount === 0) break;
@@ -74,7 +74,7 @@ async function navigateToAnyProduct(page: any): Promise<void> {
       await page.goto(subHref, { waitUntil: 'commit', timeout: 60000 });
       await waitAfterNavigation(page);
       
-      productLinks = page.locator('a[href*="/product/"]');
+      productLinks = page.locator('a[href*="/product/"]:visible');
       productCount = await productLinks.count();
     }
     attempts++;


### PR DESCRIPTION
## Root Cause

Post-launch E2E audit (148 failures, 58 passed out of 211 total) traced ~80 failures to a single selector mismatch.

All `addProductToCart` helpers used:
```typescript
page.locator('a[href*="/categories/"]')  // ← WRONG
```

But the site URL structure uses:
```
/en/products/{category}     ← category pages
/en/products/{cat}/{sub}    ← subcategory pages
/en/product/{slug}          ← product detail pages
```

Since `/categories/` never appears in any real URL, the helper found 0 category links, 0 products, and every test that needed a cart item failed immediately at `expect(productCount).toBeGreaterThan(0)`.

## Fix

Replace all `a[href*="/categories/"]` and `a[href*="/category/"]` with `a[href*="/products/"]:visible` across 6 spec files. Also update `Promise.race` waitFor from `state:'attached'` to `state:'visible'` to be consistent with the `:visible` CSS pseudo-class.

## Files Changed
| File | Change |
|------|--------|
| `cart-checkout.spec.ts` | `addProductToCart` helper + `Promise.race` |
| `cart-management.spec.ts` | `addProductToCart` helper |
| `checkout-multi-locale.spec.ts` | locale-aware cart helper |
| `discount-coupons.spec.ts` | cart helper |
| `payment-flows.spec.ts` | cart helper + `Promise.race` |
| `products.spec.ts` | `navigateToAnyProduct` + `beforeEach` + 2 category assertions |

## Expected Impact
Unblocks ~80 tests that cascade from the product drill-down failure. Remaining failures (~68) are independent issues (auth CUJ needs authenticated project, a11y violations, add-to-cart button locator refinements).