### PR TITLE
fix: use get_current_user_id() instead of context->viewer in favorite…

### DIFF
--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -66,7 +66,7 @@ add_action('graphql_register_types', function () {
         'type'        => ['list_of' => 'BapiFavorite'],
         'description' => "Get the current authenticated user's saved product favorites, sorted newest first.",
         'resolve'     => function ($root, $args, $context) {
-            $user_id = $context->viewer?->databaseId ?? 0;
+            $user_id = get_current_user_id();
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -103,7 +103,7 @@ add_action('graphql_register_types', function () {
             'success'       => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer?->databaseId ?? 0;
+            $user_id = get_current_user_id();
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -162,7 +162,7 @@ add_action('graphql_register_types', function () {
             'notFound' => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer?->databaseId ?? 0;
+            $user_id = get_current_user_id();
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -65,7 +65,7 @@ add_action('graphql_register_types', function () {
         'type'        => ['list_of' => 'BapiFavorite'],
         'description' => "Get the current authenticated user's saved product favorites, sorted newest first.",
         'resolve'     => function ($root, $args, $context) {
-            $user_id = $context->viewer?->databaseId ?? 0;
+            $user_id = get_current_user_id();
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -102,7 +102,7 @@ add_action('graphql_register_types', function () {
             'success'       => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer?->databaseId ?? 0;
+            $user_id = get_current_user_id();
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }
@@ -161,7 +161,7 @@ add_action('graphql_register_types', function () {
             'notFound' => ['type' => 'Boolean'],
         ],
         'mutateAndGetPayload' => function ($input, $context) {
-            $user_id = $context->viewer?->databaseId ?? 0;
+            $user_id = get_current_user_id();
             if (!$user_id) {
                 throw new \GraphQL\Error\UserError('Unauthorized');
             }


### PR DESCRIPTION
## Problem

The `addFavorite`, `removeFavorite`, and `myFavorites` GraphQL resolvers all used `$context->viewer?->databaseId ?? 0` to get the current user ID. While WPGraphQL's built-in `viewer` query field works correctly with JWT tokens, `AppContext->viewer` is **not populated** inside custom mutation/query resolvers registered via `register_graphql_mutation` and `register_graphql_field`.

This caused every favorites operation to return `Unauthorized` for all authenticated users — `$context->viewer` was always `null`, so `databaseId` evaluated to `0` and the auth check failed.

**Confirmed via curl:** The `{ viewer { databaseId } }` query returned the correct user (16332) with a valid JWT, but `addFavorite` with the same token returned `Unauthorized`.

## Root Cause

`AppContext->viewer` is resolved through WPGraphQL's own field resolution pipeline. It is not automatically populated when PHP code accesses it directly inside a custom resolver closure. WordPress's `get_current_user_id()` is the correct approach — the WPGraphQL JWT Authentication plugin properly calls `wp_set_current_user()` before request execution, making the current user available via standard WordPress functions.

## Fix

Replace `$context->viewer?->databaseId ?? 0` with `get_current_user_id()` in all three resolvers (`myFavorites`, `addFavorite`, `removeFavorite`) in both PHP files.

**Before:**
```php
$user_id = $context->viewer?->databaseId ?? 0;

<?php
$user_id = get_current_user_id();



{
  "data": {
    "addFavorite": {
      "success": true,
      "alreadyExists": false
    }
  }
}