### PR TITLE
fix: extend JWT expiry to 1h + silent token refresh in /api/auth/me

### DIFF
--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -27,6 +27,18 @@ if (!defined('ABSPATH')) {
  * Fixes issue: Product #136296 (Duct Temperature Transmitter) has 150 variations
  * but only first 100 were returned by GraphQL, causing missing "4-20mA" option.
  */
+/**
+ * Extend WPGraphQL JWT auth token expiry to 1 hour
+ *
+ * The plugin default is 300 seconds (5 minutes), which is far too short for
+ * normal browsing sessions. Tokens are silently refreshed by the Next.js
+ * /api/auth/me route using the 30-day refresh_token cookie, but a longer
+ * primary expiry gives a better fallback window.
+ */
+add_filter('graphql_jwt_auth_expire', function () {
+    return 3600; // 1 hour in seconds
+});
+
 add_filter('graphql_connection_max_query_amount', function($max, $source, $args, $context, $info) {
     // Increase limit only for the VariableProduct variations connection
     if (

--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -35,9 +35,9 @@ if (!defined('ABSPATH')) {
  * /api/auth/me route using the 30-day refresh_token cookie, but a longer
  * primary expiry gives a better fallback window.
  */
-add_filter('graphql_jwt_auth_expire', function () {
+add_filter('graphql_jwt_auth_expire', function ($expiration) {
     return 3600; // 1 hour in seconds
-});
+}, 10, 1);
 
 add_filter('graphql_connection_max_query_amount', function($max, $source, $args, $context, $info) {
     // Increase limit only for the VariableProduct variations connection

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -34,9 +34,9 @@ if (!defined('ABSPATH')) {
  * /api/auth/me route using the 30-day refresh_token cookie, but a longer
  * primary expiry gives a better fallback window.
  */
-add_filter('graphql_jwt_auth_expire', function () {
+add_filter('graphql_jwt_auth_expire', function ($expiration) {
     return 3600; // 1 hour in seconds
-});
+}, 10, 1);
 
 add_filter('graphql_connection_max_query_amount', function($max, $source, $args, $context, $info) {
     // Increase limit only for the VariableProduct variations connection

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -26,6 +26,18 @@ if (!defined('ABSPATH')) {
  * Fixes issue: Product #136296 (Duct Temperature Transmitter) has 150 variations
  * but only first 100 were returned by GraphQL, causing missing "4-20mA" option.
  */
+/**
+ * Extend WPGraphQL JWT auth token expiry to 1 hour
+ *
+ * The plugin default is 300 seconds (5 minutes), which is far too short for
+ * normal browsing sessions. Tokens are silently refreshed by the Next.js
+ * /api/auth/me route using the 30-day refresh_token cookie, but a longer
+ * primary expiry gives a better fallback window.
+ */
+add_filter('graphql_jwt_auth_expire', function () {
+    return 3600; // 1 hour in seconds
+});
+
 add_filter('graphql_connection_max_query_amount', function($max, $source, $args, $context, $info) {
     // Increase limit only for the VariableProduct variations connection
     if (

--- a/web/src/app/api/auth/__tests__/me.test.ts
+++ b/web/src/app/api/auth/__tests__/me.test.ts
@@ -3,7 +3,9 @@
  *
  * Tests current user fetch from WordPress JWT token with coverage of:
  * - No auth cookie → 401
- * - Invalid/expired token → 401 + cookies cleared
+ * - Invalid/expired token, no refresh token → 401 + cookies cleared
+ * - Invalid/expired token, valid refresh token → silent refresh → 200
+ * - Silent refresh fails → 401 + cookies cleared
  * - Successful fetch: user shape, roles, customer group processing
  * - Customer group slugification (e.g. "END USER" → "end-user")
  * - Default customer group fallback when none present
@@ -16,15 +18,16 @@ import { GET } from '../me/route';
 import { NextRequest } from 'next/server';
 
 // ─── Hoisted mocks ────────────────────────────────────────────────────────────
-const { mockCookieGet, mockCookieDelete, mockCookies } = vi.hoisted(() => {
+const { mockCookieGet, mockCookieDelete, mockCookieSet, mockCookies } = vi.hoisted(() => {
   const mockCookieGet = vi.fn();
   const mockCookieDelete = vi.fn();
+  const mockCookieSet = vi.fn();
   const mockCookies = vi.fn(() => ({
     get: mockCookieGet,
     delete: mockCookieDelete,
-    set: vi.fn(),
+    set: mockCookieSet,
   }));
-  return { mockCookieGet, mockCookieDelete, mockCookies };
+  return { mockCookieGet, mockCookieDelete, mockCookieSet, mockCookies };
 });
 
 vi.mock('next/headers', () => ({
@@ -63,6 +66,18 @@ function makeViewerResponse(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeExpiredTokenResponse() {
+  return { data: { viewer: null }, errors: [{ message: 'Expired token' }] };
+}
+
+function makeRefreshSuccessResponse(authToken = 'new-auth-token') {
+  return { data: { refreshJwtAuthToken: { authToken } } };
+}
+
+function makeRefreshFailResponse() {
+  return { data: { refreshJwtAuthToken: null }, errors: [{ message: 'Invalid refresh token' }] };
+}
+
 describe('GET /api/auth/me', () => {
   const mockFetch = vi.fn();
   const originalFetch = global.fetch;
@@ -71,10 +86,11 @@ describe('GET /api/auth/me', () => {
     vi.clearAllMocks();
     global.fetch = mockFetch as unknown as typeof fetch;
 
-    // Default: auth cookie is present
-    mockCookieGet.mockImplementation((name: string) =>
-      name === 'auth_token' ? { value: 'valid-token' } : undefined,
-    );
+    // Default: auth cookie present, no refresh token
+    mockCookieGet.mockImplementation((name: string) => {
+      if (name === 'auth_token') return { value: 'valid-token' };
+      return undefined;
+    });
 
     // Default: WordPress returns a valid viewer
     mockFetch.mockResolvedValue({
@@ -104,15 +120,11 @@ describe('GET /api/auth/me', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  // ─── Token validation failure ────────────────────────────────────────────────
+  // ─── Token validation failure (no refresh token) ─────────────────────────────
 
-  it('returns 401 when WordPress returns errors (expired/invalid token)', async () => {
+  it('returns 401 when WordPress returns errors and no refresh token is available', async () => {
     mockFetch.mockResolvedValue({
-      json: () =>
-        Promise.resolve({
-          data: { viewer: null },
-          errors: [{ message: 'Expired token' }],
-        }),
+      json: () => Promise.resolve(makeExpiredTokenResponse()),
     });
 
     const res = await GET(makeRequest());
@@ -121,12 +133,86 @@ describe('GET /api/auth/me', () => {
     expect(body.user).toBeNull();
   });
 
-  it('clears both cookies when token is invalid', async () => {
+  it('clears both cookies when token is invalid and no refresh token exists', async () => {
     mockFetch.mockResolvedValue({
-      json: () => Promise.resolve({ data: { viewer: null }, errors: [{ message: 'Bad token' }] }),
+      json: () => Promise.resolve(makeExpiredTokenResponse()),
     });
 
     await GET(makeRequest());
+    expect(mockCookieDelete).toHaveBeenCalledWith('auth_token');
+    expect(mockCookieDelete).toHaveBeenCalledWith('refresh_token');
+  });
+
+  // ─── Silent refresh ───────────────────────────────────────────────────────────
+
+  it('silently refreshes and returns user when auth token is expired but refresh token is valid', async () => {
+    // auth_token present, refresh_token also present
+    mockCookieGet.mockImplementation((name: string) => {
+      if (name === 'auth_token') return { value: 'expired-token' };
+      if (name === 'refresh_token') return { value: 'valid-refresh-token' };
+      return undefined;
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeExpiredTokenResponse()) }) // viewer with expired token
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeRefreshSuccessResponse()) }) // refresh mutation
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeViewerResponse()) }); // viewer retry
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.user.email).toBe('test@bapi.com');
+  });
+
+  it('sets a new auth_token cookie after successful silent refresh', async () => {
+    mockCookieGet.mockImplementation((name: string) => {
+      if (name === 'auth_token') return { value: 'expired-token' };
+      if (name === 'refresh_token') return { value: 'valid-refresh-token' };
+      return undefined;
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeExpiredTokenResponse()) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeRefreshSuccessResponse('brand-new-token')) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeViewerResponse()) });
+
+    await GET(makeRequest());
+    expect(mockCookieSet).toHaveBeenCalledWith(
+      'auth_token',
+      'brand-new-token',
+      expect.objectContaining({ httpOnly: true }),
+    );
+  });
+
+  it('does not clear cookies when silent refresh succeeds', async () => {
+    mockCookieGet.mockImplementation((name: string) => {
+      if (name === 'auth_token') return { value: 'expired-token' };
+      if (name === 'refresh_token') return { value: 'valid-refresh-token' };
+      return undefined;
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeExpiredTokenResponse()) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeRefreshSuccessResponse()) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeViewerResponse()) });
+
+    await GET(makeRequest());
+    expect(mockCookieDelete).not.toHaveBeenCalled();
+  });
+
+  it('clears cookies and returns 401 when refresh token is also invalid', async () => {
+    mockCookieGet.mockImplementation((name: string) => {
+      if (name === 'auth_token') return { value: 'expired-token' };
+      if (name === 'refresh_token') return { value: 'expired-refresh-token' };
+      return undefined;
+    });
+
+    mockFetch
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeExpiredTokenResponse()) })
+      .mockResolvedValueOnce({ json: () => Promise.resolve(makeRefreshFailResponse()) });
+
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
     expect(mockCookieDelete).toHaveBeenCalledWith('auth_token');
     expect(mockCookieDelete).toHaveBeenCalledWith('refresh_token');
   });

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -83,7 +83,7 @@ export async function GET(request: NextRequest) {
     // Primary viewer fetch
     const { data, errors } = await fetchViewer(token);
 
-    if (!errors && data?.viewer) {
+    if (!errors?.length && data?.viewer) {
       return buildUserResponse(data.viewer);
     }
 
@@ -118,13 +118,14 @@ export async function GET(request: NextRequest) {
         });
 
         const { data: retryData, errors: retryErrors } = await fetchViewer(newAuthToken);
-        if (!retryErrors && retryData?.viewer) {
+        if (!retryErrors?.length && retryData?.viewer) {
           logger.debug('Silent token refresh succeeded');
           return buildUserResponse(retryData.viewer);
         }
+        logger.debug('Silent refresh: viewer retry failed after token refresh', { retryErrors });
+      } else {
+        logger.debug('Silent token refresh failed', { refreshErrors });
       }
-
-      logger.debug('Silent token refresh failed', { refreshErrors });
     }
 
     // Both tokens exhausted — clear cookies and require sign-in

--- a/web/src/app/api/auth/me/route.ts
+++ b/web/src/app/api/auth/me/route.ts
@@ -1,16 +1,75 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import logger from '@/lib/logger';
-import { GET_CURRENT_USER_QUERY, type GetCurrentUserResponse } from '@/lib/auth/queries';
+import {
+  GET_CURRENT_USER_QUERY,
+  REFRESH_TOKEN_MUTATION,
+  type GetCurrentUserResponse,
+  type RefreshTokenResponse,
+} from '@/lib/auth/queries';
 import { slugifyArray } from '@/lib/utils/slugify';
 
 const GRAPHQL_ENDPOINT = process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL || '';
+
+/**
+ * Build a NextResponse with the authenticated user shape from a viewer object.
+ */
+function buildUserResponse(viewer: NonNullable<GetCurrentUserResponse['viewer']>): NextResponse {
+  const roles = viewer.roles?.nodes?.map((role: { name: string }) => role.name) || [];
+
+  const customerInfo = viewer.customerInformation;
+  const rawCustomerGroups = [
+    ...(customerInfo?.customerGroup1 || []),
+    ...(customerInfo?.customerGroup2 || []),
+    ...(customerInfo?.customerGroup3 || []),
+  ]
+    .filter((group): group is string => typeof group === 'string')
+    .map((group) => group.trim())
+    .filter((group) => group.length > 0 && group.toUpperCase() !== 'NO ACCESS');
+
+  const slugifiedGroups = slugifyArray(rawCustomerGroups);
+  const finalCustomerGroups = slugifiedGroups.length > 0 ? slugifiedGroups : ['end-user'];
+
+  // NOTE: 2FA will be implemented in Phase 2
+  // Phase 1 uses standard JWT authentication only
+  return NextResponse.json({
+    user: {
+      id: String(viewer.databaseId),
+      email: viewer.email,
+      displayName: viewer.name,
+      username: viewer.username,
+      customerGroups: finalCustomerGroups,
+      roles,
+    },
+  });
+}
+
+/**
+ * Fetch the current viewer from WordPress using a JWT bearer token.
+ */
+async function fetchViewer(
+  token: string,
+): Promise<{ data: GetCurrentUserResponse; errors?: unknown[] }> {
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query: GET_CURRENT_USER_QUERY }),
+  });
+  return response.json();
+}
 
 /**
  * GET /api/auth/me
  *
  * Returns current authenticated user from WordPress JWT token.
  * Uses WPGraphQL JWT Authentication viewer query.
+ *
+ * Silent refresh: if the auth token is expired but a valid refresh token exists,
+ * the token is silently renewed and the viewer query is retried — no sign-in
+ * prompt for the user.
  */
 export async function GET(request: NextRequest) {
   try {
@@ -21,68 +80,57 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Not authenticated', user: null }, { status: 401 });
     }
 
-    // Query current user with GraphQL
-    const response = await fetch(GRAPHQL_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        query: GET_CURRENT_USER_QUERY,
-      }),
-    });
+    // Primary viewer fetch
+    const { data, errors } = await fetchViewer(token);
 
-    const { data, errors }: { data: GetCurrentUserResponse; errors?: any[] } =
-      await response.json();
-
-    if (errors || !data?.viewer) {
-      logger.debug('Token validation failed', { errors });
-
-      // Clear invalid token
-      cookieStore.delete('auth_token');
-      cookieStore.delete('refresh_token');
-
-      return NextResponse.json({ error: 'Invalid token', user: null }, { status: 401 });
+    if (!errors && data?.viewer) {
+      return buildUserResponse(data.viewer);
     }
 
-    const { viewer } = data;
+    // ── Silent refresh ──────────────────────────────────────────────────────
+    // Token is expired or invalid. Try the refresh token before giving up.
+    logger.debug('Auth token invalid — attempting silent refresh', { errors });
 
-    // Extract role names from the GraphQL response
-    const roles = viewer.roles?.nodes?.map((role: { name: string }) => role.name) || [];
+    const refreshToken = cookieStore.get('refresh_token')?.value;
+    if (refreshToken) {
+      const refreshResponse = await fetch(GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: REFRESH_TOKEN_MUTATION,
+          variables: { token: refreshToken },
+        }),
+      });
+      const {
+        data: refreshData,
+        errors: refreshErrors,
+      }: { data: RefreshTokenResponse; errors?: unknown[] } = await refreshResponse.json();
 
-    // Process customer groups from ACF fields (customerInformation.customerGroup1/2/3)
-    // Schema: These are LIST types (arrays of strings)
-    // Filter out null, empty strings, and "NO ACCESS" values
-    // Then slugify to match WordPress taxonomy slugs ("END USER" → "end-user")
-    const customerInfo = viewer.customerInformation;
-    const rawCustomerGroups = [
-      ...(customerInfo?.customerGroup1 || []),
-      ...(customerInfo?.customerGroup2 || []),
-      ...(customerInfo?.customerGroup3 || []),
-    ]
-      .filter((group): group is string => typeof group === 'string')
-      .map((group) => group.trim())
-      .filter((group) => group.length > 0 && group.toUpperCase() !== 'NO ACCESS');
+      const newAuthToken = refreshData?.refreshJwtAuthToken?.authToken;
+      if (!refreshErrors && newAuthToken) {
+        // Persist the new auth token and retry
+        cookieStore.set('auth_token', newAuthToken, {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'lax',
+          maxAge: 60 * 60 * 24 * 7, // 7 days
+          path: '/',
+        });
 
-    // Slugify groups to match taxonomy slugs ("END USER" → "end-user")
-    const slugifiedGroups = slugifyArray(rawCustomerGroups);
+        const { data: retryData, errors: retryErrors } = await fetchViewer(newAuthToken);
+        if (!retryErrors && retryData?.viewer) {
+          logger.debug('Silent token refresh succeeded');
+          return buildUserResponse(retryData.viewer);
+        }
+      }
 
-    // Default to 'end-user' if no valid groups (matches legacy WordPress behavior)
-    const finalCustomerGroups = slugifiedGroups.length > 0 ? slugifiedGroups : ['end-user'];
+      logger.debug('Silent token refresh failed', { refreshErrors });
+    }
 
-    // NOTE: 2FA will be implemented in Phase 2
-    // Phase 1 uses standard JWT authentication only
-    return NextResponse.json({
-      user: {
-        id: String(viewer.databaseId),
-        email: viewer.email,
-        displayName: viewer.name,
-        username: viewer.username,
-        customerGroups: finalCustomerGroups,
-        roles,
-      },
-    });
+    // Both tokens exhausted — clear cookies and require sign-in
+    cookieStore.delete('auth_token');
+    cookieStore.delete('refresh_token');
+    return NextResponse.json({ error: 'Invalid token', user: null }, { status: 401 });
   } catch (error) {
     logger.error('Auth check error', { error });
     return NextResponse.json({ error: 'Server error', user: null }, { status: 500 });


### PR DESCRIPTION
- Add graphql_jwt_auth_expire filter: 300s default → 3600s (1 hour)
- /api/auth/me now silently refreshes expired auth tokens using the 30-day refresh_token cookie before clearing cookies and returning 401
- Users stay logged in for up to 30 days without interruption; auth token rotates silently every hour
- Extract buildUserResponse() and fetchViewer() helpers to avoid duplicating viewer-processing logic in the retry path
- Add 4 new tests: silent refresh success, new cookie set, no-cookie- clear on success, and refresh-also-expired path



