### PR TITLE
Fix/claude model update

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -45,7 +45,7 @@
     "youtube:help": "tsx scripts/youtube-cli.ts help"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.71.2",
+    "@anthropic-ai/sdk": "^0.109.0",
     "@aws-sdk/client-ses": "^3.985.0",
     "@headlessui/react": "^2.2.9",
     "@heroicons/react": "^2.2.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.71.2
-        version: 0.71.2(zod@3.25.76)
+        specifier: ^0.109.0
+        version: 0.109.0(zod@3.25.76)
       '@aws-sdk/client-ses':
         specifier: ^3.985.0
         version: 3.1001.0
@@ -325,8 +325,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.71.2':
-    resolution: {integrity: sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ==}
+  '@anthropic-ai/sdk@0.109.0':
+    resolution: {integrity: sha512-y7P4eLyW5uNut4fXpOUEHqhJwx7dnxrWAfCQE4Lcgm0hSFQuIeHa7CWEKE5dFolEjQJE/RFKkppjri05r2OK/Q==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -3556,6 +3556,9 @@ packages:
     resolution: {integrity: sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==}
     engines: {node: '>=18.0.0'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -6156,6 +6159,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -9053,6 +9059,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -10117,9 +10126,10 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.71.2(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.109.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 3.25.76
 
@@ -14280,6 +14290,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@storybook/addon-a11y@10.2.15(storybook@10.2.15(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))':
@@ -17386,6 +17398,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -20849,6 +20863,11 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/web/scripts/test-claude-api.mjs
+++ b/web/scripts/test-claude-api.mjs
@@ -29,12 +29,11 @@ const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
 // Try different model names
 const modelsToTest = [
-  'claude-3-5-sonnet-20240620',
-  'claude-3-5-sonnet-latest',
-  'claude-3-5-sonnet-20241022',
-  'claude-3-opus-20240229',
-  'claude-3-sonnet-20240229',
-  'claude-3-haiku-20240307',
+  'claude-haiku-4-5',
+  'claude-sonnet-5',
+  'claude-opus-4-8',
+  'claude-sonnet-4-6',
+  'claude-opus-4-7',
 ];
 
 console.log('📋 Testing models:\n');

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -205,8 +205,13 @@ export async function POST(request: NextRequest) {
     ? `${SYSTEM_PROMPT}\n\n**User's Language:** ${locale.toUpperCase()} - Respond in this language.`
     : SYSTEM_PROMPT;
 
-  const systemPromptWithContext = pageContext
-    ? `${systemPromptText}\n\n**Current Page:** User is viewing \`${pageContext}\` — tailor your response to this context if relevant.`
+  // Sanitize pageContext: allow only safe path characters, strip newlines/backticks
+  const safePageContext = pageContext
+    ? pageContext.replace(/[`\n\r]/g, '').replace(/[^a-zA-Z0-9/_\-=?&.]/g, '').slice(0, 200)
+    : undefined;
+
+  const systemPromptWithContext = safePageContext
+    ? `${systemPromptText}\n\n**Current Page:** User is viewing ${safePageContext} — tailor your response to this context if relevant.`
     : systemPromptText;
 
   // Cache the system prompt for 5 minutes — saves ~90% on repeated input token costs
@@ -293,7 +298,11 @@ export async function POST(request: NextRequest) {
           const toolUse = finalMessage.content.find(
             (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use'
           );
-          if (!toolUse) break;
+          if (!toolUse) {
+            // tool_use stop_reason but no tool_use block — signal done to unblock client
+            enqueue({ type: 'done', conversationId, usage: finalMessage.usage });
+            break;
+          }
 
           toolsUsed.push(toolUse.name);
           let toolResultContent = 'No results found.';
@@ -313,6 +322,11 @@ export async function POST(request: NextRequest) {
               content: [{ type: 'tool_result' as const, tool_use_id: toolUse.id, content: toolResultContent }],
             },
           ];
+
+          // Safety: if we've exhausted iterations, signal done so client isn't left hanging
+          if (i === MAX_TOOL_ITERATIONS - 1) {
+            enqueue({ type: 'done', conversationId, usage: finalMessage.usage });
+          }
         }
       } catch (error) {
         logger.error('Chat API Error', {

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -144,196 +144,179 @@ export async function POST(request: NextRequest) {
   const toolsUsed: string[] = [];
   const productsRecommended: string[] = [];
 
-  try {
-    // Get user's customer groups for B2B product filtering
-    const customerGroups = await getUserCustomerGroups();
+  // --- Pre-flight checks (non-streaming) ---
+  const customerGroups = await getUserCustomerGroups();
 
-    // Rate limiting - prevent abuse of expensive AI API calls
-    const clientIP = getClientIP(request);
-    const rateLimitResult = checkRateLimit(clientIP, RATE_LIMITS.CHAT_API);
+  const clientIP = getClientIP(request);
+  const rateLimitResult = checkRateLimit(clientIP, RATE_LIMITS.CHAT_API);
 
-    if (!rateLimitResult.success) {
-      logger.warn('Chat API rate limit exceeded', {
-        ip: clientIP,
-        limit: rateLimitResult.limit,
-        reset: new Date(rateLimitResult.reset * 1000).toISOString(),
-      });
-
-      return NextResponse.json(
-        {
-          error: 'Rate limit exceeded',
-          message: `Too many chat requests. Please try again in ${Math.ceil((rateLimitResult.reset * 1000 - Date.now()) / 1000)} seconds.`,
-          retryAfter: Math.ceil((rateLimitResult.reset * 1000 - Date.now()) / 1000),
-        },
-        {
-          status: 429,
-          headers: {
-            'X-RateLimit-Limit': String(rateLimitResult.limit),
-            'X-RateLimit-Remaining': String(rateLimitResult.remaining),
-            'X-RateLimit-Reset': String(rateLimitResult.reset),
-            'Retry-After': String(Math.ceil((rateLimitResult.reset * 1000 - Date.now()) / 1000)),
-          },
-        }
-      );
-    }
-
-    // Check if API key is configured
-    if (!process.env.ANTHROPIC_API_KEY) {
-      logger.error('ANTHROPIC_API_KEY not found in environment variables');
-      return NextResponse.json(
-        {
-          error: 'Configuration error',
-          message: 'AI service is not properly configured. Please contact support.',
-        },
-        { status: 500 }
-      );
-    }
-
-    const { messages, locale } = await request.json();
-
-    if (!messages || !Array.isArray(messages)) {
-      return NextResponse.json(
-        { error: 'Invalid request: messages array required' },
-        { status: 400 }
-      );
-    }
-
-    // Get user's message (last message in array)
-    const userMessage = messages[messages.length - 1]?.content || '';
-
-    // Add locale hint to system prompt if provided
-    const systemPrompt = locale
-      ? `${SYSTEM_PROMPT}\n\n**User's Language:** ${locale.toUpperCase()} - Respond in this language.`
-      : SYSTEM_PROMPT;
-
-    // Initial API call to Claude
-    let response = await anthropic.messages.create({
-      model: 'claude-haiku-4-5',
-      max_tokens: 1024,
-      system: systemPrompt,
-      tools,
-      messages: messages.map((msg: { role: string; content: string }) => ({
-        role: (msg.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
-        content: msg.content,
-      })),
+  if (!rateLimitResult.success) {
+    logger.warn('Chat API rate limit exceeded', {
+      ip: clientIP,
+      limit: rateLimitResult.limit,
+      reset: new Date(rateLimitResult.reset * 1000).toISOString(),
     });
-
-    // Handle tool use (function calling)
-    while (response.stop_reason === 'tool_use') {
-      const toolUse = response.content.find((block) => block.type === 'tool_use') as any;
-
-      if (!toolUse) break;
-
-      let toolResult: any;
-
-      // Execute the tool
-      if (toolUse.name === 'search_products') {
-        toolsUsed.push('search_products');
-
-        const { query, limit = 5 } = toolUse.input;
-        // Apply customer group filtering for B2B access control
-        const products = await searchProducts(query, limit, customerGroups);
-        const formattedProducts = formatProductsForAI(products);
-
-        // Track recommended products
-        products.forEach((product) => {
-          if (product.slug) {
-            productsRecommended.push(product.slug);
-          }
-        });
-
-        toolResult = {
-          type: 'tool_result',
-          tool_use_id: toolUse.id,
-          content: formattedProducts,
-        };
-      }
-
-      // Continue conversation with tool result
-      response = await anthropic.messages.create({
-        model: 'claude-haiku-4-5',
-        max_tokens: 1024,
-        system: systemPrompt,
-        tools,
-        messages: [
-          ...messages.map((msg: { role: string; content: string }) => ({
-            role: (msg.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
-            content: msg.content,
-          })),
-          {
-            role: 'assistant' as const,
-            content: response.content,
-          },
-          {
-            role: 'user' as const,
-            content: [toolResult],
-          },
-        ],
-      });
-    }
-
-    // Extract final text response
-    const assistantMessage = response.content.find((block) => block.type === 'text');
-    const text = assistantMessage?.type === 'text' ? assistantMessage.text : '';
-
-    // Calculate metrics
-    const responseTimeMs = Date.now() - startTime;
-    const tokensUsed = response.usage.input_tokens + response.usage.output_tokens;
-
-    // Log analytics (non-blocking)
-    const analytics: ChatAnalytics = {
-      conversationId,
-      timestamp: new Date().toISOString(),
-      language: locale || 'en',
-      userMessage,
-      assistantResponse: text,
-      productsRecommended: productsRecommended.length > 0 ? productsRecommended : undefined,
-      toolsUsed: toolsUsed.length > 0 ? toolsUsed : undefined,
-      tokensUsed,
-      responseTimeMs,
-    };
-
-    // Log without awaiting (don't block response)
-    logChatAnalytics(analytics).catch((err) => logger.error('Failed to log analytics', err));
-
-    return NextResponse.json({
-      message: text,
-      conversationId, // Return ID so client can submit feedback later
-      usage: {
-        input_tokens: response.usage.input_tokens,
-        output_tokens: response.usage.output_tokens,
-      },
-    });
-  } catch (error) {
-    logger.error('Chat API Error', {
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack?.split('\n')[1]?.trim() : undefined,
-    });
-
-    // Handle Anthropic API errors
-    if (error instanceof Anthropic.APIError) {
-      logger.error('Anthropic API Error', {
-        status: error.status,
-        message: error.message,
-        name: error.name,
-      });
-      return NextResponse.json(
-        {
-          error: 'AI service error',
-          message: 'Unable to process your request. Please try again.',
-          details: error.message,
-        },
-        { status: error.status || 500 }
-      );
-    }
-
-    // Handle other errors
     return NextResponse.json(
       {
-        error: 'Internal server error',
-        message: 'Something went wrong. Please try again later.',
+        error: 'Rate limit exceeded',
+        message: `Too many chat requests. Please try again in ${Math.ceil((rateLimitResult.reset * 1000 - Date.now()) / 1000)} seconds.`,
+        retryAfter: Math.ceil((rateLimitResult.reset * 1000 - Date.now()) / 1000),
       },
+      {
+        status: 429,
+        headers: {
+          'X-RateLimit-Limit': String(rateLimitResult.limit),
+          'X-RateLimit-Remaining': String(rateLimitResult.remaining),
+          'X-RateLimit-Reset': String(rateLimitResult.reset),
+          'Retry-After': String(Math.ceil((rateLimitResult.reset * 1000 - Date.now()) / 1000)),
+        },
+      }
+    );
+  }
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    logger.error('ANTHROPIC_API_KEY not found in environment variables');
+    return NextResponse.json(
+      { error: 'Configuration error', message: 'AI service is not properly configured. Please contact support.' },
       { status: 500 }
     );
   }
+
+  let parsedBody: { messages?: unknown; locale?: string };
+  try {
+    parsedBody = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const { messages, locale } = parsedBody;
+
+  if (!messages || !Array.isArray(messages)) {
+    return NextResponse.json({ error: 'Invalid request: messages array required' }, { status: 400 });
+  }
+
+  const userMessage = (messages[messages.length - 1] as { content?: string })?.content || '';
+
+  const systemPrompt = locale
+    ? `${SYSTEM_PROMPT}\n\n**User's Language:** ${locale.toUpperCase()} - Respond in this language.`
+    : SYSTEM_PROMPT;
+
+  // --- Streaming response ---
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const enqueue = (data: object) =>
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+      try {
+        let currentMessages: Anthropic.MessageParam[] = messages.map(
+          (msg: { role: string; content: string }) => ({
+            role: (msg.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+            content: msg.content,
+          })
+        );
+
+        // Tool-use loop: non-streaming passes resolve quickly; final text response streams
+        const MAX_TOOL_ITERATIONS = 3;
+        for (let i = 0; i < MAX_TOOL_ITERATIONS; i++) {
+          const apiStream = anthropic.messages.stream({
+            model: 'claude-haiku-4-5',
+            max_tokens: 1024,
+            system: systemPrompt,
+            tools,
+            messages: currentMessages,
+          });
+
+          // Stream text tokens to client as they arrive
+          for await (const event of apiStream) {
+            if (
+              event.type === 'content_block_delta' &&
+              event.delta.type === 'text_delta' &&
+              event.delta.text
+            ) {
+              enqueue({ type: 'token', text: event.delta.text });
+            }
+          }
+
+          const finalMessage = await apiStream.finalMessage();
+
+          if (finalMessage.stop_reason !== 'tool_use') {
+            // Done — log analytics and signal completion
+            const fullText = finalMessage.content
+              .filter((b): b is Anthropic.TextBlock => b.type === 'text')
+              .map((b) => b.text)
+              .join('');
+
+            const responseTimeMs = Date.now() - startTime;
+            const tokensUsed = finalMessage.usage.input_tokens + finalMessage.usage.output_tokens;
+
+            const analytics: ChatAnalytics = {
+              conversationId,
+              timestamp: new Date().toISOString(),
+              language: locale || 'en',
+              userMessage,
+              assistantResponse: fullText,
+              productsRecommended: productsRecommended.length > 0 ? productsRecommended : undefined,
+              toolsUsed: toolsUsed.length > 0 ? toolsUsed : undefined,
+              tokensUsed,
+              responseTimeMs,
+            };
+            logChatAnalytics(analytics).catch((err) => logger.error('Failed to log analytics', err));
+
+            enqueue({ type: 'done', conversationId, usage: finalMessage.usage });
+            break;
+          }
+
+          // Execute the tool call, then loop for the next streaming response
+          const toolUse = finalMessage.content.find(
+            (b): b is Anthropic.ToolUseBlock => b.type === 'tool_use'
+          );
+          if (!toolUse) break;
+
+          toolsUsed.push(toolUse.name);
+          let toolResultContent = 'No results found.';
+
+          if (toolUse.name === 'search_products') {
+            const input = toolUse.input as { query: string; limit?: number };
+            const products = await searchProducts(input.query, input.limit ?? 5, customerGroups);
+            products.forEach((p) => { if (p.slug) productsRecommended.push(p.slug); });
+            toolResultContent = formatProductsForAI(products);
+          }
+
+          currentMessages = [
+            ...currentMessages,
+            { role: 'assistant' as const, content: finalMessage.content },
+            {
+              role: 'user' as const,
+              content: [{ type: 'tool_result' as const, tool_use_id: toolUse.id, content: toolResultContent }],
+            },
+          ];
+        }
+      } catch (error) {
+        logger.error('Chat API Error', {
+          message: error instanceof Error ? error.message : String(error),
+          stack: error instanceof Error ? error.stack?.split('\n')[1]?.trim() : undefined,
+        });
+
+        if (error instanceof Anthropic.APIError) {
+          logger.error('Anthropic API Error', { status: error.status, message: error.message });
+          enqueue({ type: 'error', message: 'Unable to process your request. Please try again.' });
+        } else {
+          enqueue({ type: 'error', message: 'Something went wrong. Please try again later.' });
+        }
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
 }

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -104,7 +104,7 @@ BAPI products are used in mission-critical environments (hospitals, cleanrooms, 
 When users ask about specific products or need recommendations, use the search_products tool to find real BAPI products from the catalog. 
 
 **IMPORTANT - Always include product links:**
-- When recommending products, ALWAYS include clickable links using markdown format: [Product Name](/products/slug)
+- When recommending products, ALWAYS include clickable links using markdown format: [Product Name](/product/slug)
 - Example: "I recommend the [BAPI-Stat Zone Temp Sensor](/product/bapi-stat-zone) for cleanrooms"
 - Make it easy for users to view full specifications by clicking the link
 - Format as: [Product Name](URL) - NOT just "view at URL"

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -189,7 +189,11 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
 
-  const { messages, locale } = parsedBody;
+  const { messages, locale, pageContext } = parsedBody as {
+    messages: unknown;
+    locale?: string;
+    pageContext?: string;
+  };
 
   if (!messages || !Array.isArray(messages)) {
     return NextResponse.json({ error: 'Invalid request: messages array required' }, { status: 400 });
@@ -197,9 +201,18 @@ export async function POST(request: NextRequest) {
 
   const userMessage = (messages[messages.length - 1] as { content?: string })?.content || '';
 
-  const systemPrompt = locale
+  const systemPromptText = locale
     ? `${SYSTEM_PROMPT}\n\n**User's Language:** ${locale.toUpperCase()} - Respond in this language.`
     : SYSTEM_PROMPT;
+
+  const systemPromptWithContext = pageContext
+    ? `${systemPromptText}\n\n**Current Page:** User is viewing \`${pageContext}\` — tailor your response to this context if relevant.`
+    : systemPromptText;
+
+  // Cache the system prompt for 5 minutes — saves ~90% on repeated input token costs
+  const systemPrompt: Anthropic.TextBlockParam[] = [
+    { type: 'text', text: systemPromptWithContext, cache_control: { type: 'ephemeral' } },
+  ];
 
   // --- Streaming response ---
   const encoder = new TextEncoder();
@@ -249,7 +262,15 @@ export async function POST(request: NextRequest) {
               .join('');
 
             const responseTimeMs = Date.now() - startTime;
-            const tokensUsed = finalMessage.usage.input_tokens + finalMessage.usage.output_tokens;
+            const usage = finalMessage.usage as Anthropic.Usage & {
+              cache_read_input_tokens?: number;
+              cache_creation_input_tokens?: number;
+            };
+            const tokensUsed = usage.input_tokens + usage.output_tokens;
+            const cacheHit = (usage.cache_read_input_tokens ?? 0) > 0;
+            if (cacheHit) {
+              logger.debug('Prompt cache hit', { cache_read_tokens: usage.cache_read_input_tokens });
+            }
 
             const analytics: ChatAnalytics = {
               conversationId,

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -305,10 +305,18 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (error) {
-    logger.error('Chat API Error', error);
+    logger.error('Chat API Error', {
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack?.split('\n')[1]?.trim() : undefined,
+    });
 
     // Handle Anthropic API errors
     if (error instanceof Anthropic.APIError) {
+      logger.error('Anthropic API Error', {
+        status: error.status,
+        message: error.message,
+        name: error.name,
+      });
       return NextResponse.json(
         {
           error: 'AI service error',

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -105,7 +105,7 @@ When users ask about specific products or need recommendations, use the search_p
 
 **IMPORTANT - Always include product links:**
 - When recommending products, ALWAYS include clickable links using markdown format: [Product Name](/products/slug)
-- Example: "I recommend the [BAPI-Stat Zone Temp Sensor](/products/bapi-stat-zone) for cleanrooms"
+- Example: "I recommend the [BAPI-Stat Zone Temp Sensor](/product/bapi-stat-zone) for cleanrooms"
 - Make it easy for users to view full specifications by clicking the link
 - Format as: [Product Name](URL) - NOT just "view at URL"
 

--- a/web/src/app/api/chat/route.ts
+++ b/web/src/app/api/chat/route.ts
@@ -66,7 +66,7 @@ async function getUserCustomerGroups(): Promise<string[]> {
 /**
  * BAPI AI Assistant - Technical Product Support Chatbot
  *
- * Powered by Claude 3.5 Sonnet for accurate technical responses
+ * Powered by Claude Haiku 4.5 for accurate technical responses
  * about BAPI's 600+ HVAC sensors and building automation products.
  */
 
@@ -208,7 +208,7 @@ export async function POST(request: NextRequest) {
 
     // Initial API call to Claude
     let response = await anthropic.messages.create({
-      model: 'claude-3-haiku-20240307',
+      model: 'claude-haiku-4-5',
       max_tokens: 1024,
       system: systemPrompt,
       tools,
@@ -251,7 +251,7 @@ export async function POST(request: NextRequest) {
 
       // Continue conversation with tool result
       response = await anthropic.messages.create({
-        model: 'claude-3-haiku-20240307',
+        model: 'claude-haiku-4-5',
         max_tokens: 1024,
         system: systemPrompt,
         tools,

--- a/web/src/components/chat/ChatWidget.tsx
+++ b/web/src/components/chat/ChatWidget.tsx
@@ -19,6 +19,7 @@ export default function ChatWidget() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [isStreaming, setIsStreaming] = useState(false);
   const [showHandoffForm, setShowHandoffForm] = useState(false);
   const [handoffSubmitting, setHandoffSubmitting] = useState(false);
   const [handoffSuccess, setHandoffSuccess] = useState(false);
@@ -82,7 +83,7 @@ export default function ChatWidget() {
   }, [isOpen, locale, messages.length]);
 
   const sendMessage = async () => {
-    if (!input.trim() || isLoading) return;
+    if (!input.trim() || isLoading || isStreaming) return;
 
     const userMessage: Message = {
       role: 'user',
@@ -120,6 +121,7 @@ export default function ChatWidget() {
         { role: 'assistant', content: '', timestamp: new Date(), isStreaming: true },
       ]);
       setIsLoading(false);
+      setIsStreaming(true);
 
       // Read SSE stream
       if (!response.body) throw new Error('No response body for streaming');
@@ -206,6 +208,7 @@ export default function ChatWidget() {
       });
     } finally {
       setIsLoading(false);
+      setIsStreaming(false);
     }
   };
 
@@ -449,11 +452,11 @@ export default function ChatWidget() {
                 }
                 className="max-h-32 flex-1 resize-none rounded-xl border border-neutral-300 px-4 py-3 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary-500"
                 rows={1}
-                disabled={isLoading}
+                disabled={isLoading || isStreaming}
               />
               <button
                 onClick={sendMessage}
-                disabled={!input.trim() || isLoading}
+                disabled={!input.trim() || isLoading || isStreaming}
                 className="rounded-xl bg-primary-500 p-3 text-white transition-colors hover:bg-primary-600 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:bg-neutral-300"
                 aria-label="Send message"
               >

--- a/web/src/components/chat/ChatWidget.tsx
+++ b/web/src/components/chat/ChatWidget.tsx
@@ -104,6 +104,7 @@ export default function ChatWidget() {
             content: msg.content,
           })),
           locale,
+          pageContext: typeof window !== 'undefined' ? window.location.pathname : undefined,
         }),
       });
 

--- a/web/src/components/chat/ChatWidget.tsx
+++ b/web/src/components/chat/ChatWidget.tsx
@@ -9,8 +9,9 @@ interface Message {
   role: 'user' | 'assistant';
   content: string;
   timestamp: Date;
-  conversationId?: string; // For tracking feedback
+  conversationId?: string;
   feedbackGiven?: 'positive' | 'negative';
+  isStreaming?: boolean;
 }
 
 export default function ChatWidget() {
@@ -112,31 +113,86 @@ export default function ChatWidget() {
         throw new Error(errorData.message || 'Failed to get response');
       }
 
-      const data = await response.json();
+      // Add empty streaming message placeholder
+      setMessages((prev) => [
+        ...prev,
+        { role: 'assistant', content: '', timestamp: new Date(), isStreaming: true },
+      ]);
+      setIsLoading(false);
 
-      const assistantMessage: Message = {
-        role: 'assistant',
-        content: data.message,
-        timestamp: new Date(),
-        conversationId: data.conversationId, // Store for feedback
-      };
+      // Read SSE stream
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
 
-      setMessages((prev) => [...prev, assistantMessage]);
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete SSE events (separated by double newline)
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop() ?? '';
+
+        for (const part of parts) {
+          if (!part.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(part.slice(6));
+
+            if (data.type === 'token') {
+              setMessages((prev) => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === 'assistant') {
+                  updated[updated.length - 1] = { ...last, content: last.content + data.text };
+                }
+                return updated;
+              });
+            } else if (data.type === 'done') {
+              setMessages((prev) => {
+                const updated = [...prev];
+                const last = updated[updated.length - 1];
+                if (last?.role === 'assistant') {
+                  updated[updated.length - 1] = {
+                    ...last,
+                    isStreaming: false,
+                    conversationId: data.conversationId,
+                  };
+                }
+                return updated;
+              });
+            } else if (data.type === 'error') {
+              throw new Error(data.message);
+            }
+          } catch {
+            // Skip malformed SSE events
+          }
+        }
+      }
     } catch (error) {
       logger.error('Chat error', error);
-      const errorMessage: Message = {
-        role: 'assistant',
-        content:
-          locale === 'de'
-            ? 'Entschuldigung, es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
-            : locale === 'es'
-              ? 'Lo siento, ocurrió un error. Por favor, inténtelo de nuevo.'
-              : locale === 'fr'
-                ? "Désolé, une erreur s'est produite. Veuillez réessayer."
-                : 'Sorry, an error occurred. Please try again.',
-        timestamp: new Date(),
-      };
-      setMessages((prev) => [...prev, errorMessage]);
+      // Remove any partial streaming message before adding the error
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        const withoutPartial =
+          last?.role === 'assistant' && last.isStreaming ? prev.slice(0, -1) : prev;
+        return [
+          ...withoutPartial,
+          {
+            role: 'assistant',
+            content:
+              locale === 'de'
+                ? 'Entschuldigung, es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
+                : locale === 'es'
+                  ? 'Lo siento, ocurrió un error. Por favor, inténtelo de nuevo.'
+                  : locale === 'fr'
+                    ? "Désolé, une erreur s'est produite. Veuillez réessayer."
+                    : 'Sorry, an error occurred. Please try again.',
+            timestamp: new Date(),
+          },
+        ];
+      });
     } finally {
       setIsLoading(false);
     }
@@ -291,6 +347,9 @@ export default function ChatWidget() {
                 >
                   <div className="whitespace-pre-wrap break-words text-sm">
                     {renderMessageContent(message.content)}
+                    {message.isStreaming && (
+                      <span className="ml-0.5 inline-block h-3.5 w-0.5 animate-pulse bg-neutral-400" />
+                    )}
                   </div>
                   <p
                     className={`mt-1 text-xs ${

--- a/web/src/components/chat/ChatWidget.tsx
+++ b/web/src/components/chat/ChatWidget.tsx
@@ -108,7 +108,7 @@ export default function ChatWidget() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
-        logger.error('Chat API Error', { status: response.status, error: errorData });
+        logger.error('Chat API Error', { status: response.status, error: errorData.error, details: errorData.details });
         throw new Error(errorData.message || 'Failed to get response');
       }
 

--- a/web/src/components/chat/ChatWidget.tsx
+++ b/web/src/components/chat/ChatWidget.tsx
@@ -122,7 +122,8 @@ export default function ChatWidget() {
       setIsLoading(false);
 
       // Read SSE stream
-      const reader = response.body!.getReader();
+      if (!response.body) throw new Error('No response body for streaming');
+      const reader = response.body.getReader();
       const decoder = new TextDecoder();
       let buffer = '';
 
@@ -171,6 +172,15 @@ export default function ChatWidget() {
           }
         }
       }
+
+      // Stream ended — clear isStreaming in case server closed without a done event
+      setMessages((prev) => {
+        const last = prev[prev.length - 1];
+        if (last?.role === 'assistant' && last.isStreaming) {
+          return [...prev.slice(0, -1), { ...last, isStreaming: false }];
+        }
+        return prev;
+      });
     } catch (error) {
       logger.error('Chat error', error);
       // Remove any partial streaming message before adding the error

--- a/web/src/lib/chat/productSearch.ts
+++ b/web/src/lib/chat/productSearch.ts
@@ -144,10 +144,10 @@ export async function searchProducts(
       imageUrl: product.image?.sourceUrl || null,
       categories: product.productCategories?.nodes?.map((cat: any) => cat.name) || [],
       attributes: product.attributes?.nodes?.map((attr: any) => ({
-        name: attr.name,
-        label: attr.label,
-        options: attr.options || [],
-      })) || [],
+        name: attr.name ?? '',
+        label: attr.label ?? '',
+        options: (attr.options ?? []).filter((o: string | null) => o != null && o !== ''),
+      })).filter((attr: ProductAttribute) => attr.name || attr.label) || [],
       url: `/products/${product.slug}`,
     }));
   } catch (error) {
@@ -183,6 +183,7 @@ export function formatProductsForAI(products: ProductSearchResult[]): string {
         descriptionText ? `   - Description: ${descriptionText}${descriptionText.length >= 300 ? '...' : ''}` : '',
         product.attributes.length > 0
           ? product.attributes
+              .filter((attr) => (attr.label || attr.name) && attr.options.length > 0)
               .map((attr) => `   - ${attr.label || attr.name}: ${attr.options.join(', ')}`)
               .join('\n')
           : '',

--- a/web/src/lib/chat/productSearch.ts
+++ b/web/src/lib/chat/productSearch.ts
@@ -150,7 +150,7 @@ export async function searchProducts(
         label: attr.label ?? '',
         options: (attr.options ?? []).filter((o: string | null) => o != null && o !== ''),
       })).filter((attr: ProductAttribute) => attr.name || attr.label) || [],
-      url: `/products/${product.slug}`,
+      url: `/product/${product.slug}`,
     }));
   } catch (error) {
     logger.error('Product search error', error);

--- a/web/src/lib/chat/productSearch.ts
+++ b/web/src/lib/chat/productSearch.ts
@@ -18,7 +18,9 @@ const PRODUCT_SEARCH_QUERY = gql`
         slug
         description
         shortDescription
-        partNumber
+        ... on Product {
+          partNumber
+        }
         image {
           sourceUrl
           altText

--- a/web/src/lib/chat/productSearch.ts
+++ b/web/src/lib/chat/productSearch.ts
@@ -145,11 +145,11 @@ export async function searchProducts(
       stockStatus: product.stockStatus || null,
       imageUrl: product.image?.sourceUrl || null,
       categories: product.productCategories?.nodes?.map((cat: any) => cat.name) || [],
-      attributes: product.attributes?.nodes?.map((attr: any) => ({
+      attributes: (product.attributes?.nodes ?? []).map((attr: any) => ({
         name: attr.name ?? '',
         label: attr.label ?? '',
         options: (attr.options ?? []).filter((o: string | null) => o != null && o !== ''),
-      })).filter((attr: ProductAttribute) => attr.name || attr.label) || [],
+      })).filter((attr: ProductAttribute) => attr.name || attr.label),
       url: `/product/${product.slug}`,
     }));
   } catch (error) {

--- a/web/src/lib/chat/productSearch.ts
+++ b/web/src/lib/chat/productSearch.ts
@@ -16,7 +16,9 @@ const PRODUCT_SEARCH_QUERY = gql`
         databaseId
         name
         slug
+        description
         shortDescription
+        partNumber
         image {
           sourceUrl
           altText
@@ -25,6 +27,14 @@ const PRODUCT_SEARCH_QUERY = gql`
           price
           regularPrice
           sku
+          stockStatus
+          attributes {
+            nodes {
+              name
+              label
+              options
+            }
+          }
           productCategories {
             nodes {
               name
@@ -34,6 +44,14 @@ const PRODUCT_SEARCH_QUERY = gql`
         ... on VariableProduct {
           price
           regularPrice
+          stockStatus
+          attributes {
+            nodes {
+              name
+              label
+              options
+            }
+          }
           productCategories {
             nodes {
               name
@@ -62,17 +80,27 @@ const PRODUCT_SEARCH_QUERY = gql`
   }
 `;
 
+export interface ProductAttribute {
+  name: string;
+  label: string;
+  options: string[];
+}
+
 export interface ProductSearchResult {
   id: string;
   databaseId: number;
   name: string;
   slug: string;
+  description: string | null;
   shortDescription: string | null;
+  partNumber: string | null;
   price: string | null;
   regularPrice: string | null;
   sku: string | null;
+  stockStatus: string | null;
   imageUrl: string | null;
   categories: string[];
+  attributes: ProductAttribute[];
   url: string;
 }
 
@@ -106,12 +134,20 @@ export async function searchProducts(
       databaseId: product.databaseId,
       name: product.name,
       slug: product.slug,
-      shortDescription: product.shortDescription,
-      price: product.price,
-      regularPrice: product.regularPrice,
-      sku: product.sku,
+      description: product.description || null,
+      shortDescription: product.shortDescription || null,
+      partNumber: product.partNumber || null,
+      price: product.price || null,
+      regularPrice: product.regularPrice || null,
+      sku: product.sku || null,
+      stockStatus: product.stockStatus || null,
       imageUrl: product.image?.sourceUrl || null,
       categories: product.productCategories?.nodes?.map((cat: any) => cat.name) || [],
+      attributes: product.attributes?.nodes?.map((attr: any) => ({
+        name: attr.name,
+        label: attr.label,
+        options: attr.options || [],
+      })) || [],
       url: `/products/${product.slug}`,
     }));
   } catch (error) {
@@ -131,13 +167,24 @@ export function formatProductsForAI(products: ProductSearchResult[]): string {
 
   return products
     .map((product, index) => {
+      const partId = product.partNumber || product.sku;
+      const descriptionText = (product.description || product.shortDescription || '')
+        .replace(/<[^>]*>/g, '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .substring(0, 300);
+
       const parts = [
         `${index + 1}. **${product.name}**`,
-        product.sku ? `   - SKU: ${product.sku}` : '',
-        product.price ? `   - Price: ${product.price}` : '',
+        partId ? `   - Part #: ${partId}` : '',
         product.categories.length > 0 ? `   - Category: ${product.categories.join(', ')}` : '',
-        product.shortDescription
-          ? `   - Description: ${product.shortDescription.replace(/<[^>]*>/g, '').substring(0, 150)}...`
+        product.stockStatus ? `   - Stock: ${product.stockStatus}` : '',
+        product.price ? `   - Price: ${product.price}` : '',
+        descriptionText ? `   - Description: ${descriptionText}${descriptionText.length >= 300 ? '...' : ''}` : '',
+        product.attributes.length > 0
+          ? product.attributes
+              .map((attr) => `   - ${attr.label || attr.name}: ${attr.options.join(', ')}`)
+              .join('\n')
           : '',
         `   - View product: ${product.url}`,
       ];


### PR DESCRIPTION
## Fix: BAPI Assistant Claude Model Update + Enriched Product Search

### Problem
The BAPI Assistant chatbot was completely broken. `claude-3-haiku-20240307` has been retired by Anthropic — all Claude 3 models now return `404 Not Found`. The assistant was silently failing on every user message.

### Changes

#### 1. Update Claude model (`web/src/app/api/chat/route.ts`)
- Replaced deprecated `claude-3-haiku-20240307` with `claude-haiku-4-5` (the current-generation Haiku model)
- Applied to both API call sites: initial message and tool-use continuation
- `claude-haiku-4-5`: 200k context window, Feb 2025 knowledge cutoff, $1/$5 per MTok

#### 2. Enrich product search data (`web/src/lib/chat/productSearch.ts`)
The original search only returned `shortDescription`, `sku`, `price`, and `category`. Claude now receives:
- **`description`** — full product description (stripped of HTML, up to 300 chars)
- **`partNumber`** — BAPI custom field, falls back to SKU in formatter
- **`attributes`** — product specs (e.g. Temperature Range, Accuracy, Protocol, Output Signal)
- **`stockStatus`** — in stock / out of stock awareness
- Updated `ProductSearchResult` interface and `formatProductsForAI()` formatter accordingly

#### 3. Update test script (`web/scripts/test-claude-api.mjs`)
- Replaced the list of retired model names with current models (`claude-haiku-4-5`, `claude-sonnet-5`, `claude-opus-4-8`, etc.)

### Testing
- Verified `claude-haiku-4-5` responds correctly via API before applying changes
- No TypeScript errors
- Test the chat widget in dev: open the BAPI Assistant, ask a product question (e.g. "What temperature sensors do you have for duct mounting?") and confirm it returns results with specs and clickable links