### PR TITLE
fix: toast notifications z-index, cross-navigation persistence, and c…

### DIFF
--- a/web/src/app/[locale]/layout.tsx
+++ b/web/src/app/[locale]/layout.tsx
@@ -8,6 +8,8 @@ import { HtmlLangAttribute } from '@/components/layout/HtmlLangAttribute';
 import { setRequestLocale, getMessages } from 'next-intl/server';
 import { NextIntlClientProvider } from 'next-intl';
 import { ToastProvider } from '@/components/ui/Toast';
+import { PendingToastFlush } from '@/components/ui/PendingToastFlush';
+import { SessionExpiryToast } from '@/components/auth/SessionExpiryToast';
 import { AnalyticsClient, SpeedInsightsClient } from '@/components/analytics/AnalyticsClient';
 import { WebVitalsClient } from '@/components/analytics/WebVitalsClient';
 import { StructuredData, generateOrganizationSchema, generateWebSiteSchema } from '@/lib/schema';
@@ -90,6 +92,8 @@ export default async function LocaleLayout({
               {/* Auto-detect region/language for first-time visitors */}
               <AutoRegionDetection />
 
+              <PendingToastFlush />
+              <SessionExpiryToast />
               <Header />
               <main id="main-content" className="relative z-base">
                 {children}

--- a/web/src/app/[locale]/sign-in/SignInForm.tsx
+++ b/web/src/app/[locale]/sign-in/SignInForm.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { Link } from '@/lib/navigation';
 import { useTranslations } from 'next-intl';
 import { useToast } from '@/components/ui/Toast';
+import { schedulePendingToast } from '@/components/ui/PendingToastFlush';
 import { TwoFactorVerify } from '@/components/auth/TwoFactorVerify';
 import { EyeIcon, EyeOffIcon, LockIcon, UserIcon, ShieldCheckIcon } from '@/lib/icons';
 import logger from '@/lib/logger';
@@ -55,7 +56,11 @@ export function SignInForm({ locale }: SignInFormProps) {
         // Phase 1 uses standard JWT authentication only
         
         // Standard login (no 2FA)
-        showToast('success', t('toast.welcomeBack.title'), t('toast.welcomeBack.message'));
+        schedulePendingToast({
+          type: 'success',
+          title: t('toast.welcomeBack.title'),
+          message: t('toast.welcomeBack.message'),
+        });
 
         // Redirect to intended page or account dashboard
         const redirect = searchParams?.get('redirect') || `/${locale}/account`;

--- a/web/src/components/auth/SessionExpiryToast.tsx
+++ b/web/src/components/auth/SessionExpiryToast.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { useToast } from '@/components/ui/Toast';
+
+/**
+ * Detects when a previously authenticated user's session has expired
+ * and shows a warning toast prompting them to sign in again.
+ *
+ * Uses localStorage to track prior auth state. Renders nothing.
+ */
+export function SessionExpiryToast() {
+  const { isLoaded, isSignedIn } = useAuth();
+  const { showToast } = useToast();
+  const hasHandled = useRef(false);
+
+  useEffect(() => {
+    if (!isLoaded || hasHandled.current) return;
+    hasHandled.current = true;
+
+    const wasAuthenticated = localStorage.getItem('bapi_was_authenticated') === 'true';
+
+    if (isSignedIn) {
+      localStorage.setItem('bapi_was_authenticated', 'true');
+    } else if (wasAuthenticated) {
+      // Session expired — user was previously signed in but is no longer
+      localStorage.removeItem('bapi_was_authenticated');
+      showToast(
+        'warning',
+        'Session Expired',
+        'Your session has expired. Please sign in again to continue.',
+        8000,
+        { label: 'Sign In', onClick: () => { window.location.href = '/sign-in'; } }
+      );
+    }
+  }, [isLoaded, isSignedIn, showToast]);
+
+  return null;
+}

--- a/web/src/components/checkout/CheckoutPageClient.tsx
+++ b/web/src/components/checkout/CheckoutPageClient.tsx
@@ -24,6 +24,7 @@ import CheckoutWizard from './CheckoutWizard';
 import CheckoutSummary from './CheckoutSummary';
 import { useToast } from '@/components/ui/Toast';
 import { getUserErrorMessage, logError } from '@/lib/errors';
+import { schedulePendingToast } from '@/components/ui/PendingToastFlush';
 import { useCartStore } from '@/store/cart';
 
 export interface ShippingAddress {
@@ -120,7 +121,7 @@ export default function CheckoutPageClient({ locale }: CheckoutPageClientProps) 
     // Redirect to cart if empty (e.g., after clearing or manual removal)
     if (totalItems() === 0) {
       logger.debug('[Checkout] Cart became empty, redirecting to cart page');
-      showToast('warning', t('toasts.cartEmpty'), t('toasts.cartEmptyMessage'));
+      schedulePendingToast({ type: 'warning', title: t('toasts.cartEmpty'), message: t('toasts.cartEmptyMessage') });
       router.push(`/${locale}/cart`);
     }
   }, [totalItems, isLoadingCart, router, showToast, locale, t]);
@@ -137,20 +138,32 @@ export default function CheckoutPageClient({ locale }: CheckoutPageClientProps) 
       if (!localCartData) {
         logger.debug('[Checkout] No cart data found');
         setIsLoadingCart(false);
-        showToast('warning', t('toasts.cartEmpty'), t('toasts.cartEmptyMessage'));
+        schedulePendingToast({ type: 'warning', title: t('toasts.cartEmpty'), message: t('toasts.cartEmptyMessage') });
         setTimeout(() => router.push(`/${locale}/cart`), 1000);
         return;
       }
 
       const parsed = JSON.parse(localCartData);
       const items = parsed.state?.items || [];
+      const zustandItemCount = totalItems();
 
       logger.debug('[Checkout] Cart items loaded', { itemCount: items.length });
+
+      // Warn if local storage has fewer items than the Zustand store expected
+      // (can happen if localStorage was partially cleared or corrupted in another tab)
+      if (zustandItemCount > 0 && items.length < zustandItemCount) {
+        showToast(
+          'warning',
+          'Cart Updated',
+          `${zustandItemCount - items.length} item(s) could not be restored and were removed from your cart.`,
+          6000
+        );
+      }
 
       if (items.length === 0) {
         logger.debug('[Checkout] Cart is empty');
         setIsLoadingCart(false);
-        showToast('warning', t('toasts.cartEmpty'), t('toasts.cartEmptyMessage'));
+        schedulePendingToast({ type: 'warning', title: t('toasts.cartEmpty'), message: t('toasts.cartEmptyMessage') });
         setTimeout(() => router.push(`/${locale}/cart`), 1000);
         return;
       }
@@ -213,7 +226,7 @@ export default function CheckoutPageClient({ locale }: CheckoutPageClientProps) 
 
       // Redirect to cart if empty
       if (data.cart?.isEmpty) {
-        showToast('warning', t('toasts.cartEmpty'), t('toasts.cartEmptyMessage'));
+        schedulePendingToast({ type: 'warning', title: t('toasts.cartEmpty'), message: t('toasts.cartEmptyMessage') });
         router.push(`/${locale}/cart`);
         return;
       }
@@ -222,7 +235,7 @@ export default function CheckoutPageClient({ locale }: CheckoutPageClientProps) 
     } catch (error) {
       const { title, message } = getUserErrorMessage(error);
       logError('checkout.fetch_cart_failed', error);
-      showToast('error', title, message);
+      schedulePendingToast({ type: 'error', title, message });
       router.push(`/${locale}/cart`);
     } finally {
       setIsLoadingCart(false);
@@ -284,8 +297,8 @@ export default function CheckoutPageClient({ locale }: CheckoutPageClientProps) 
         }
 
         // Redirect to order confirmation with actual order ID
+        schedulePendingToast({ type: 'success', title: t('toasts.orderPlaced'), message: t('toasts.orderPlacedMessage') });
         router.push(`/${locale}/order-confirmation/${result.order.id}`);
-        showToast('success', t('toasts.orderPlaced'), t('toasts.orderPlacedMessage'));
       } else {
         // PayPal or other payment methods
         // Phase 2: Implement PayPal order creation via WooCommerce API
@@ -293,8 +306,8 @@ export default function CheckoutPageClient({ locale }: CheckoutPageClientProps) 
         await new Promise((resolve) => setTimeout(resolve, 2000));
 
         const mockOrderId = Math.floor(Math.random() * 100000);
+        schedulePendingToast({ type: 'success', title: t('toasts.orderPlaced'), message: t('toasts.orderPlacedMessage') });
         router.push(`/${locale}/order-confirmation/${mockOrderId}`);
-        showToast('success', t('toasts.orderPlaced'), t('toasts.orderPlacedMessage'));
       }
     } catch (error) {
       const { title, message } = getUserErrorMessage(error);

--- a/web/src/components/layout/Header/components/LanguageSelectorV2.tsx
+++ b/web/src/components/layout/Header/components/LanguageSelectorV2.tsx
@@ -5,7 +5,7 @@ import Image from 'next/image';
 import { Listbox, Transition } from '@headlessui/react';
 import { useRouter, usePathname } from '@/lib/navigation';
 import { useLocale, useTranslations } from 'next-intl';
-import { useToast } from '@/components/ui/Toast';
+import { schedulePendingToast } from '@/components/ui/PendingToastFlush';
 import { LANGUAGES } from '@/types/region';
 import type { LanguageCode } from '@/types/region';
 import { LANGUAGE_GROUPS } from '@/lib/constants/languageGroups';
@@ -17,7 +17,6 @@ export function LanguageSelectorV2() {
   const pathname = usePathname();
   const currentLocale = useLocale() as LanguageCode;
   const t = useTranslations('ui.languageChanged');
-  const { showToast } = useToast();
 
   // Prevent hydration mismatch by only rendering Headless UI on client
   // This is a standard Next.js pattern for client-only components
@@ -34,11 +33,13 @@ export function LanguageSelectorV2() {
 
     const languageName = LANGUAGES[newLocale].nativeName;
 
-    // Show toast notification with setTimeout to ensure it's visible
-    // Toast appears in current language before navigation
-    setTimeout(() => {
-      showToast('success', t('title'), t('message', { language: languageName }), 2500);
-    }, 100);
+    // Schedule toast to fire after navigation remounts the page
+    schedulePendingToast({
+      type: 'success',
+      title: t('title'),
+      message: t('message', { language: languageName }),
+      duration: 4000,
+    });
 
     // Use next-intl's router which handles locale switching automatically
     router.replace(pathname, { locale: newLocale });

--- a/web/src/components/layout/Header/components/RegionSelectorV2.tsx
+++ b/web/src/components/layout/Header/components/RegionSelectorV2.tsx
@@ -6,7 +6,7 @@ import { Listbox, Transition } from '@headlessui/react';
 import { useRouter, usePathname } from '@/lib/navigation';
 import { useLocale } from 'next-intl';
 import { useRegion, useSetRegion } from '@/store/regionStore';
-import { toast } from 'sonner';
+import { useToast } from '@/components/ui/Toast';
 import { REGIONS, LANGUAGES, CURRENCIES } from '@/types/region';
 import type { RegionCode, LanguageCode } from '@/types/region';
 import {
@@ -23,6 +23,7 @@ const RegionSelectorV2: React.FC = () => {
   const currentLocale = useLocale() as LanguageCode;
   const router = useRouter();
   const pathname = usePathname();
+  const { showToast } = useToast();
 
   // Prevent hydration mismatch by only rendering Headless UI on client
   useEffect(() => {
@@ -40,18 +41,11 @@ const RegionSelectorV2: React.FC = () => {
       const languageName = LANGUAGES[suggestedLanguage].nativeName;
       const message = getLanguageSuggestionMessage(regionCode, languageName);
 
-      // Show toast with action button using Sonner
-      toast.info(message, {
-        duration: 7000,
-        action: {
-          label: 'Switch',
-          onClick: () => {
-            // Change language using next-intl navigation helpers
-            router.replace(pathname, { locale: suggestedLanguage });
-
-            // Show success toast after language switch
-            toast.success('Language Changed');
-          },
+      showToast('info', 'Language Suggestion', message, 7000, {
+        label: 'Switch',
+        onClick: () => {
+          router.replace(pathname, { locale: suggestedLanguage });
+          showToast('success', 'Language Changed', `Switched to ${languageName}`, 3000);
         },
       });
     }

--- a/web/src/components/products/VariationSelector.tsx
+++ b/web/src/components/products/VariationSelector.tsx
@@ -22,6 +22,7 @@ import { useRegion } from '@/store/regionStore';
 import { formatPrice, convertWooCommercePrice, convertWooCommercePriceNumeric } from '@/lib/utils/currency';
 import AddToCartButton from '@/components/cart/AddToCartButton';
 import { useCart as defaultUseCart, useCartDrawer as defaultUseCartDrawer } from '@/store';
+import { useToast } from '@/components/ui/Toast';
 
 interface VariationSelectorProps {
   attributes: ProductAttribute[];
@@ -80,6 +81,7 @@ export default function VariationSelector({
   const t = useTranslations('productPage.configurator');
   const tAttr = useTranslations('productPage.productAttributes');
   const locale = useLocale();
+  const { showToast } = useToast();
   const [selectedAttributes, setSelectedAttributes] = useState<SelectedAttributes>({});
   const [matchedVariation, setMatchedVariation] = useState<ProductVariation | null>(null);
   const [showShareConfirmation, setShowShareConfirmation] = useState(false);
@@ -479,9 +481,11 @@ export default function VariationSelector({
                             try {
                               await navigator.clipboard.writeText(partNumber);
                               setCopySuccess(true);
+                              showToast('success', 'Copied!', `Part number ${partNumber} copied to clipboard.`, 2500);
                               setTimeout(() => setCopySuccess(false), 1500);
                             } catch (err) {
                               logger.error('Failed to copy part number', { error: err });
+                              showToast('error', 'Copy Failed', 'Unable to copy to clipboard. Please copy manually.', 4000);
                             }
                           }}
                           className={`flex h-10 w-10 items-center justify-center rounded-lg border shadow-sm transition-all focus:outline-none focus:ring-2 focus:ring-primary-500/50 ${

--- a/web/src/components/products/__tests__/VariationSelector.test.tsx
+++ b/web/src/components/products/__tests__/VariationSelector.test.tsx
@@ -38,6 +38,10 @@ vi.mock('@/lib/logger', () => ({
   },
 }));
 
+vi.mock('@/components/ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
 describe('VariationSelector - Component Smoke Tests', () => {
   it('renders without crashing with empty data', () => {
     expect(() => {

--- a/web/src/components/search/SearchResults.tsx
+++ b/web/src/components/search/SearchResults.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { sanitizeWordPressContent } from '@/lib/sanitizeDescription';
 import { Link } from '@/lib/navigation';
 import Image from 'next/image';
 import { SearchIcon, ArrowLeftIcon } from '@/lib/icons';
 import { useAuth } from '@/hooks/useAuth';
 import { filterProductsByCustomerGroup } from '@/lib/utils/filterProductsByCustomerGroup';
+import { useToast } from '@/components/ui/Toast';
 
 interface Product {
   id: string;
@@ -58,11 +59,22 @@ export default function SearchResults({
   locale,
   translations: t,
 }: SearchResultsProps) {
-  const { user } = useAuth();
+  const { user, isLoaded } = useAuth();
+  const { showToast } = useToast();
   const [failedImages, setFailedImages] = useState<Set<string>>(new Set());
+  const noResultsToastShown = useRef(false);
 
   // Filter products by customer group (B2B access control)
   const filteredProducts = filterProductsByCustomerGroup(products, user?.customerGroups || ['END USER']);
+
+  // Show info toast once when auth is resolved and results are confirmed empty
+  useEffect(() => {
+    if (!isLoaded || noResultsToastShown.current) return;
+    if (filteredProducts.length === 0) {
+      noResultsToastShown.current = true;
+      showToast('info', 'No Results Found', `No products matched "${query}". Try a different search term or browse all products.`, 6000);
+    }
+  }, [isLoaded, filteredProducts.length, query, showToast]);
 
   const handleImageError = (productId: string) => {
     setFailedImages((prev) => new Set(prev).add(productId));

--- a/web/src/components/search/__tests__/SearchResults.test.tsx
+++ b/web/src/components/search/__tests__/SearchResults.test.tsx
@@ -21,7 +21,11 @@ import SearchResults from '../SearchResults';
 
 // ─── Mock deps ────────────────────────────────────────────────────────────────
 vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: { customerGroups: ['end-user'] } }),
+  useAuth: () => ({ user: { customerGroups: ['end-user'] }, isLoaded: true }),
+}));
+
+vi.mock('@/components/ui/Toast', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
 }));
 
 vi.mock('@/lib/navigation', () => ({

--- a/web/src/components/ui/PendingToastFlush.tsx
+++ b/web/src/components/ui/PendingToastFlush.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useToast } from '@/components/ui/Toast';
+import type { ToastType } from '@/components/ui/Toast';
+
+interface PendingToast {
+  type: ToastType;
+  title: string;
+  message: string;
+  duration?: number;
+}
+
+export const PENDING_TOAST_KEY = 'bapi_pending_toast';
+
+/**
+ * Write a toast intent to sessionStorage to be fired after the next navigation.
+ * Call this before router.replace() / router.push() so the toast survives remount.
+ */
+export function schedulePendingToast(toast: PendingToast) {
+  try {
+    sessionStorage.setItem(PENDING_TOAST_KEY, JSON.stringify(toast));
+  } catch {
+    // sessionStorage unavailable (e.g., private mode restriction) — silent fail
+  }
+}
+
+/**
+ * Reads and fires any pending toast written before a navigation.
+ * Add once to the root layout inside ToastProvider — it runs on every page mount.
+ */
+export function PendingToastFlush() {
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    let raw: string | null = null;
+    try {
+      raw = sessionStorage.getItem(PENDING_TOAST_KEY);
+      if (raw) sessionStorage.removeItem(PENDING_TOAST_KEY);
+    } catch {
+      return; // sessionStorage unavailable
+    }
+
+    if (!raw) return;
+
+    try {
+      const { type, title, message, duration = 4000 } = JSON.parse(raw) as PendingToast;
+      showToast(type, title, message, duration);
+    } catch {
+      // Corrupt entry — ignore
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentionally runs once on mount
+
+  return null;
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -11,17 +11,23 @@ import {
 
 export type ToastType = 'success' | 'error' | 'info' | 'warning';
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 export interface Toast {
   id: string;
   type: ToastType;
   title: string;
   message: string;
   duration?: number;
+  action?: ToastAction;
 }
 
 interface ToastContextType {
   toasts: Toast[];
-  showToast: (type: ToastType, title: string, message: string, duration?: number) => void;
+  showToast: (type: ToastType, title: string, message: string, duration?: number, action?: ToastAction) => void;
   removeToast: (id: string) => void;
 }
 
@@ -36,7 +42,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const showToast = useCallback(
-    (type: ToastType, title: string, message: string, duration = 5000) => {
+    (type: ToastType, title: string, message: string, duration = 5000, action?: ToastAction) => {
       const id = Math.random().toString(36).substring(2, 9);
       const newToast: Toast = {
         id,
@@ -44,6 +50,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         title,
         message,
         duration,
+        action,
       };
 
       setToasts((prev) => [...prev, newToast]);
@@ -83,7 +90,7 @@ function ToastContainer({ toasts, onClose }: ToastContainerProps) {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="pointer-events-none fixed inset-0 z-50 flex items-end px-4 py-6 sm:items-start sm:p-6">
+    <div className="pointer-events-none fixed inset-0 z-toast flex items-end px-4 py-6 sm:items-start sm:p-6">
       <div className="flex w-full flex-col items-center space-y-4 sm:items-end">
         {toasts.map((toast) => (
           <ToastItem key={toast.id} toast={toast} onClose={onClose} />
@@ -137,6 +144,20 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
           <div className="ml-3 w-0 flex-1 pt-0.5">
             <p className="text-sm font-medium">{toast.title}</p>
             <p className="mt-1 text-sm opacity-90">{toast.message}</p>
+            {toast.action && (
+              <div className="mt-3">
+                <button
+                  type="button"
+                  className="rounded-md text-sm font-semibold underline underline-offset-2 opacity-90 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  onClick={() => {
+                    toast.action!.onClick();
+                    onClose(toast.id);
+                  }}
+                >
+                  {toast.action.label}
+                </button>
+              </div>
+            )}
           </div>
           <div className="ml-4 flex flex-shrink-0">
             <button


### PR DESCRIPTION
- Fix ToastContainer z-index from z-50 (50) to z-toast (1080) — toasts were rendering behind header/cart drawer and never visible

- Add optional action button support to Toast (label + onClick)

- Add PendingToastFlush utility: schedulePendingToast() writes intent to sessionStorage; PendingToastFlush component drains it on next mount, so toasts survive router.replace/push and window.location.href reloads

- Migrate all toast+navigate pairs to schedulePendingToast: LanguageSelectorV2, SignInForm (welcome back), CheckoutPageClient (cart empty x3, fetch error, order placed x2)

- Migrate RegionSelectorV2 from Sonner to useToast for consistency; language suggestion now uses action button ('Switch')

- New toasts: SearchResults no-results (info), VariationSelector clipboard copy success/error, cart sync mismatch warning at checkout

- New SessionExpiryToast component: detects expired sessions via localStorage flag, shows warning with 'Sign In' action button

- Fix failing tests: mock useToast in VariationSelector and SearchResults test files (2299 tests passing)


