### PR TITLE
fix(e2e): extract shared addProductToCart helper; fix drill-down + ti…

### DIFF
--- a/web/tests/e2e/cart-management.spec.ts
+++ b/web/tests/e2e/cart-management.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { routes } from './helpers/routes';
 import { safeClick, waitForStableElement, waitForPageReady, waitAfterNavigation } from './helpers/test-utils';
+import { addProductToCart } from './helpers/cart-utils';
 
 /**
  * Cart Management Edge Cases E2E Tests (Phase G)
@@ -381,7 +382,7 @@ test.describe('Multiple Items Management', () => {
   test('should handle multiple different products in cart', async ({ page }) => {
     // Add two different products
     await addProductToCart(page);
-    await addProductToCart(page, true); // Force different product
+    await addProductToCart(page, { productIndex: 1 }); // Force different product
     
     await page.goto(routes.cart(), { waitUntil: 'commit', timeout: 60000 });
     await waitAfterNavigation(page);
@@ -405,7 +406,7 @@ test.describe('Multiple Items Management', () => {
 
   test('should update individual item quantities independently', async ({ page }) => {
     await addProductToCart(page);
-    await addProductToCart(page, true);
+    await addProductToCart(page, { productIndex: 1 });
     
     await page.goto(routes.cart(), { waitUntil: 'commit', timeout: 60000 });
     await waitAfterNavigation(page);
@@ -433,7 +434,7 @@ test.describe('Multiple Items Management', () => {
 
   test('should remove individual items without affecting others', async ({ page }) => {
     await addProductToCart(page);
-    await addProductToCart(page, true);
+    await addProductToCart(page, { productIndex: 1 });
     
     await page.goto(routes.cart(), { waitUntil: 'commit', timeout: 60000 });
     await waitAfterNavigation(page);
@@ -559,50 +560,7 @@ test.describe('Cart Error Handling', () => {
   });
 });
 
-/**
- * Helper: Add product to cart
- */
-async function addProductToCart(page: Page, forceDifferent: boolean = false): Promise<void> {
-  await page.goto(routes.products(), { waitUntil: 'commit', timeout: 60000 });
-  await waitAfterNavigation(page);
-  
-  let productLinks = page.locator('a[href*="/product/"]:visible');
-  let productCount = await productLinks.count();
-  
-  if (productCount === 0) {
-    const categoryLink = page.locator('main').locator('a[href*="/products/"]:visible').first();
-    if (await categoryLink.isVisible({ timeout: 3000 })) {
-      const categoryHref = await categoryLink.getAttribute('href');
-      if (categoryHref) {
-        await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
-        await waitAfterNavigation(page);
-        productLinks = page.locator('a[href*="/product/"]:visible');
-        productCount = await productLinks.count();
-      }
-    }
-  }
-  
-  if (productCount === 0) {
-    throw new Error('No products found after navigating through categories — cannot add to cart');
-  }
-  
-  const productIndex = forceDifferent ? Math.min(1, productCount - 1) : 0;
-  const productHref = await productLinks.nth(productIndex).getAttribute('href');
-  
-  if (productHref) {
-    await page.goto(productHref, { waitUntil: 'commit', timeout: 60000 });
-    await waitAfterNavigation(page);
-    
-    const addToCartButton = page.getByRole('button').filter({ hasText: /cart|carrito|panier/i });
-    
-    if (await addToCartButton.first().isVisible({ timeout: 3000 })) {
-      await safeClick(addToCartButton.first());
-      
-      // Wait for toast
-      await waitForToastToDismiss(page);
-    }
-  }
-}
+// addProductToCart is imported from helpers/cart-utils
 
 /**
  * Helper: Get cart total amount

--- a/web/tests/e2e/checkout-multi-locale.spec.ts
+++ b/web/tests/e2e/checkout-multi-locale.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { routes } from './helpers/routes';
 import { safeClick, waitAfterNavigation, waitForPageReady } from './helpers/test-utils';
+import { addProductToCart } from './helpers/cart-utils';
 
 /**
  * Multi-Locale Checkout E2E Tests (Phase B)
@@ -313,64 +314,8 @@ async function setupCheckoutWithProduct(page: Page, locale: string): Promise<voi
   await page.reload({ waitUntil: 'commit' });
   await waitAfterNavigation(page);
   
-  // Navigate to products page in specified locale
-  await page.goto(routes.products(locale), { waitUntil: 'commit', timeout: 60000 });
-  await waitAfterNavigation(page);
-  
-  // Find and add product (language-agnostic approach)
-  let productAdded = false;
-  
-  // Look for product links
-  let productLinks = page.locator('a[href*="/product/"]:visible');
-  let productCount = await productLinks.count();
-  
-  // Navigate through categories if needed
-  if (productCount === 0) {
-    const categoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
-    const categoryCount = await categoryLinks.count();
-    
-    if (categoryCount > 0) {
-      const categoryHref = await categoryLinks.first().getAttribute('href');
-      if (categoryHref) {
-        await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
-        await waitAfterNavigation(page);
-        
-        productLinks = page.locator('a[href*="/product/"]:visible');
-        productCount = await productLinks.count();
-      }
-    }
-  }
-  
-  // Try to add products (try first 3)
-  for (let i = 0; i < Math.min(productCount, 3); i++) {
-    const productHref = await productLinks.nth(i).getAttribute('href');
-    if (!productHref) continue;
-    
-    await page.goto(productHref, { waitUntil: 'commit', timeout: 60000 });
-    await waitAfterNavigation(page);
-    
-    // Look for Add to Cart button (language agnostic - uses button role)
-    const addToCartButton = page.getByRole('button').filter({ hasText: /cart|carrito|panier|warenkorb|カート/i });
-    const buttonVisible = await addToCartButton.first().isVisible({ timeout: 2000 }).catch(() => false);
-    
-    if (buttonVisible) {
-      await safeClick(addToCartButton.first());
-      
-      // Check for toast (success indicator)
-      const toast = page.locator('[role="alert"], [role="status"]');
-      const toastAppeared = await toast.first().isVisible({ timeout: 3000 }).catch(() => false);
-      
-      if (toastAppeared) {
-        await waitForToastToDismiss(page);
-        productAdded = true;
-        break;
-      }
-    }
-  }
-  
-  if (!productAdded) {
-    throw new Error(`Could not add product to cart in locale: ${locale}`);
-  }
+  // Navigate to products in locale, drill down through categories, and add a product to cart
+  await addProductToCart(page, { locale });
   
   // Navigate to checkout
   await page.goto(routes.checkout(locale), { waitUntil: 'commit', timeout: 60000 });

--- a/web/tests/e2e/discount-coupons.spec.ts
+++ b/web/tests/e2e/discount-coupons.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { routes } from './helpers/routes';
 import { safeClick, waitForStableElement, waitAfterNavigation, waitForPageReady } from './helpers/test-utils';
+import { addProductToCart } from './helpers/cart-utils';
 
 /**
  * Discount Codes & Coupons E2E Tests (Phase D)
@@ -475,56 +476,8 @@ async function setupCheckoutWithProduct(page: Page, locale: string = 'en'): Prom
   await page.reload({ waitUntil: 'commit' });
   await waitAfterNavigation(page);
   
-  // Navigate to products
-  await page.goto(routes.products(locale), { waitUntil: 'commit', timeout: 60000 });
-  await waitAfterNavigation(page);
-  
-  // Find and add product
-  let productAdded = false;
-  let productLinks = page.locator('a[href*="/product/"]:visible');
-  let productCount = await productLinks.count();
-  
-  if (productCount === 0) {
-    const categoryLink = page.locator('main').locator('a[href*="/products/"]:visible').first();
-    if (await categoryLink.isVisible({ timeout: 3000 })) {
-      const categoryHref = await categoryLink.getAttribute('href');
-      if (categoryHref) {
-        await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
-        await waitAfterNavigation(page);
-        productLinks = page.locator('a[href*="/product/"]:visible');
-        productCount = await productLinks.count();
-      }
-    }
-  }
-  
-  for (let i = 0; i < Math.min(productCount, 3); i++) {
-    const productHref = await productLinks.nth(i).getAttribute('href');
-    if (!productHref) continue;
-    
-    await page.goto(productHref, { waitUntil: 'commit', timeout: 60000 });
-    await waitAfterNavigation(page);
-    
-    const addToCartButton = page.getByRole('button').filter({ hasText: /cart|carrito|panier/i });
-    const buttonVisible = await addToCartButton.first().isVisible({ timeout: 2000 }).catch(() => false);
-    
-    if (buttonVisible) {
-      await safeClick(addToCartButton.first());
-      
-      // Wait for success toast
-      const toast = page.locator('[role="alert"], [role="status"]');
-      const toastAppeared = await toast.first().waitFor({ state: 'visible', timeout: 3000 }).then(() => true).catch(() => false);
-      
-      if (toastAppeared) {
-        await waitForToastToDismiss(page);
-        productAdded = true;
-        break;
-      }
-    }
-  }
-  
-  if (!productAdded) {
-    throw new Error(`Could not add product to cart in locale: ${locale}`);
-  }
+  // Navigate to products in locale, drill down through categories, and add a product to cart
+  await addProductToCart(page, { locale });
   
   // Navigate to checkout
   await page.goto(routes.checkout(locale), { waitUntil: 'commit', timeout: 60000 });

--- a/web/tests/e2e/helpers/cart-utils.ts
+++ b/web/tests/e2e/helpers/cart-utils.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
-import { routes } from './routes';
+import { routes, DEFAULT_LOCALE } from './routes';
 import { safeClick, waitForStableElement, waitAfterNavigation, waitForFullPageLoad } from './test-utils';
 
 /**
@@ -17,16 +17,17 @@ import { safeClick, waitForStableElement, waitAfterNavigation, waitForFullPageLo
  * 6. Verify the cart badge updates to show at least one item.
  *
  * @param page         Playwright Page instance
- * @param options.locale       BCP-47 locale code for locale-prefixed routes (default: 'en')
+ * @param options.locale       BCP-47 locale code for locale-prefixed routes (default: DEFAULT_LOCALE)
  * @param options.productIndex Which product to add (0-based). Clamped to available count.
  */
 export async function addProductToCart(
   page: Page,
   options: { locale?: string; productIndex?: number } = {}
 ): Promise<void> {
-  const { locale = 'en', productIndex = 0 } = options;
+  const { locale = DEFAULT_LOCALE, productIndex = 0 } = options;
 
   await page.goto(routes.products(locale), { waitUntil: 'commit', timeout: 60000 });
+  await waitAfterNavigation(page);
 
   // Wait for either category links OR direct product links to appear
   await Promise.race([

--- a/web/tests/e2e/helpers/cart-utils.ts
+++ b/web/tests/e2e/helpers/cart-utils.ts
@@ -1,0 +1,112 @@
+import type { Page } from '@playwright/test';
+import { expect } from '@playwright/test';
+import { routes } from './routes';
+import { safeClick, waitForStableElement, waitAfterNavigation, waitForFullPageLoad } from './test-utils';
+
+/**
+ * Shared robust add-to-cart helper used across E2E spec files.
+ *
+ * Strategy (mirrors the working cart-checkout.spec.ts pattern):
+ * 1. Navigate to the products landing page (locale-aware).
+ * 2. Drill down through the category → subcategory tree with a while-loop
+ *    (up to 3 hops) until individual product links (/product/) are found.
+ * 3. Navigate to the product at `productIndex` (defaults to 0).
+ * 4. Handle variable products — select the first radio option for every
+ *    required attribute group so the Add to Cart button becomes active.
+ * 5. Wait up to 20 s for the Add to Cart button then click it.
+ * 6. Verify the cart badge updates to show at least one item.
+ *
+ * @param page         Playwright Page instance
+ * @param options.locale       BCP-47 locale code for locale-prefixed routes (default: 'en')
+ * @param options.productIndex Which product to add (0-based). Clamped to available count.
+ */
+export async function addProductToCart(
+  page: Page,
+  options: { locale?: string; productIndex?: number } = {}
+): Promise<void> {
+  const { locale = 'en', productIndex = 0 } = options;
+
+  await page.goto(routes.products(locale), { waitUntil: 'commit', timeout: 60000 });
+
+  // Wait for either category links OR direct product links to appear
+  await Promise.race([
+    page.locator('a[href*="/products/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
+    page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
+  ]).catch(() => {
+    // Neither appeared — continue and let the assertion below catch it
+  });
+
+  let productLinks = page.locator('a[href*="/product/"]:visible');
+  let productCount = await productLinks.count();
+
+  // Drill down category → subcategory → product (up to 3 levels)
+  let attempts = 0;
+  while (productCount === 0 && attempts < 3) {
+    const subcategoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
+    const subCount = await subcategoryLinks.count();
+    if (subCount === 0) break;
+
+    const subHref = await subcategoryLinks.first().getAttribute('href');
+    if (!subHref) break;
+
+    await page.goto(subHref, { waitUntil: 'commit', timeout: 60000 });
+    try {
+      await page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 8000 });
+    } catch {
+      await waitAfterNavigation(page);
+    }
+
+    productLinks = page.locator('a[href*="/product/"]:visible');
+    productCount = await productLinks.count();
+    attempts++;
+  }
+
+  expect(productCount).toBeGreaterThan(0);
+
+  // Clamp index so we never exceed what's available
+  const safeIndex = Math.min(productIndex, productCount - 1);
+  const productHref = await productLinks.nth(safeIndex).getAttribute('href');
+  expect(productHref).toBeTruthy();
+
+  await page.goto(productHref!, { waitUntil: 'commit', timeout: 60000 });
+  await waitForFullPageLoad(page);
+
+  // Handle variable products — select first radio for every attribute group
+  const configureMessage = page.getByText(/configure.*specifications|select.*specifications/i);
+  const hasConfigureMessage = await Promise.race([
+    configureMessage.count().then(c => c > 0),
+    page.waitForTimeout(2000).then(() => false),
+  ]);
+
+  if (hasConfigureMessage) {
+    const attributeNames: string[] = await page.evaluate(() => {
+      const radios = Array.from(document.querySelectorAll('input[type="radio"]'));
+      const names = radios.map(r => r.getAttribute('name')).filter(Boolean) as string[];
+      return [...new Set(names)];
+    });
+
+    for (const attributeName of attributeNames.slice(0, 5)) {
+      const firstRadio = page.locator(`input[type="radio"][name="${attributeName}"]`).first();
+      const radioId = await firstRadio.getAttribute('id');
+      if (radioId) {
+        const label = page.locator(`label[for="${radioId}"]`);
+        const isChecked = await firstRadio.isChecked();
+        if (!isChecked) {
+          await label.click({ timeout: 2000 });
+          await page.waitForTimeout(200);
+        }
+      }
+    }
+    await page.waitForTimeout(500);
+  }
+
+  // Wait for Add to Cart button and click it
+  const addToCartButton = page.getByRole('button', { name: /Add.*to cart/i });
+  await addToCartButton.waitFor({ state: 'visible', timeout: 20000 });
+  await waitForStableElement(addToCartButton);
+  await safeClick(addToCartButton);
+
+  // Verify cart badge updated (shows any digit)
+  const cartBadge = page.getByRole('link', { name: /cart/i }).first();
+  await expect(cartBadge).toContainText(/\d+/, { timeout: 10000 });
+}

--- a/web/tests/e2e/payment-flows.spec.ts
+++ b/web/tests/e2e/payment-flows.spec.ts
@@ -3,6 +3,7 @@ import { injectAxe, checkA11y } from 'axe-playwright';
 import type { Page } from '@playwright/test';
 import { routes, DEFAULT_LOCALE } from './helpers/routes';
 import { safeClick, waitForStableElement, waitForPageReady, waitAfterNavigation } from './helpers/test-utils';
+import { addProductToCart } from './helpers/cart-utils';
 
 /**
  * Payment Flow E2E Tests (Phase A)
@@ -468,99 +469,9 @@ async function setupCheckoutWithProduct(page: Page): Promise<void> {
   await page.evaluate(() => localStorage.clear());
   await page.reload({ waitUntil: 'commit' });
   await waitForPageReady(page);
-  
-  // Navigate to products page
-  await page.goto(routes.products(), { waitUntil: 'commit', timeout: 60000 });
-  await waitAfterNavigation(page);
-  
-  // Wait for content to load
-  await Promise.race([
-    page.locator('a[href*="/products/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
-    page.locator('a[href*="/product/"]:visible').first().waitFor({ state: 'visible', timeout: 10000 }),
-  ]).catch(() => {
-    // Continue anyway
-  });
-  
-  let productAdded = false;
-  
-  // Try to find direct product links first
-  let productLinks = page.locator('a[href*="/product/"]:visible');
-  let productCount = await productLinks.count();
-  
-  // If no products, navigate to first category
-  if (productCount === 0) {
-    const categoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
-    const categoryCount = await categoryLinks.count();
-    
-    if (categoryCount > 0) {
-      const categoryHref = await categoryLinks.first().getAttribute('href');
-      if (categoryHref) {
-        await page.goto(categoryHref, { waitUntil: 'commit', timeout: 60000 });
-        await waitAfterNavigation(page);
-        
-        productLinks = page.locator('a[href*="/product/"]:visible');
-        productCount = await productLinks.count();
-      }
-    }
-  }
-  
-  // Still no products? Try navigating through subcategories
-  if (productCount === 0) {
-    const subcategoryLinks = page.locator('main').locator('a[href*="/products/"]:visible');
-    const subCount = await subcategoryLinks.count();
-    
-    if (subCount > 0) {
-      const subHref = await subcategoryLinks.first().getAttribute('href');
-      if (subHref) {
-        await page.goto(subHref, { waitUntil: 'commit', timeout: 60000 });
-        await waitAfterNavigation(page);
-        
-        productLinks = page.locator('a[href*="/product/"]:visible');
-        productCount = await productLinks.count();
-      }
-    }
-  }
-  
-  // Must have at least one product by now
-  if (productCount === 0) {
-    throw new Error('No products found after navigating through categories');
-  }
-  
-  // Snapshot all product hrefs BEFORE navigating away (locator becomes stale after page change)
-  const productHrefs: string[] = [];
-  for (let i = 0; i < Math.min(productCount, 3); i++) {
-    const href = await productLinks.nth(i).getAttribute('href');
-    if (href) productHrefs.push(href);
-  }
-  
-  // Try to add products to cart using the snapshotted hrefs
-  for (const productHref of productHrefs) {
-    await page.goto(productHref, { waitUntil: 'commit', timeout: 60000 });
-    await waitAfterNavigation(page);
-    
-    // Check for Add to Cart button
-    const addToCartButton = page.getByRole('button', { name: /add to cart/i });
-    const buttonVisible = await addToCartButton.isVisible({ timeout: 2000 }).catch(() => false);
-    
-    if (buttonVisible) {
-      await safeClick(addToCartButton);
-      await waitForPageReady(page);
-      
-      // Check if toast appeared (indicating success)
-      const toast = page.locator('[role="alert"], [role="status"]').filter({ hasText: /added to cart/i });
-      const toastAppeared = await toast.isVisible({ timeout: 3000 }).catch(() => false);
-      
-      if (toastAppeared) {
-        await waitForToastToDismiss(page);
-        productAdded = true;
-        break;
-      }
-    }
-  }
-  
-  if (!productAdded) {
-    throw new Error('Could not add any product to cart (all out of stock or no Add to Cart button)');
-  }
+
+  // Navigate to products, drill down through categories, add a product to cart
+  await addProductToCart(page);
   
   // Navigate to checkout
   await page.goto(routes.checkout(), { waitUntil: 'commit', timeout: 60000 });


### PR DESCRIPTION
Root causes addressed:
- One-level category drill-down: replaced with while-loop (up to 3 hops) matching the working cart-checkout.spec.ts pattern
- isVisible({ timeout: 2000 }) on add-to-cart button: replaced with waitFor({ state: 'visible', timeout: 20000 })
- Variable product handling: select first radio option for each attribute group before clicking Add to Cart
- Button selector: getByRole('button').filter(hasText: /cart|.../) replaced with getByRole('button', { name: /Add.*to cart/i })
- Toast-based success check: replaced with cart badge numeric check (toContainText(/\d+/))

Files changed:
- web/tests/e2e/helpers/cart-utils.ts (new shared helper)
- web/tests/e2e/cart-management.spec.ts (import shared helper; fix forceDifferent calls)
- web/tests/e2e/checkout-multi-locale.spec.ts (import shared helper)
- web/tests/e2e/discount-coupons.spec.ts (import shared helper)
- web/tests/e2e/payment-flows.spec.ts (import shared helper; simplify setupCheckoutWithProduct)

Expected improvement: ~86 currently failing tests should start passing
(cart-management: 22, checkout-multi-locale: 26, discount-coupons: 18, payment-flows: 20)

