### PR TITLE
fix: address PR #590 review - deps, schedulePendingToast, localStorag…

### DIFF
--- a/web/src/components/auth/SessionExpiryToast.tsx
+++ b/web/src/components/auth/SessionExpiryToast.tsx
@@ -19,13 +19,26 @@ export function SessionExpiryToast() {
     if (!isLoaded || hasHandled.current) return;
     hasHandled.current = true;
 
-    const wasAuthenticated = localStorage.getItem('bapi_was_authenticated') === 'true';
+    let wasAuthenticated = false;
+    try {
+      wasAuthenticated = localStorage.getItem('bapi_was_authenticated') === 'true';
+    } catch {
+      return; // localStorage unavailable (e.g. Safari private mode)
+    }
 
     if (isSignedIn) {
-      localStorage.setItem('bapi_was_authenticated', 'true');
+      try {
+        localStorage.setItem('bapi_was_authenticated', 'true');
+      } catch {
+        // Ignore write failures
+      }
     } else if (wasAuthenticated) {
       // Session expired — user was previously signed in but is no longer
-      localStorage.removeItem('bapi_was_authenticated');
+      try {
+        localStorage.removeItem('bapi_was_authenticated');
+      } catch {
+        // Ignore removal failures
+      }
       showToast(
         'warning',
         'Session Expired',

--- a/web/src/components/layout/Header/components/RegionSelectorV2.tsx
+++ b/web/src/components/layout/Header/components/RegionSelectorV2.tsx
@@ -7,6 +7,7 @@ import { useRouter, usePathname } from '@/lib/navigation';
 import { useLocale } from 'next-intl';
 import { useRegion, useSetRegion } from '@/store/regionStore';
 import { useToast } from '@/components/ui/Toast';
+import { schedulePendingToast } from '@/components/ui/PendingToastFlush';
 import { REGIONS, LANGUAGES, CURRENCIES } from '@/types/region';
 import type { RegionCode, LanguageCode } from '@/types/region';
 import {
@@ -44,8 +45,8 @@ const RegionSelectorV2: React.FC = () => {
       showToast('info', 'Language Suggestion', message, 7000, {
         label: 'Switch',
         onClick: () => {
+          schedulePendingToast({ type: 'success', title: 'Language Changed', message: `Switched to ${languageName}`, duration: 3000 });
           router.replace(pathname, { locale: suggestedLanguage });
-          showToast('success', 'Language Changed', `Switched to ${languageName}`, 3000);
         },
       });
     }

--- a/web/src/components/search/__tests__/SearchResults.test.tsx
+++ b/web/src/components/search/__tests__/SearchResults.test.tsx
@@ -19,13 +19,17 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import SearchResults from '../SearchResults';
 
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockShowToast } = vi.hoisted(() => ({ mockShowToast: vi.fn() }));
+
 // ─── Mock deps ────────────────────────────────────────────────────────────────
 vi.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ user: { customerGroups: ['end-user'] }, isLoaded: true }),
 }));
 
 vi.mock('@/components/ui/Toast', () => ({
-  useToast: () => ({ showToast: vi.fn() }),
+  useToast: () => ({ showToast: mockShowToast }),
 }));
 
 vi.mock('@/lib/navigation', () => ({
@@ -157,6 +161,31 @@ describe('SearchResults', () => {
       <SearchResults products={[]} query="xyz" locale="en" translations={baseTranslations} />,
     );
     expect(screen.getByRole('link', { name: 'Contact Us' })).toBeInTheDocument();
+  });
+
+  it('fires showToast once when products are empty and auth is loaded', () => {
+    render(
+      <SearchResults products={[]} query="widget" locale="en" translations={baseTranslations} />,
+    );
+    expect(mockShowToast).toHaveBeenCalledOnce();
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'info',
+      'No Results Found',
+      expect.stringContaining('widget'),
+      expect.any(Number),
+    );
+  });
+
+  it('does not fire showToast when results are present', () => {
+    render(
+      <SearchResults
+        products={[makeProduct(1)] as any}
+        query="sensor"
+        locale="en"
+        translations={baseTranslations}
+      />,
+    );
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 
   // ─── Product rendering ────────────────────────────────────────────────────────

--- a/web/src/components/ui/PendingToastFlush.tsx
+++ b/web/src/components/ui/PendingToastFlush.tsx
@@ -49,7 +49,7 @@ export function PendingToastFlush() {
     } catch {
       // Corrupt entry — ignore
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps — intentionally runs once on mount
+  }, [showToast]);
 
   return null;
 }


### PR DESCRIPTION
fix: address PR #590 review comments (toast system hardening)

Followup to #590 addressing all 5 review comments that were flagged after merge.

Changes:

PendingToastFlush.tsx — Added showToast to the useEffect dependency array; removed the eslint-disable suppression comment. showToast is stable (useCallback in context) so this is safe and correct.

RegionSelectorV2.tsx — The language-switch action's success toast was calling showToast() immediately after router.replace(), which caused it to be lost when the locale remount tore down the React tree. Replaced with schedulePendingToast() (the same pattern already used in LanguageSelectorV2) so the toast survives navigation.

SessionExpiryToast.tsx — Wrapped all localStorage get/set/remove calls in try/catch blocks. Prevents uncaught exceptions in Safari private browsing and other environments where storage is blocked, which could otherwise break root layout hydration.

SearchResults.test.tsx — Added two regression tests for the no-results toast: one asserting showToast is called once with the query in the message when products is empty and auth is loaded, and one asserting it is not called when results are present. Refactored the useToast mock to use vi.hoisted so mockShowToast is assertable across tests.

Tests: 2301 passing (2 new tests added)