### PR TITLE
fix: migrate /api/favorites from JSON file store to WordPress user me…

### DIFF
--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -118,6 +118,10 @@ add_action('graphql_register_types', function () {
                 }
             }
 
+            if (count($favs) >= 500) {
+                throw new \GraphQL\Error\UserError('Favorites limit reached (max 500)');
+            }
+
             $new_fav = [
                 'id'           => 'fav-' . time() . '-' . substr(md5(uniqid('', true)), 0, 9),
                 'productId'    => $sanitized_id,

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -103,16 +103,18 @@ add_action('graphql_register_types', function () {
                 $favs = [];
             }
 
-            // Idempotent: return existing entry if already saved
+            // Sanitize input first, then check for duplicates against stored (already-sanitized) values
+            $sanitized_id = sanitize_text_field($input['productId']);
+
             foreach ($favs as $fav) {
-                if ($fav['productId'] === $input['productId']) {
+                if ($fav['productId'] === $sanitized_id) {
                     return ['favorite' => $fav, 'alreadyExists' => true, 'success' => false];
                 }
             }
 
             $new_fav = [
                 'id'           => 'fav-' . time() . '-' . substr(md5(uniqid('', true)), 0, 9),
-                'productId'    => sanitize_text_field($input['productId']),
+                'productId'    => $sanitized_id,
                 'productName'  => sanitize_text_field($input['productName']),
                 'productSlug'  => sanitize_text_field($input['productSlug']),
                 'productImage' => isset($input['productImage']) ? esc_url_raw($input['productImage']) : null,
@@ -149,8 +151,9 @@ add_action('graphql_register_types', function () {
             }
 
             $original_count = count($favs);
+            $sanitized_id = sanitize_text_field($input['productId']);
             $favs = array_values(
-                array_filter($favs, fn($fav) => $fav['productId'] !== $input['productId'])
+                array_filter($favs, fn($fav) => $fav['productId'] !== $sanitized_id)
             );
 
             if (count($favs) === $original_count) {

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -79,10 +79,11 @@ add_action('graphql_register_types', function () {
 
             // Filter out any corrupted/non-array entries before sorting
             $favs = array_values(array_filter($favs, fn($f) => is_array($f)));
-            usort($favs, fn($a, $b) => strcmp(
-                $b['createdAt'] ?? '',
-                $a['createdAt'] ?? ''
-            ));
+            usort($favs, function ($a, $b) {
+                $ta = strtotime($a['createdAt'] ?? '') ?: 0;
+                $tb = strtotime($b['createdAt'] ?? '') ?: 0;
+                return $tb - $ta; // newest first
+            });
             return $favs;
         },
     ]);

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -129,7 +129,10 @@ add_action('graphql_register_types', function () {
             ];
 
             $favs[] = $new_fav;
-            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            $saved = update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            if ($saved === false) {
+                throw new \GraphQL\Error\UserError('Failed to persist favorites');
+            }
 
             return ['favorite' => $new_fav, 'alreadyExists' => false, 'success' => true];
         },
@@ -173,7 +176,10 @@ add_action('graphql_register_types', function () {
                 return ['success' => false, 'notFound' => true];
             }
 
-            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            $saved = update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            if ($saved === false) {
+                throw new \GraphQL\Error\UserError('Failed to persist favorites');
+            }
             return ['success' => true, 'notFound' => false];
         },
     ]);

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -35,3 +35,130 @@ add_filter('graphql_connection_max_query_amount', function($max, $source, $args,
     // Keep existing limit for other queries
     return $max;
 }, 10, 5);
+
+// ---------------------------------------------------------------------------
+// BAPI Favorites — stored as JSON in WordPress user meta (bapi_favorites)
+// ---------------------------------------------------------------------------
+
+add_action('graphql_register_types', function () {
+
+    // ── Shared object type ─────────────────────────────────────────────────
+    register_graphql_object_type('BapiFavorite', [
+        'description' => 'A BAPI saved product favorite',
+        'fields'      => [
+            'id'           => ['type' => 'String', 'description' => 'Unique favorite ID'],
+            'productId'    => ['type' => 'String', 'description' => 'WordPress product database ID'],
+            'productName'  => ['type' => 'String', 'description' => 'Product display name'],
+            'productSlug'  => ['type' => 'String', 'description' => 'Product URL slug'],
+            'productImage' => ['type' => 'String', 'description' => 'Product image URL'],
+            'productPrice' => ['type' => 'String', 'description' => 'Product price string'],
+            'createdAt'    => ['type' => 'String', 'description' => 'ISO 8601 creation timestamp'],
+        ],
+    ]);
+
+    // ── Query: myFavorites ─────────────────────────────────────────────────
+    register_graphql_field('RootQuery', 'myFavorites', [
+        'type'        => ['list_of' => 'BapiFavorite'],
+        'description' => "Get the current authenticated user's saved product favorites, sorted newest first.",
+        'resolve'     => function ($root, $args, $context) {
+            $user_id = $context->viewer->databaseId ?? 0;
+            if (!$user_id) {
+                return [];
+            }
+
+            $raw  = get_user_meta($user_id, 'bapi_favorites', true);
+            $favs = $raw ? json_decode($raw, true) : [];
+            if (!is_array($favs)) {
+                return [];
+            }
+
+            usort($favs, fn($a, $b) => strcmp($b['createdAt'], $a['createdAt']));
+            return $favs;
+        },
+    ]);
+
+    // ── Mutation: addFavorite ──────────────────────────────────────────────
+    register_graphql_mutation('addFavorite', [
+        'inputFields'  => [
+            'productId'    => ['type' => ['non_null' => 'String']],
+            'productName'  => ['type' => ['non_null' => 'String']],
+            'productSlug'  => ['type' => ['non_null' => 'String']],
+            'productImage' => ['type' => 'String'],
+            'productPrice' => ['type' => 'String'],
+        ],
+        'outputFields' => [
+            'favorite'      => ['type' => 'BapiFavorite'],
+            'alreadyExists' => ['type' => 'Boolean'],
+            'success'       => ['type' => 'Boolean'],
+        ],
+        'mutateAndGetPayload' => function ($input, $context) {
+            $user_id = $context->viewer->databaseId ?? 0;
+            if (!$user_id) {
+                throw new \GraphQL\Error\UserError('Unauthorized');
+            }
+
+            $raw  = get_user_meta($user_id, 'bapi_favorites', true);
+            $favs = $raw ? json_decode($raw, true) : [];
+            if (!is_array($favs)) {
+                $favs = [];
+            }
+
+            // Idempotent: return existing entry if already saved
+            foreach ($favs as $fav) {
+                if ($fav['productId'] === $input['productId']) {
+                    return ['favorite' => $fav, 'alreadyExists' => true, 'success' => false];
+                }
+            }
+
+            $new_fav = [
+                'id'           => 'fav-' . time() . '-' . substr(md5(uniqid('', true)), 0, 9),
+                'productId'    => sanitize_text_field($input['productId']),
+                'productName'  => sanitize_text_field($input['productName']),
+                'productSlug'  => sanitize_text_field($input['productSlug']),
+                'productImage' => isset($input['productImage']) ? esc_url_raw($input['productImage']) : null,
+                'productPrice' => isset($input['productPrice']) ? sanitize_text_field($input['productPrice']) : null,
+                'createdAt'    => gmdate('c'),
+            ];
+
+            $favs[] = $new_fav;
+            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+
+            return ['favorite' => $new_fav, 'alreadyExists' => false, 'success' => true];
+        },
+    ]);
+
+    // ── Mutation: removeFavorite ───────────────────────────────────────────
+    register_graphql_mutation('removeFavorite', [
+        'inputFields'  => [
+            'productId' => ['type' => ['non_null' => 'String']],
+        ],
+        'outputFields' => [
+            'success'  => ['type' => 'Boolean'],
+            'notFound' => ['type' => 'Boolean'],
+        ],
+        'mutateAndGetPayload' => function ($input, $context) {
+            $user_id = $context->viewer->databaseId ?? 0;
+            if (!$user_id) {
+                throw new \GraphQL\Error\UserError('Unauthorized');
+            }
+
+            $raw  = get_user_meta($user_id, 'bapi_favorites', true);
+            $favs = $raw ? json_decode($raw, true) : [];
+            if (!is_array($favs)) {
+                $favs = [];
+            }
+
+            $original_count = count($favs);
+            $favs = array_values(
+                array_filter($favs, fn($fav) => $fav['productId'] !== $input['productId'])
+            );
+
+            if (count($favs) === $original_count) {
+                return ['success' => false, 'notFound' => true];
+            }
+
+            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            return ['success' => true, 'notFound' => false];
+        },
+    ]);
+});

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -72,7 +72,12 @@ add_action('graphql_register_types', function () {
                 return [];
             }
 
-            usort($favs, fn($a, $b) => strcmp($b['createdAt'], $a['createdAt']));
+            // Filter out any corrupted/non-array entries before sorting
+            $favs = array_values(array_filter($favs, fn($f) => is_array($f)));
+            usort($favs, fn($a, $b) => strcmp(
+                $b['createdAt'] ?? '',
+                $a['createdAt'] ?? ''
+            ));
             return $favs;
         },
     ]);
@@ -107,6 +112,7 @@ add_action('graphql_register_types', function () {
             $sanitized_id = sanitize_text_field($input['productId']);
 
             foreach ($favs as $fav) {
+                if (!is_array($fav)) continue;
                 if ($fav['productId'] === $sanitized_id) {
                     return ['favorite' => $fav, 'alreadyExists' => true, 'success' => false];
                 }
@@ -153,7 +159,7 @@ add_action('graphql_register_types', function () {
             $original_count = count($favs);
             $sanitized_id = sanitize_text_field($input['productId']);
             $favs = array_values(
-                array_filter($favs, fn($fav) => $fav['productId'] !== $sanitized_id)
+                array_filter($favs, fn($fav) => is_array($fav) && ($fav['productId'] ?? null) !== $sanitized_id)
             );
 
             if (count($favs) === $original_count) {

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -108,6 +108,9 @@ add_action('graphql_register_types', function () {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
 
+            // NOTE: This is a read-modify-write on a shared JSON blob. Concurrent writes from
+            // multiple tabs could overwrite each other (last-write-wins). Accepted limitation
+            // for Phase 1 given the low probability of simultaneous favorites saves.
             $raw  = get_user_meta($user_id, 'bapi_favorites', true);
             $favs = $raw ? json_decode($raw, true) : [];
             if (!is_array($favs)) {

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -7,6 +7,11 @@
  *
  * This file should live at:
  * cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+ *
+ * DUAL-FILE PATTERN: The repo root copy (bapi-graphql-fixes.php) is the development
+ * source of truth. The CMS copy (cms/wp-content/mu-plugins/bapi-graphql-fixes.php) is
+ * the deploy artifact kept in sync manually. Always edit the root copy and SCP it to
+ * Kinsta staging; never edit the CMS copy independently.
  */
 
 if (!defined('ABSPATH')) {

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -156,13 +156,20 @@ add_action('graphql_register_types', function () {
                 $favs = [];
             }
 
-            $original_count = count($favs);
             $sanitized_id = sanitize_text_field($input['productId']);
+            $found = false;
             $favs = array_values(
-                array_filter($favs, fn($fav) => is_array($fav) && ($fav['productId'] ?? null) !== $sanitized_id)
+                array_filter($favs, function ($fav) use ($sanitized_id, &$found) {
+                    if (!is_array($fav)) return false; // drop corrupted entries
+                    if (($fav['productId'] ?? null) === $sanitized_id) {
+                        $found = true;
+                        return false; // remove matched entry
+                    }
+                    return true;
+                })
             );
 
-            if (count($favs) === $original_count) {
+            if (!$found) {
                 return ['success' => false, 'notFound' => true];
             }
 

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -66,7 +66,7 @@ add_action('graphql_register_types', function () {
         'type'        => ['list_of' => 'BapiFavorite'],
         'description' => "Get the current authenticated user's saved product favorites, sorted newest first.",
         'resolve'     => function ($root, $args, $context) {
-            $user_id = $context->viewer->databaseId ?? 0;
+            $user_id = $context->viewer?->databaseId ?? 0;
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -102,7 +102,7 @@ add_action('graphql_register_types', function () {
             'success'       => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer->databaseId ?? 0;
+            $user_id = $context->viewer?->databaseId ?? 0;
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -112,6 +112,7 @@ add_action('graphql_register_types', function () {
             if (!is_array($favs)) {
                 $favs = [];
             }
+            $favs = array_values(array_filter($favs, 'is_array'));
 
             // Sanitize input first, then check for duplicates against stored (already-sanitized) values
             $sanitized_id = sanitize_text_field($input['productId']);
@@ -157,7 +158,7 @@ add_action('graphql_register_types', function () {
             'notFound' => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer->databaseId ?? 0;
+            $user_id = $context->viewer?->databaseId ?? 0;
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -63,7 +63,7 @@ add_action('graphql_register_types', function () {
         'resolve'     => function ($root, $args, $context) {
             $user_id = $context->viewer->databaseId ?? 0;
             if (!$user_id) {
-                return [];
+                throw new \GraphQL\Error\UserError('Unauthorized');
             }
 
             $raw  = get_user_meta($user_id, 'bapi_favorites', true);
@@ -113,7 +113,7 @@ add_action('graphql_register_types', function () {
 
             foreach ($favs as $fav) {
                 if (!is_array($fav)) continue;
-                if ($fav['productId'] === $sanitized_id) {
+                if (($fav['productId'] ?? null) === $sanitized_id) {
                     return ['favorite' => $fav, 'alreadyExists' => true, 'success' => false];
                 }
             }

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -118,6 +118,10 @@ add_action('graphql_register_types', function () {
                 }
             }
 
+            if (count($favs) >= 500) {
+                throw new \GraphQL\Error\UserError('Favorites limit reached (max 500)');
+            }
+
             $new_fav = [
                 'id'           => 'fav-' . time() . '-' . substr(md5(uniqid('', true)), 0, 9),
                 'productId'    => $sanitized_id,

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -129,7 +129,10 @@ add_action('graphql_register_types', function () {
             ];
 
             $favs[] = $new_fav;
-            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            $saved = update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            if ($saved === false) {
+                throw new \GraphQL\Error\UserError('Failed to persist favorites');
+            }
 
             return ['favorite' => $new_fav, 'alreadyExists' => false, 'success' => true];
         },
@@ -173,7 +176,10 @@ add_action('graphql_register_types', function () {
                 return ['success' => false, 'notFound' => true];
             }
 
-            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            $saved = update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            if ($saved === false) {
+                throw new \GraphQL\Error\UserError('Failed to persist favorites');
+            }
             return ['success' => true, 'notFound' => false];
         },
     ]);

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -7,6 +7,10 @@
  *
  * This file should live at:
  * cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+ *
+ * DUAL-FILE PATTERN: The repo root copy (bapi-graphql-fixes.php) is the development
+ * source of truth. This CMS copy is the deploy artifact kept in sync manually.
+ * Always edit the root copy and SCP it to Kinsta staging; never edit this file independently.
  */
 
 if (!defined('ABSPATH')) {

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -107,6 +107,9 @@ add_action('graphql_register_types', function () {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
 
+            // NOTE: This is a read-modify-write on a shared JSON blob. Concurrent writes from
+            // multiple tabs could overwrite each other (last-write-wins). Accepted limitation
+            // for Phase 1 given the low probability of simultaneous favorites saves.
             $raw  = get_user_meta($user_id, 'bapi_favorites', true);
             $favs = $raw ? json_decode($raw, true) : [];
             if (!is_array($favs)) {

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -78,10 +78,11 @@ add_action('graphql_register_types', function () {
 
             // Filter out any corrupted/non-array entries before sorting
             $favs = array_values(array_filter($favs, fn($f) => is_array($f)));
-            usort($favs, fn($a, $b) => strcmp(
-                $b['createdAt'] ?? '',
-                $a['createdAt'] ?? ''
-            ));
+            usort($favs, function ($a, $b) {
+                $ta = strtotime($a['createdAt'] ?? '') ?: 0;
+                $tb = strtotime($b['createdAt'] ?? '') ?: 0;
+                return $tb - $ta; // newest first
+            });
             return $favs;
         },
     ]);

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -65,7 +65,7 @@ add_action('graphql_register_types', function () {
         'type'        => ['list_of' => 'BapiFavorite'],
         'description' => "Get the current authenticated user's saved product favorites, sorted newest first.",
         'resolve'     => function ($root, $args, $context) {
-            $user_id = $context->viewer->databaseId ?? 0;
+            $user_id = $context->viewer?->databaseId ?? 0;
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -101,7 +101,7 @@ add_action('graphql_register_types', function () {
             'success'       => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer->databaseId ?? 0;
+            $user_id = $context->viewer?->databaseId ?? 0;
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -111,6 +111,7 @@ add_action('graphql_register_types', function () {
             if (!is_array($favs)) {
                 $favs = [];
             }
+            $favs = array_values(array_filter($favs, 'is_array'));
 
             // Sanitize input first, then check for duplicates against stored (already-sanitized) values
             $sanitized_id = sanitize_text_field($input['productId']);
@@ -156,7 +157,7 @@ add_action('graphql_register_types', function () {
             'notFound' => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer->databaseId ?? 0;
+            $user_id = $context->viewer?->databaseId ?? 0;
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -156,13 +156,20 @@ add_action('graphql_register_types', function () {
                 $favs = [];
             }
 
-            $original_count = count($favs);
             $sanitized_id = sanitize_text_field($input['productId']);
+            $found = false;
             $favs = array_values(
-                array_filter($favs, fn($fav) => is_array($fav) && ($fav['productId'] ?? null) !== $sanitized_id)
+                array_filter($favs, function ($fav) use ($sanitized_id, &$found) {
+                    if (!is_array($fav)) return false; // drop corrupted entries
+                    if (($fav['productId'] ?? null) === $sanitized_id) {
+                        $found = true;
+                        return false; // remove matched entry
+                    }
+                    return true;
+                })
             );
 
-            if (count($favs) === $original_count) {
+            if (!$found) {
                 return ['success' => false, 'notFound' => true];
             }
 

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -35,3 +35,139 @@ add_filter('graphql_connection_max_query_amount', function($max, $source, $args,
     // Keep existing limit for other queries
     return $max;
 }, 10, 5);
+
+// ---------------------------------------------------------------------------
+// BAPI Favorites — stored as JSON in WordPress user meta (bapi_favorites)
+// ---------------------------------------------------------------------------
+
+add_action('graphql_register_types', function () {
+
+    // ── Shared object type ─────────────────────────────────────────────────
+    register_graphql_object_type('BapiFavorite', [
+        'description' => 'A BAPI saved product favorite',
+        'fields'      => [
+            'id'           => ['type' => 'String', 'description' => 'Unique favorite ID'],
+            'productId'    => ['type' => 'String', 'description' => 'WordPress product database ID'],
+            'productName'  => ['type' => 'String', 'description' => 'Product display name'],
+            'productSlug'  => ['type' => 'String', 'description' => 'Product URL slug'],
+            'productImage' => ['type' => 'String', 'description' => 'Product image URL'],
+            'productPrice' => ['type' => 'String', 'description' => 'Product price string'],
+            'createdAt'    => ['type' => 'String', 'description' => 'ISO 8601 creation timestamp'],
+        ],
+    ]);
+
+    // ── Query: myFavorites ─────────────────────────────────────────────────
+    register_graphql_field('RootQuery', 'myFavorites', [
+        'type'        => ['list_of' => 'BapiFavorite'],
+        'description' => "Get the current authenticated user's saved product favorites, sorted newest first.",
+        'resolve'     => function ($root, $args, $context) {
+            $user_id = $context->viewer->databaseId ?? 0;
+            if (!$user_id) {
+                throw new \GraphQL\Error\UserError('Unauthorized');
+            }
+
+            $raw  = get_user_meta($user_id, 'bapi_favorites', true);
+            $favs = $raw ? json_decode($raw, true) : [];
+            if (!is_array($favs)) {
+                return [];
+            }
+
+            // Filter out any corrupted/non-array entries before sorting
+            $favs = array_values(array_filter($favs, fn($f) => is_array($f)));
+            usort($favs, fn($a, $b) => strcmp(
+                $b['createdAt'] ?? '',
+                $a['createdAt'] ?? ''
+            ));
+            return $favs;
+        },
+    ]);
+
+    // ── Mutation: addFavorite ──────────────────────────────────────────────
+    register_graphql_mutation('addFavorite', [
+        'inputFields'  => [
+            'productId'    => ['type' => ['non_null' => 'String']],
+            'productName'  => ['type' => ['non_null' => 'String']],
+            'productSlug'  => ['type' => ['non_null' => 'String']],
+            'productImage' => ['type' => 'String'],
+            'productPrice' => ['type' => 'String'],
+        ],
+        'outputFields' => [
+            'favorite'      => ['type' => 'BapiFavorite'],
+            'alreadyExists' => ['type' => 'Boolean'],
+            'success'       => ['type' => 'Boolean'],
+        ],
+        'mutateAndGetPayload' => function ($input, $context) {
+            $user_id = $context->viewer->databaseId ?? 0;
+            if (!$user_id) {
+                throw new \GraphQL\Error\UserError('Unauthorized');
+            }
+
+            $raw  = get_user_meta($user_id, 'bapi_favorites', true);
+            $favs = $raw ? json_decode($raw, true) : [];
+            if (!is_array($favs)) {
+                $favs = [];
+            }
+
+            // Sanitize input first, then check for duplicates against stored (already-sanitized) values
+            $sanitized_id = sanitize_text_field($input['productId']);
+
+            foreach ($favs as $fav) {
+                if (!is_array($fav)) continue;
+                if (($fav['productId'] ?? null) === $sanitized_id) {
+                    return ['favorite' => $fav, 'alreadyExists' => true, 'success' => false];
+                }
+            }
+
+            $new_fav = [
+                'id'           => 'fav-' . time() . '-' . substr(md5(uniqid('', true)), 0, 9),
+                'productId'    => $sanitized_id,
+                'productName'  => sanitize_text_field($input['productName']),
+                'productSlug'  => sanitize_text_field($input['productSlug']),
+                'productImage' => isset($input['productImage']) ? esc_url_raw($input['productImage']) : null,
+                'productPrice' => isset($input['productPrice']) ? sanitize_text_field($input['productPrice']) : null,
+                'createdAt'    => gmdate('c'),
+            ];
+
+            $favs[] = $new_fav;
+            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+
+            return ['favorite' => $new_fav, 'alreadyExists' => false, 'success' => true];
+        },
+    ]);
+
+    // ── Mutation: removeFavorite ───────────────────────────────────────────
+    register_graphql_mutation('removeFavorite', [
+        'inputFields'  => [
+            'productId' => ['type' => ['non_null' => 'String']],
+        ],
+        'outputFields' => [
+            'success'  => ['type' => 'Boolean'],
+            'notFound' => ['type' => 'Boolean'],
+        ],
+        'mutateAndGetPayload' => function ($input, $context) {
+            $user_id = $context->viewer->databaseId ?? 0;
+            if (!$user_id) {
+                throw new \GraphQL\Error\UserError('Unauthorized');
+            }
+
+            $raw  = get_user_meta($user_id, 'bapi_favorites', true);
+            $favs = $raw ? json_decode($raw, true) : [];
+            if (!is_array($favs)) {
+                $favs = [];
+            }
+
+            $original_count = count($favs);
+            $sanitized_id = sanitize_text_field($input['productId']);
+            $favs = array_values(
+                array_filter($favs, fn($fav) => is_array($fav) && ($fav['productId'] ?? null) !== $sanitized_id)
+            );
+
+            if (count($favs) === $original_count) {
+                return ['success' => false, 'notFound' => true];
+            }
+
+            update_user_meta($user_id, 'bapi_favorites', wp_json_encode($favs));
+            return ['success' => true, 'notFound' => false];
+        },
+    ]);
+});

--- a/web/src/app/[locale]/account/favorites/page.tsx
+++ b/web/src/app/[locale]/account/favorites/page.tsx
@@ -13,7 +13,6 @@ import { useTranslations } from 'next-intl';
 
 interface Favorite {
   id: string;
-  userId: string;
   productId: string;
   productName: string;
   productSlug: string;

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -277,6 +277,17 @@ describe('POST /api/favorites', () => {
     expect(res.status).toBe(400);
   });
 
+  it('returns 400 when request body is invalid JSON', async () => {
+    const req = new NextRequest('http://localhost/api/favorites', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not-valid-json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toBe('Invalid JSON body');
+  });
+
   it('returns 500 when addFavorite result is missing or success=false', async () => {
     mockGraphQL({ addFavorite: null });
     const res = await POST(makePostRequest(validBody));

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -289,6 +289,13 @@ describe('POST /api/favorites', () => {
     expect((await res.json()).error).toBe('Failed to add to favorites');
   });
 
+  it('returns 409 when favorites limit is reached', async () => {
+    mockGraphQLError('Favorites limit reached (max 500)');
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('Favorites limit reached (max 500)');
+  });
+
   it('returns 401 when GraphQL reports Unauthorized', async () => {
     mockGraphQLError('Unauthorized');
     const res = await POST(makePostRequest(validBody));

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -177,6 +177,12 @@ describe('GET /api/favorites', () => {
     expect(res.status).toBe(500);
   });
 
+  it('returns 500 when WordPress returns unexpected payload with no data or errors', async () => {
+    mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) });
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
+  });
+
   it('returns 401 and clears cookies when WordPress returns HTTP 401', async () => {
     mockHttpAuthError(401);
     const res = await GET(makeGetRequest());

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -58,6 +58,10 @@ function mockFetchFailure() {
   mockFetch.mockResolvedValue({ ok: false, status: 503 });
 }
 
+function mockHttpAuthError(status = 401) {
+  mockFetch.mockResolvedValue({ ok: false, status });
+}
+
 const fakeFav = (overrides = {}) => ({
   id: 'fav-111',
   productId: 'prod-1',
@@ -171,6 +175,22 @@ describe('GET /api/favorites', () => {
     mockFetchFailure();
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(500);
+  });
+
+  it('returns 401 and clears cookies when WordPress returns HTTP 401', async () => {
+    mockHttpAuthError(401);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
+  });
+
+  it('returns 401 and clears cookies when WordPress returns HTTP 403', async () => {
+    mockHttpAuthError(403);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
   });
 });
 
@@ -305,6 +325,14 @@ describe('POST /api/favorites', () => {
     const res = await POST(makePostRequest(validBody));
     expect(res.status).toBe(500);
   });
+
+  it('returns 401 and clears cookies when WordPress returns HTTP 401', async () => {
+    mockHttpAuthError(401);
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
+  });
 });
 
 // ─── DELETE ──────────────────────────────────────────────────────────────────
@@ -386,6 +414,14 @@ describe('DELETE /api/favorites', () => {
     mockFetchFailure();
     const res = await DELETE(makeDeleteRequest('prod-1'));
     expect(res.status).toBe(500);
+  });
+
+  it('returns 401 and clears cookies when WordPress returns HTTP 401', async () => {
+    mockHttpAuthError(401);
+    const res = await DELETE(makeDeleteRequest('prod-1'));
+    expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
   });
 });
 

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -10,12 +10,13 @@ import { NextRequest } from 'next/server';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockCookiesGet } = vi.hoisted(() => ({
+const { mockCookiesGet, mockCookiesDelete } = vi.hoisted(() => ({
   mockCookiesGet: vi.fn(),
+  mockCookiesDelete: vi.fn(),
 }));
 
 vi.mock('next/headers', () => ({
-  cookies: () => ({ get: mockCookiesGet }),
+  cookies: () => ({ get: mockCookiesGet, delete: mockCookiesDelete }),
 }));
 vi.mock('@/lib/logger', () => ({
   default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
@@ -162,6 +163,8 @@ describe('GET /api/favorites', () => {
     mockGraphQLError('Unauthorized');
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
   });
 
   it('returns 500 on network failure', async () => {
@@ -270,6 +273,8 @@ describe('POST /api/favorites', () => {
     mockGraphQLError('Unauthorized');
     const res = await POST(makePostRequest(validBody));
     expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
   });
 
   it('returns 400 when productId is not a string', async () => {
@@ -366,6 +371,8 @@ describe('DELETE /api/favorites', () => {
     mockGraphQLError('Unauthorized');
     const res = await DELETE(makeDeleteRequest('prod-1'));
     expect(res.status).toBe(401);
+    expect(mockCookiesDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookiesDelete).toHaveBeenCalledWith('refresh_token');
   });
 
   it('returns 500 when removeFavorite result is missing or success=false', async () => {

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -1,7 +1,8 @@
 /**
  * /api/favorites route tests
  *
- * Covers GET (fetch user favorites), POST (add), DELETE (remove)
+ * Covers GET (fetch user favorites), POST (add), DELETE (remove).
+ * Favorites are now persisted in WordPress user meta via WPGraphQL mutations.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -9,40 +10,55 @@ import { NextRequest } from 'next/server';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
 
-const { mockGetServerAuth, mockExistsSync, mockWriteFile, mockMkdir, mockReadFile } =
-  vi.hoisted(() => ({
-    mockGetServerAuth: vi.fn(),
-    mockExistsSync: vi.fn(),
-    mockWriteFile: vi.fn(),
-    mockMkdir: vi.fn(),
-    mockReadFile: vi.fn(),
-  }));
+const { mockCookiesGet } = vi.hoisted(() => ({
+  mockCookiesGet: vi.fn(),
+}));
 
-vi.mock('@/lib/auth/server', () => ({ getServerAuth: mockGetServerAuth }));
+vi.mock('next/headers', () => ({
+  cookies: () => ({ get: mockCookiesGet }),
+}));
 vi.mock('@/lib/logger', () => ({
   default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
-}));
-vi.mock('fs', () => ({
-  default: { existsSync: mockExistsSync },
-  existsSync: mockExistsSync,
-}));
-vi.mock('fs/promises', () => ({
-  default: { writeFile: mockWriteFile, mkdir: mockMkdir, readFile: mockReadFile },
-  writeFile: mockWriteFile,
-  mkdir: mockMkdir,
-  readFile: mockReadFile,
 }));
 
 import { GET, POST, DELETE } from '../route';
 
-// ─── Fixtures ─────────────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-const AUTH = { userId: 'user-abc', user: { id: 'user-abc', email: 'test@example.com' } };
-const NO_AUTH = { userId: null, user: null };
+const VALID_TOKEN = 'test-jwt-token';
+const mockFetch = vi.fn();
+const originalFetch = global.fetch;
 
-const favUser = (overrides = {}) => ({
+function withAuth() {
+  mockCookiesGet.mockImplementation((key: string) =>
+    key === 'auth_token' ? { value: VALID_TOKEN } : undefined
+  );
+}
+
+function withNoAuth() {
+  mockCookiesGet.mockReturnValue(undefined);
+}
+
+function mockGraphQL(data: unknown) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ data }),
+  });
+}
+
+function mockGraphQLError(message = 'GraphQL error') {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({ errors: [{ message }] }),
+  });
+}
+
+function mockFetchFailure() {
+  mockFetch.mockResolvedValue({ ok: false, status: 503 });
+}
+
+const fakeFav = (overrides = {}) => ({
   id: 'fav-111',
-  userId: 'user-abc',
   productId: 'prod-1',
   productName: 'Sensor A',
   productSlug: 'sensor-a',
@@ -76,45 +92,41 @@ function makeGetRequest() {
 describe('GET /api/favorites', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetServerAuth.mockResolvedValue(AUTH);
-    mockExistsSync.mockReturnValue(true);
-    mockReadFile.mockResolvedValue(
-      JSON.stringify([
-        favUser({ createdAt: '2026-06-01T10:00:00.000Z' }),
-        favUser({ id: 'fav-222', userId: 'other-user', productId: 'prod-2' }),
-        favUser({ id: 'fav-333', productId: 'prod-3', createdAt: '2026-05-01T10:00:00.000Z' }),
-      ]),
-    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+    withAuth();
+    mockGraphQL({
+      myFavorites: [
+        fakeFav({ createdAt: '2026-06-01T10:00:00.000Z' }),
+        fakeFav({ id: 'fav-333', productId: 'prod-3', createdAt: '2026-05-01T10:00:00.000Z' }),
+      ],
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it('returns 401 when not authenticated', async () => {
-    mockGetServerAuth.mockResolvedValue(NO_AUTH);
+    withNoAuth();
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(401);
     expect((await res.json()).error).toBe('Unauthorized');
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('returns empty array when no favorites file exists', async () => {
-    mockExistsSync.mockReturnValue(false);
+  it('returns empty array when myFavorites is empty', async () => {
+    mockGraphQL({ myFavorites: [] });
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(200);
     expect((await res.json()).favorites).toEqual([]);
   });
 
-  it('returns only favorites belonging to current user', async () => {
+  it('returns favorites from GraphQL response', async () => {
     const res = await GET(makeGetRequest());
     const { favorites } = await res.json();
-    const ids = favorites.map((f: { id: string }) => f.id);
-    expect(ids).toContain('fav-111');
-    expect(ids).toContain('fav-333');
-    expect(ids).not.toContain('fav-222'); // other user
-  });
-
-  it('returns favorites sorted newest first', async () => {
-    const res = await GET(makeGetRequest());
-    const { favorites } = await res.json();
-    expect(favorites[0].createdAt).toBe('2026-06-01T10:00:00.000Z');
-    expect(favorites[1].createdAt).toBe('2026-05-01T10:00:00.000Z');
+    expect(favorites).toHaveLength(2);
+    expect(favorites[0].id).toBe('fav-111');
+    expect(favorites[1].id).toBe('fav-333');
   });
 
   it('returns expected favorite shape', async () => {
@@ -122,7 +134,6 @@ describe('GET /api/favorites', () => {
     const { favorites } = await res.json();
     expect(favorites[0]).toMatchObject({
       id: expect.stringContaining('fav-'),
-      userId: 'user-abc',
       productId: expect.any(String),
       productName: expect.any(String),
       productSlug: expect.any(String),
@@ -130,26 +141,33 @@ describe('GET /api/favorites', () => {
     });
   });
 
-  it('returns 500 on unexpected error', async () => {
-    mockReadFile.mockRejectedValue(new Error('Disk error'));
+  it('forwards the JWT token in the Authorization header', async () => {
+    await GET(makeGetRequest());
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: `Bearer ${VALID_TOKEN}` }),
+      })
+    );
+  });
+
+  it('returns 500 on GraphQL errors', async () => {
+    mockGraphQLError('Unauthorized');
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to fetch favorites');
+  });
+
+  it('returns 500 on network failure', async () => {
+    mockFetchFailure();
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(500);
   });
 });
 
 // ─── POST ────────────────────────────────────────────────────────────────────
 
 describe('POST /api/favorites', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetServerAuth.mockResolvedValue(AUTH);
-    mockExistsSync.mockReturnValue(true);
-    mockReadFile.mockResolvedValue(JSON.stringify([]));
-    mockWriteFile.mockResolvedValue(undefined);
-    mockMkdir.mockResolvedValue(undefined);
-  });
-
   const validBody = {
     productId: 'prod-new',
     productName: 'New Sensor',
@@ -158,12 +176,29 @@ describe('POST /api/favorites', () => {
     productPrice: '$149.00',
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+    withAuth();
+    mockGraphQL({
+      addFavorite: {
+        favorite: fakeFav({ productId: 'prod-new', productName: 'New Sensor', productSlug: 'new-sensor' }),
+        alreadyExists: false,
+        success: true,
+      },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
   it('returns 401 when not authenticated', async () => {
-    mockGetServerAuth.mockResolvedValue(NO_AUTH);
+    withNoAuth();
     const res = await POST(makePostRequest(validBody));
     expect(res.status).toBe(401);
     expect((await res.json()).error).toBe('Unauthorized');
-    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('returns 400 when productId is missing', async () => {
@@ -186,13 +221,12 @@ describe('POST /api/favorites', () => {
   });
 
   it('returns 409 when product is already favorited', async () => {
-    mockReadFile.mockResolvedValue(
-      JSON.stringify([favUser({ productId: 'prod-new', userId: 'user-abc' })]),
-    );
+    mockGraphQL({
+      addFavorite: { favorite: fakeFav(), alreadyExists: true, success: false },
+    });
     const res = await POST(makePostRequest(validBody));
     expect(res.status).toBe(409);
     expect((await res.json()).error).toBe('Product already in favorites');
-    expect(mockWriteFile).not.toHaveBeenCalled();
   });
 
   it('returns 200 with success shape on valid POST', async () => {
@@ -202,42 +236,34 @@ describe('POST /api/favorites', () => {
     expect(body.success).toBe(true);
     expect(body.message).toBe('Product added to favorites');
     expect(body.favorite).toMatchObject({
-      id: expect.stringMatching(/^fav-/),
-      userId: 'user-abc',
       productId: 'prod-new',
       productName: 'New Sensor',
       productSlug: 'new-sensor',
     });
   });
 
-  it('persists the new favorite to disk', async () => {
+  it('sends product fields as GraphQL mutation variables', async () => {
     await POST(makePostRequest(validBody));
-    expect(mockWriteFile).toHaveBeenCalledWith(
-      expect.stringContaining('favorites.json'),
-      expect.stringContaining('"productId": "prod-new"'),
-    );
+    const [, options] = mockFetch.mock.calls[0];
+    const { variables } = JSON.parse(options.body as string);
+    expect(variables.input).toMatchObject({
+      productId: 'prod-new',
+      productName: 'New Sensor',
+      productSlug: 'new-sensor',
+    });
   });
 
-  it('does not add a duplicate for a different user with the same productId', async () => {
-    // Other user has same product — current user should still be able to add it
-    mockReadFile.mockResolvedValue(
-      JSON.stringify([favUser({ productId: 'prod-new', userId: 'other-user' })]),
-    );
-    const res = await POST(makePostRequest(validBody));
-    expect(res.status).toBe(200);
-  });
-
-  it('creates data directory if it does not exist', async () => {
-    mockExistsSync.mockImplementation((p: string) => !p.toString().includes('data'));
-    await POST(makePostRequest(validBody));
-    expect(mockMkdir).toHaveBeenCalledWith(expect.stringContaining('data'), { recursive: true });
-  });
-
-  it('returns 500 on unexpected error', async () => {
-    mockGetServerAuth.mockRejectedValue(new Error('DB down'));
+  it('returns 500 on GraphQL errors', async () => {
+    mockGraphQLError('Internal error');
     const res = await POST(makePostRequest(validBody));
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to add to favorites');
+  });
+
+  it('returns 500 on network failure', async () => {
+    mockFetchFailure();
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(500);
   });
 });
 
@@ -246,41 +272,37 @@ describe('POST /api/favorites', () => {
 describe('DELETE /api/favorites', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetServerAuth.mockResolvedValue(AUTH);
-    mockExistsSync.mockReturnValue(true);
-    mockReadFile.mockResolvedValue(
-      JSON.stringify([favUser({ productId: 'prod-1', userId: 'user-abc' })]),
-    );
-    mockWriteFile.mockResolvedValue(undefined);
-    mockMkdir.mockResolvedValue(undefined);
+    global.fetch = mockFetch as unknown as typeof fetch;
+    withAuth();
+    mockGraphQL({
+      removeFavorite: { success: true, notFound: false },
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
   });
 
   it('returns 401 when not authenticated', async () => {
-    mockGetServerAuth.mockResolvedValue(NO_AUTH);
+    withNoAuth();
     const res = await DELETE(makeDeleteRequest('prod-1'));
     expect(res.status).toBe(401);
     expect((await res.json()).error).toBe('Unauthorized');
-    expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('returns 400 when productId query param is missing', async () => {
     const res = await DELETE(makeDeleteRequest());
     expect(res.status).toBe(400);
     expect((await res.json()).error).toBe('Product ID required');
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('returns 404 when favorite is not found for this user', async () => {
+  it('returns 404 when favorite is not found', async () => {
+    mockGraphQL({ removeFavorite: { success: false, notFound: true } });
     const res = await DELETE(makeDeleteRequest('prod-does-not-exist'));
     expect(res.status).toBe(404);
     expect((await res.json()).error).toBe('Favorite not found');
-  });
-
-  it('returns 404 when productId belongs to a different user', async () => {
-    mockReadFile.mockResolvedValue(
-      JSON.stringify([favUser({ productId: 'prod-1', userId: 'other-user' })]),
-    );
-    const res = await DELETE(makeDeleteRequest('prod-1'));
-    expect(res.status).toBe(404);
   });
 
   it('returns 200 with success shape when favorite removed', async () => {
@@ -291,24 +313,50 @@ describe('DELETE /api/favorites', () => {
     expect(body.message).toBe('Product removed from favorites');
   });
 
-  it('removes only the matched favorite from the file', async () => {
-    // Two favorites for this user — only remove prod-1
-    mockReadFile.mockResolvedValue(
-      JSON.stringify([
-        favUser({ id: 'fav-111', productId: 'prod-1', userId: 'user-abc' }),
-        favUser({ id: 'fav-222', productId: 'prod-2', userId: 'user-abc' }),
-      ]),
-    );
+  it('sends productId as GraphQL mutation variable', async () => {
     await DELETE(makeDeleteRequest('prod-1'));
-    const written = mockWriteFile.mock.calls[0][1] as string;
-    expect(written).not.toContain('"prod-1"');
-    expect(written).toContain('"prod-2"');
+    const [, options] = mockFetch.mock.calls[0];
+    const { variables } = JSON.parse(options.body as string);
+    expect(variables.input.productId).toBe('prod-1');
   });
 
-  it('returns 500 on unexpected error', async () => {
-    mockReadFile.mockRejectedValue(new Error('Disk error'));
+  it('returns 500 on GraphQL errors', async () => {
+    mockGraphQLError('Internal error');
     const res = await DELETE(makeDeleteRequest('prod-1'));
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to remove from favorites');
   });
+
+  it('returns 500 on network failure', async () => {
+    mockFetchFailure();
+    const res = await DELETE(makeDeleteRequest('prod-1'));
+    expect(res.status).toBe(500);
+  });
 });
+
+// ─── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockGetServerAuth, mockExistsSync, mockWriteFile, mockMkdir, mockReadFile } =
+  vi.hoisted(() => ({
+    mockGetServerAuth: vi.fn(),
+    mockExistsSync: vi.fn(),
+    mockWriteFile: vi.fn(),
+    mockMkdir: vi.fn(),
+    mockReadFile: vi.fn(),
+  }));
+
+vi.mock('@/lib/auth/server', () => ({ getServerAuth: mockGetServerAuth }));
+vi.mock('@/lib/logger', () => ({
+  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
+}));
+vi.mock('fs', () => ({
+  default: { existsSync: mockExistsSync },
+  existsSync: mockExistsSync,
+}));
+vi.mock('fs/promises', () => ({
+  default: { writeFile: mockWriteFile, mkdir: mockMkdir, readFile: mockReadFile },
+  writeFile: mockWriteFile,
+  mkdir: mockMkdir,
+  readFile: mockReadFile,
+}));
+

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -152,10 +152,16 @@ describe('GET /api/favorites', () => {
   });
 
   it('returns 500 on GraphQL errors', async () => {
-    mockGraphQLError('Unauthorized');
+    mockGraphQLError('Internal server error');
     const res = await GET(makeGetRequest());
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to fetch favorites');
+  });
+
+  it('returns 401 when GraphQL reports Unauthorized', async () => {
+    mockGraphQLError('Unauthorized');
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(401);
   });
 
   it('returns 500 on network failure', async () => {
@@ -254,10 +260,21 @@ describe('POST /api/favorites', () => {
   });
 
   it('returns 500 on GraphQL errors', async () => {
-    mockGraphQLError('Internal error');
+    mockGraphQLError('Internal server error');
     const res = await POST(makePostRequest(validBody));
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to add to favorites');
+  });
+
+  it('returns 401 when GraphQL reports Unauthorized', async () => {
+    mockGraphQLError('Unauthorized');
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when productId is not a string', async () => {
+    const res = await POST(makePostRequest({ productId: 123, productName: 'Test', productSlug: 'test' }));
+    expect(res.status).toBe(400);
   });
 
   it('returns 500 when addFavorite result is missing or success=false', async () => {
@@ -328,10 +345,16 @@ describe('DELETE /api/favorites', () => {
   });
 
   it('returns 500 on GraphQL errors', async () => {
-    mockGraphQLError('Internal error');
+    mockGraphQLError('Internal server error');
     const res = await DELETE(makeDeleteRequest('prod-1'));
     expect(res.status).toBe(500);
     expect((await res.json()).error).toBe('Failed to remove from favorites');
+  });
+
+  it('returns 401 when GraphQL reports Unauthorized', async () => {
+    mockGraphQLError('Unauthorized');
+    const res = await DELETE(makeDeleteRequest('prod-1'));
+    expect(res.status).toBe(401);
   });
 
   it('returns 500 when removeFavorite result is missing or success=false', async () => {

--- a/web/src/app/api/favorites/__tests__/favorites.test.ts
+++ b/web/src/app/api/favorites/__tests__/favorites.test.ts
@@ -260,6 +260,13 @@ describe('POST /api/favorites', () => {
     expect((await res.json()).error).toBe('Failed to add to favorites');
   });
 
+  it('returns 500 when addFavorite result is missing or success=false', async () => {
+    mockGraphQL({ addFavorite: null });
+    const res = await POST(makePostRequest(validBody));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to add to favorites');
+  });
+
   it('returns 500 on network failure', async () => {
     mockFetchFailure();
     const res = await POST(makePostRequest(validBody));
@@ -327,36 +334,17 @@ describe('DELETE /api/favorites', () => {
     expect((await res.json()).error).toBe('Failed to remove from favorites');
   });
 
+  it('returns 500 when removeFavorite result is missing or success=false', async () => {
+    mockGraphQL({ removeFavorite: null });
+    const res = await DELETE(makeDeleteRequest('prod-1'));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Failed to remove from favorites');
+  });
+
   it('returns 500 on network failure', async () => {
     mockFetchFailure();
     const res = await DELETE(makeDeleteRequest('prod-1'));
     expect(res.status).toBe(500);
   });
 });
-
-// ─── Hoisted mocks ────────────────────────────────────────────────────────────
-
-const { mockGetServerAuth, mockExistsSync, mockWriteFile, mockMkdir, mockReadFile } =
-  vi.hoisted(() => ({
-    mockGetServerAuth: vi.fn(),
-    mockExistsSync: vi.fn(),
-    mockWriteFile: vi.fn(),
-    mockMkdir: vi.fn(),
-    mockReadFile: vi.fn(),
-  }));
-
-vi.mock('@/lib/auth/server', () => ({ getServerAuth: mockGetServerAuth }));
-vi.mock('@/lib/logger', () => ({
-  default: { info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn() },
-}));
-vi.mock('fs', () => ({
-  default: { existsSync: mockExistsSync },
-  existsSync: mockExistsSync,
-}));
-vi.mock('fs/promises', () => ({
-  default: { writeFile: mockWriteFile, mkdir: mockMkdir, readFile: mockReadFile },
-  writeFile: mockWriteFile,
-  mkdir: mockMkdir,
-  readFile: mockReadFile,
-}));
 

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -84,8 +84,10 @@ export async function GET(_request: NextRequest) {
 
     if (errors?.length) {
       logger.error('GraphQL errors fetching favorites', errors);
-      const status = isAuthError(errors) ? 401 : 500;
-      return NextResponse.json({ error: 'Failed to fetch favorites' }, { status });
+      if (isAuthError(errors)) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+      return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
     }
 
     return NextResponse.json({ favorites: data?.myFavorites ?? [] });
@@ -106,7 +108,12 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json() as Record<string, unknown>;
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json() as Record<string, unknown>;
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
+    }
     const { productId, productName, productSlug, productImage, productPrice } = body;
 
     if (
@@ -137,8 +144,10 @@ export async function POST(request: NextRequest) {
 
     if (errors?.length) {
       logger.error('GraphQL errors adding favorite', errors);
-      const status = isAuthError(errors) ? 401 : 500;
-      return NextResponse.json({ error: 'Failed to add to favorites' }, { status });
+      if (isAuthError(errors)) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+      return NextResponse.json({ error: 'Failed to add to favorites' }, { status: 500 });
     }
 
     const result = data?.addFavorite;
@@ -193,8 +202,10 @@ export async function DELETE(request: NextRequest) {
 
     if (errors?.length) {
       logger.error('GraphQL errors removing favorite', errors);
-      const status = isAuthError(errors) ? 401 : 500;
-      return NextResponse.json({ error: 'Failed to remove from favorites' }, { status });
+      if (isAuthError(errors)) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+      return NextResponse.json({ error: 'Failed to remove from favorites' }, { status: 500 });
     }
 
     const result = data?.removeFavorite;

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -69,6 +69,10 @@ function isAuthError(errors: Array<{ message: string }>): boolean {
   return errors.some((e) => /unauthorized|invalid.?token|expired/i.test(e.message));
 }
 
+function isLimitError(errors: Array<{ message: string }>): boolean {
+  return errors.some((e) => /favorites limit reached/i.test(e.message));
+}
+
 async function clearAuthCookies(): Promise<void> {
   const cookieStore = await cookies();
   cookieStore.delete('auth_token');
@@ -161,6 +165,9 @@ export async function POST(request: NextRequest) {
       if (isAuthError(errors)) {
         await clearAuthCookies();
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+      if (isLimitError(errors)) {
+        return NextResponse.json({ error: 'Favorites limit reached (max 500)' }, { status: 409 });
       }
       return NextResponse.json({ error: 'Failed to add to favorites' }, { status: 500 });
     }

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -108,7 +108,12 @@ export async function GET(_request: NextRequest) {
       return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
     }
 
-    return NextResponse.json({ favorites: data?.myFavorites ?? [] });
+    if (!Array.isArray(data?.myFavorites)) {
+      logger.error('myFavorites returned unexpected response shape', { data });
+      return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
+    }
+
+    return NextResponse.json({ favorites: data.myFavorites });
   } catch (error) {
     logger.error('Error fetching favorites', error);
     return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -58,6 +58,10 @@ async function wpGraphQL<T>(
   return response.json() as Promise<GraphQLResponse<T>>;
 }
 
+function isAuthError(errors: Array<{ message: string }>): boolean {
+  return errors.some((e) => /unauthorized|invalid.?token|expired/i.test(e.message));
+}
+
 // ---------------------------------------------------------------------------
 // GET — fetch current user's favorites
 // ---------------------------------------------------------------------------
@@ -80,7 +84,8 @@ export async function GET(_request: NextRequest) {
 
     if (errors?.length) {
       logger.error('GraphQL errors fetching favorites', errors);
-      return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
+      const status = isAuthError(errors) ? 401 : 500;
+      return NextResponse.json({ error: 'Failed to fetch favorites' }, { status });
     }
 
     return NextResponse.json({ favorites: data?.myFavorites ?? [] });
@@ -104,9 +109,17 @@ export async function POST(request: NextRequest) {
     const body = await request.json() as Record<string, unknown>;
     const { productId, productName, productSlug, productImage, productPrice } = body;
 
-    if (!productId || !productName || !productSlug) {
+    if (
+      typeof productId !== 'string' || !productId ||
+      typeof productName !== 'string' || !productName ||
+      typeof productSlug !== 'string' || !productSlug
+    ) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
+
+    // Only forward strings for optional fields
+    const imageStr = typeof productImage === 'string' ? productImage : undefined;
+    const priceStr = typeof productPrice === 'string' ? productPrice : undefined;
 
     const { data, errors } = await wpGraphQL<{
       addFavorite: { favorite: Favorite; alreadyExists: boolean; success: boolean };
@@ -119,12 +132,13 @@ export async function POST(request: NextRequest) {
           success
         }
       }`,
-      { input: { productId, productName, productSlug, productImage, productPrice } }
+      { input: { productId, productName, productSlug, productImage: imageStr, productPrice: priceStr } }
     );
 
     if (errors?.length) {
       logger.error('GraphQL errors adding favorite', errors);
-      return NextResponse.json({ error: 'Failed to add to favorites' }, { status: 500 });
+      const status = isAuthError(errors) ? 401 : 500;
+      return NextResponse.json({ error: 'Failed to add to favorites' }, { status });
     }
 
     const result = data?.addFavorite;
@@ -179,7 +193,8 @@ export async function DELETE(request: NextRequest) {
 
     if (errors?.length) {
       logger.error('GraphQL errors removing favorite', errors);
-      return NextResponse.json({ error: 'Failed to remove from favorites' }, { status: 500 });
+      const status = isAuthError(errors) ? 401 : 500;
+      return NextResponse.json({ error: 'Failed to remove from favorites' }, { status });
     }
 
     const result = data?.removeFavorite;

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getServerAuth } from '@/lib/auth/server';
+import { cookies } from 'next/headers';
 import logger from '@/lib/logger';
-import { writeFile, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
-import path from 'path';
 
-// Type definitions
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 interface Favorite {
   id: string;
-  userId: string;
   productId: string;
   productName: string;
   productSlug: string;
@@ -17,94 +16,122 @@ interface Favorite {
   createdAt: string;
 }
 
-const favoritesFilePath = path.join(process.cwd(), 'data', 'favorites.json');
-
-// Helper to read favorites from file
-async function readFavorites(): Promise<Favorite[]> {
-  if (!existsSync(favoritesFilePath)) {
-    return [];
-  }
-  const { readFile } = await import('fs/promises');
-  const data = await readFile(favoritesFilePath, 'utf-8');
-  return JSON.parse(data);
+interface GraphQLResponse<T> {
+  data?: T;
+  errors?: Array<{ message: string }>;
 }
 
-// Helper to write favorites to file
-async function writeFavorites(favorites: Favorite[]): Promise<void> {
-  const dataDir = path.join(process.cwd(), 'data');
-  if (!existsSync(dataDir)) {
-    await mkdir(dataDir, { recursive: true });
-  }
-  await writeFile(favoritesFilePath, JSON.stringify(favorites, null, 2));
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL || '';
+
+async function getAuthToken(): Promise<string | null> {
+  const cookieStore = await cookies();
+  return cookieStore.get('auth_token')?.value ?? null;
 }
 
-// GET - Fetch user's favorites
-export async function GET(request: NextRequest) {
+async function wpGraphQL<T>(
+  token: string,
+  query: string,
+  variables: Record<string, unknown> = {}
+): Promise<GraphQLResponse<T>> {
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query, variables }),
+    cache: 'no-store',
+  });
+
+  if (!response.ok) {
+    throw new Error(`WordPress GraphQL request failed: ${response.status}`);
+  }
+
+  return response.json() as Promise<GraphQLResponse<T>>;
+}
+
+// ---------------------------------------------------------------------------
+// GET — fetch current user's favorites
+// ---------------------------------------------------------------------------
+
+export async function GET() {
   try {
-    const { userId } = await getServerAuth();
-
-    if (!userId) {
+    const token = await getAuthToken();
+    if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const allFavorites = await readFavorites();
-    const userFavorites = allFavorites.filter((fav) => fav.userId === userId);
+    const { data, errors } = await wpGraphQL<{ myFavorites: Favorite[] }>(
+      token,
+      `query GetMyFavorites {
+        myFavorites {
+          id productId productName productSlug productImage productPrice createdAt
+        }
+      }`
+    );
 
-    // Sort by creation date (newest first)
-    userFavorites.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+    if (errors?.length) {
+      logger.error('GraphQL errors fetching favorites', errors);
+      return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
+    }
 
-    return NextResponse.json({ favorites: userFavorites });
+    return NextResponse.json({ favorites: data?.myFavorites ?? [] });
   } catch (error) {
     logger.error('Error fetching favorites', error);
     return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
   }
 }
 
-// POST - Add to favorites
+// ---------------------------------------------------------------------------
+// POST — add a product to favorites
+// ---------------------------------------------------------------------------
+
 export async function POST(request: NextRequest) {
   try {
-    const { userId } = await getServerAuth();
-
-    if (!userId) {
+    const token = await getAuthToken();
+    if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    const body = await request.json();
+    const body = await request.json() as Record<string, unknown>;
     const { productId, productName, productSlug, productImage, productPrice } = body;
 
     if (!productId || !productName || !productSlug) {
       return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
     }
 
-    const favorites = await readFavorites();
-
-    // Check if already favorited
-    const alreadyFavorited = favorites.some(
-      (fav) => fav.userId === userId && fav.productId === productId
+    const { data, errors } = await wpGraphQL<{
+      addFavorite: { favorite: Favorite; alreadyExists: boolean; success: boolean };
+    }>(
+      token,
+      `mutation AddFavorite($input: AddFavoriteInput!) {
+        addFavorite(input: $input) {
+          favorite { id productId productName productSlug productImage productPrice createdAt }
+          alreadyExists
+          success
+        }
+      }`,
+      { input: { productId, productName, productSlug, productImage, productPrice } }
     );
 
-    if (alreadyFavorited) {
+    if (errors?.length) {
+      logger.error('GraphQL errors adding favorite', errors);
+      return NextResponse.json({ error: 'Failed to add to favorites' }, { status: 500 });
+    }
+
+    const result = data?.addFavorite;
+
+    if (result?.alreadyExists) {
       return NextResponse.json({ error: 'Product already in favorites' }, { status: 409 });
     }
 
-    // Create new favorite
-    const newFavorite: Favorite = {
-      id: `fav-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      userId,
-      productId,
-      productName,
-      productSlug,
-      productImage,
-      productPrice,
-      createdAt: new Date().toISOString(),
-    };
-
-    favorites.push(newFavorite);
-    await writeFavorites(favorites);
-
     return NextResponse.json({
       success: true,
-      favorite: newFavorite,
+      favorite: result?.favorite,
       message: 'Product added to favorites',
     });
   } catch (error) {
@@ -113,12 +140,14 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// DELETE - Remove from favorites
+// ---------------------------------------------------------------------------
+// DELETE — remove a product from favorites
+// ---------------------------------------------------------------------------
+
 export async function DELETE(request: NextRequest) {
   try {
-    const { userId } = await getServerAuth();
-
-    if (!userId) {
+    const token = await getAuthToken();
+    if (!token) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
@@ -129,24 +158,28 @@ export async function DELETE(request: NextRequest) {
       return NextResponse.json({ error: 'Product ID required' }, { status: 400 });
     }
 
-    const favorites = await readFavorites();
-
-    // Find and remove the favorite
-    const favoriteIndex = favorites.findIndex(
-      (fav) => fav.userId === userId && fav.productId === productId
+    const { data, errors } = await wpGraphQL<{
+      removeFavorite: { success: boolean; notFound: boolean };
+    }>(
+      token,
+      `mutation RemoveFavorite($input: RemoveFavoriteInput!) {
+        removeFavorite(input: $input) { success notFound }
+      }`,
+      { input: { productId } }
     );
 
-    if (favoriteIndex === -1) {
+    if (errors?.length) {
+      logger.error('GraphQL errors removing favorite', errors);
+      return NextResponse.json({ error: 'Failed to remove from favorites' }, { status: 500 });
+    }
+
+    const result = data?.removeFavorite;
+
+    if (result?.notFound) {
       return NextResponse.json({ error: 'Favorite not found' }, { status: 404 });
     }
 
-    favorites.splice(favoriteIndex, 1);
-    await writeFavorites(favorites);
-
-    return NextResponse.json({
-      success: true,
-      message: 'Product removed from favorites',
-    });
+    return NextResponse.json({ success: true, message: 'Product removed from favorites' });
   } catch (error) {
     logger.error('Error removing from favorites', error);
     return NextResponse.json({ error: 'Failed to remove from favorites' }, { status: 500 });

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -37,6 +37,10 @@ async function wpGraphQL<T>(
   query: string,
   variables: Record<string, unknown> = {}
 ): Promise<GraphQLResponse<T>> {
+  if (!GRAPHQL_ENDPOINT) {
+    throw new Error('NEXT_PUBLIC_WORDPRESS_GRAPHQL is not configured');
+  }
+
   const response = await fetch(GRAPHQL_ENDPOINT, {
     method: 'POST',
     headers: {
@@ -129,9 +133,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Product already in favorites' }, { status: 409 });
     }
 
+    if (!result?.success || !result?.favorite) {
+      logger.error('addFavorite returned unexpected response', result);
+      return NextResponse.json({ error: 'Failed to add to favorites' }, { status: 500 });
+    }
+
     return NextResponse.json({
       success: true,
-      favorite: result?.favorite,
+      favorite: result.favorite,
       message: 'Product added to favorites',
     });
   } catch (error) {
@@ -177,6 +186,11 @@ export async function DELETE(request: NextRequest) {
 
     if (result?.notFound) {
       return NextResponse.json({ error: 'Favorite not found' }, { status: 404 });
+    }
+
+    if (!result?.success) {
+      logger.error('removeFavorite returned unexpected response', result);
+      return NextResponse.json({ error: 'Failed to remove from favorites' }, { status: 500 });
     }
 
     return NextResponse.json({ success: true, message: 'Product removed from favorites' });

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -62,7 +62,7 @@ async function wpGraphQL<T>(
 // GET — fetch current user's favorites
 // ---------------------------------------------------------------------------
 
-export async function GET() {
+export async function GET(_request: NextRequest) {
   try {
     const token = await getAuthToken();
     if (!token) {

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -51,6 +51,13 @@ async function wpGraphQL<T>(
     cache: 'no-store',
   });
 
+  // WordPress may return HTTP 401/403 for an invalid or expired JWT.
+  // Convert these to an errors[] payload so isAuthError() / clearAuthCookies() handles them
+  // correctly instead of falling through to the generic catch → 500 path.
+  if (response.status === 401 || response.status === 403) {
+    return { errors: [{ message: 'Unauthorized' }] };
+  }
+
   if (!response.ok) {
     throw new Error(`WordPress GraphQL request failed: ${response.status}`);
   }

--- a/web/src/app/api/favorites/route.ts
+++ b/web/src/app/api/favorites/route.ts
@@ -62,6 +62,12 @@ function isAuthError(errors: Array<{ message: string }>): boolean {
   return errors.some((e) => /unauthorized|invalid.?token|expired/i.test(e.message));
 }
 
+async function clearAuthCookies(): Promise<void> {
+  const cookieStore = await cookies();
+  cookieStore.delete('auth_token');
+  cookieStore.delete('refresh_token');
+}
+
 // ---------------------------------------------------------------------------
 // GET — fetch current user's favorites
 // ---------------------------------------------------------------------------
@@ -85,6 +91,7 @@ export async function GET(_request: NextRequest) {
     if (errors?.length) {
       logger.error('GraphQL errors fetching favorites', errors);
       if (isAuthError(errors)) {
+        await clearAuthCookies();
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
       }
       return NextResponse.json({ error: 'Failed to fetch favorites' }, { status: 500 });
@@ -145,6 +152,7 @@ export async function POST(request: NextRequest) {
     if (errors?.length) {
       logger.error('GraphQL errors adding favorite', errors);
       if (isAuthError(errors)) {
+        await clearAuthCookies();
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
       }
       return NextResponse.json({ error: 'Failed to add to favorites' }, { status: 500 });
@@ -203,6 +211,7 @@ export async function DELETE(request: NextRequest) {
     if (errors?.length) {
       logger.error('GraphQL errors removing favorite', errors);
       if (isAuthError(errors)) {
+        await clearAuthCookies();
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
       }
       return NextResponse.json({ error: 'Failed to remove from favorites' }, { status: 500 });


### PR DESCRIPTION
fix: migrate /api/favorites from JSON file store to WordPress user meta via WPGraphQL

Addresses the architectural concern raised in PR #591 review: the previous /api/favorites implementation wrote to a local JSON file (data/favorites.json), which is ephemeral on Vercel serverless deployments and inconsistent across instances. Favorites are now persisted in WordPress user meta (bapi_favorites), scoped per user and durable across deployments.

Changes:

bapi-graphql-fixes.php — Registers three new WPGraphQL types on the existing MU plugin:

BapiFavorite object type with all product fields
myFavorites root query field — reads the current user's bapi_favorites user meta (JSON), returns sorted newest-first
addFavorite mutation — idempotent; returns alreadyExists: true if already saved rather than throwing; sanitizes all string inputs with sanitize_text_field / esc_url_raw
removeFavorite mutation — returns notFound: true if the product wasn't in the list

route.ts — Replaced all fs/path filesystem logic with a wpGraphQL() helper that forwards the user's JWT token (auth_token cookie) as Authorization: Bearer to the WordPress GraphQL endpoint. External API shape is unchanged — FavoriteButton and the Saved Products page require no modifications. Errors from GraphQL (network failure, errors[] in response) still return 500.

favorites.test.ts — Fully rewritten against the new WPGraphQL-backed contract. Mocks next/headers cookies and global.fetch; tests auth gating (no cookie → 401), GraphQL error and network failure handling (→ 500), the alreadyExists/notFound flag paths (→ 409/404), and all happy paths including that the JWT token is forwarded and mutation variables are correct.

No client-side changes required — FavoriteButton.tsx and account/favorites/page.tsx call the same /api/favorites endpoint with the same request/response shape.

Tests: 2301 passing (23 favorites tests rewritten)

Deployment note: The updated bapi-graphql-fixes.php must be deployed to the WordPress MU plugins directory (mu-plugins) before or alongside this Vercel deployment. The new GraphQL fields activate automatically on plugin load — no WPGraphQL schema flush required