### PR TITLE
fix: Toast accessibility, cap, deduplication, animation, action-dismiss

### DIFF
--- a/web/src/components/FavoriteButton.tsx
+++ b/web/src/components/FavoriteButton.tsx
@@ -108,7 +108,7 @@ export default function FavoriteButton({
 
         if (response.status === 409) {
           // Already favorited (e.g. added from another tab or session) — treat as success
-          showToast('success', 'Already Saved', `${productName} is already in your saved products.`, 3000, {
+          showToast('success', 'Already Saved', `${productName} is already in your saved products.`, undefined, {
             label: 'View Saved',
             onClick: () => { router.push(`/${locale}/account/favorites`); },
           });
@@ -121,7 +121,7 @@ export default function FavoriteButton({
           throw new Error('Failed to add to favorites');
         }
 
-        showToast('success', 'Saved to Favorites', `${productName} has been added to your saved products.`, 3000, {
+        showToast('success', 'Saved to Favorites', `${productName} has been added to your saved products.`, undefined, {
           label: 'View Saved',
           onClick: () => { router.push(`/${locale}/account/favorites`); },
         });

--- a/web/src/components/__tests__/FavoriteButton.test.tsx
+++ b/web/src/components/__tests__/FavoriteButton.test.tsx
@@ -225,7 +225,7 @@ describe('FavoriteButton', () => {
     await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
     await userEvent.click(screen.getByRole('button'));
     await waitFor(() =>
-      expect(mockShowToast).toHaveBeenCalledWith('success', 'Saved to Favorites', expect.any(String), 3000, expect.anything()),
+      expect(mockShowToast).toHaveBeenCalledWith('success', 'Saved to Favorites', expect.any(String), undefined, expect.anything()),
     );
   });
 

--- a/web/src/components/auth/SessionExpiryToast.tsx
+++ b/web/src/components/auth/SessionExpiryToast.tsx
@@ -43,7 +43,7 @@ export function SessionExpiryToast() {
         'warning',
         'Session Expired',
         'Your session has expired. Please sign in again to continue.',
-        8000,
+        undefined,
         { label: 'Sign In', onClick: () => { window.location.href = '/sign-in'; } }
       );
     }

--- a/web/src/components/layout/Header/components/RegionSelectorV2.tsx
+++ b/web/src/components/layout/Header/components/RegionSelectorV2.tsx
@@ -42,7 +42,7 @@ const RegionSelectorV2: React.FC = () => {
       const languageName = LANGUAGES[suggestedLanguage].nativeName;
       const message = getLanguageSuggestionMessage(regionCode, languageName);
 
-      showToast('info', 'Language Suggestion', message, 7000, {
+      showToast('info', 'Language Suggestion', message, undefined, {
         label: 'Switch',
         onClick: () => {
           schedulePendingToast({ type: 'success', title: 'Language Changed', message: `Switched to ${languageName}`, duration: 3000 });

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -65,9 +65,10 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       duration?: number,
       action?: ToastAction,
     ) => {
-      // Toasts with action buttons must not auto-dismiss — user needs time to act.
-      // Caller can override by passing an explicit duration.
-      const effectiveDuration = duration ?? (action ? 0 : 5000);
+      // Toasts with action buttons must never auto-dismiss — action presence
+      // takes precedence over any caller-supplied duration. This ensures the
+      // action button is always reachable (keyboard, pointer, screen reader).
+      const effectiveDuration = action ? 0 : (duration ?? 5000);
 
       setToasts((prev) => {
         // Deduplicate: ignore if identical type+title+message already visible

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { createContext, useContext, useState, useCallback, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
 import {
   XIcon,
   CheckCircleIcon,
@@ -21,48 +29,67 @@ export interface Toast {
   type: ToastType;
   title: string;
   message: string;
-  duration?: number;
+  duration: number;
   action?: ToastAction;
 }
 
 interface ToastContextType {
   toasts: Toast[];
-  showToast: (type: ToastType, title: string, message: string, duration?: number, action?: ToastAction) => void;
+  showToast: (
+    type: ToastType,
+    title: string,
+    message: string,
+    duration?: number,
+    action?: ToastAction,
+  ) => void;
   removeToast: (id: string) => void;
 }
 
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
+/** Maximum number of toasts visible simultaneously. Oldest is dropped when exceeded. */
+const MAX_TOASTS = 4;
+
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  // Declare removeToast BEFORE showToast to fix temporal dead zone error
   const removeToast = useCallback((id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
   const showToast = useCallback(
-    (type: ToastType, title: string, message: string, duration = 5000, action?: ToastAction) => {
-      const id = Math.random().toString(36).substring(2, 9);
-      const newToast: Toast = {
-        id,
-        type,
-        title,
-        message,
-        duration,
-        action,
-      };
+    (
+      type: ToastType,
+      title: string,
+      message: string,
+      duration?: number,
+      action?: ToastAction,
+    ) => {
+      // Toasts with action buttons must not auto-dismiss — user needs time to act.
+      // Caller can override by passing an explicit duration.
+      const effectiveDuration = duration ?? (action ? 0 : 5000);
 
-      setToasts((prev) => [...prev, newToast]);
+      setToasts((prev) => {
+        // Deduplicate: ignore if identical type+title+message already visible
+        if (prev.some((t) => t.type === type && t.title === title && t.message === message)) {
+          return prev;
+        }
 
-      // Auto-remove after duration
-      if (duration > 0) {
-        setTimeout(() => {
-          removeToast(id);
-        }, duration);
-      }
+        const newToast: Toast = {
+          id: Math.random().toString(36).substring(2, 9),
+          type,
+          title,
+          message,
+          duration: effectiveDuration,
+          action,
+        };
+
+        // Cap at MAX_TOASTS — drop the oldest when exceeded
+        const withNew = [...prev, newToast];
+        return withNew.length > MAX_TOASTS ? withNew.slice(withNew.length - MAX_TOASTS) : withNew;
+      });
     },
-    [removeToast] // Add removeToast to dependencies
+    [],
   );
 
   return (
@@ -106,6 +133,36 @@ interface ToastItemProps {
 }
 
 function ToastItem({ toast, onClose }: ToastItemProps) {
+  // Animate in: start invisible/translated, flip to visible on first paint
+  const [isVisible, setIsVisible] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Enter animation — triggers on next frame so the transition actually runs
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => setIsVisible(true));
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  // Animate out, then call onClose after the transition completes (300ms)
+  const handleClose = useCallback(() => {
+    setIsVisible(false);
+    closeTimerRef.current = setTimeout(() => onClose(toast.id), 300);
+  }, [onClose, toast.id]);
+
+  // Auto-dismiss timer (skipped when duration === 0)
+  useEffect(() => {
+    if (!toast.duration || toast.duration <= 0) return;
+    const timer = setTimeout(handleClose, toast.duration);
+    return () => clearTimeout(timer);
+  }, [toast.duration, handleClose]);
+
+  // Clean up pending close timer on unmount
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
   const icons = {
     success: CheckCircleIcon,
     error: AlertCircleIcon,
@@ -121,19 +178,25 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
   };
 
   const iconStyles = {
-    success: 'text-success-700', // Darker for better contrast on light background
+    success: 'text-success-700',
     error: 'text-error-700',
-    warning: 'text-warning-800', // Warning needs even darker due to yellow
+    warning: 'text-warning-800',
     info: 'text-info-700',
   };
+
+  // Only errors and warnings should interrupt screen readers immediately.
+  // Success and info use polite so they don't break the user's current reading flow.
+  const ariaLive = toast.type === 'error' || toast.type === 'warning' ? 'assertive' : 'polite';
 
   const Icon = icons[toast.type];
 
   return (
     <div
-      className={`pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg border shadow-lg ${styles[toast.type]}`}
+      className={`pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg border shadow-lg transition-all duration-300 ease-in-out ${styles[toast.type]} ${
+        isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'
+      }`}
       role="alert"
-      aria-live="assertive"
+      aria-live={ariaLive}
       aria-atomic="true"
     >
       <div className="p-4">
@@ -151,7 +214,7 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
                   className="rounded-md text-sm font-semibold underline underline-offset-2 opacity-90 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
                   onClick={() => {
                     toast.action!.onClick();
-                    onClose(toast.id);
+                    handleClose();
                   }}
                 >
                   {toast.action.label}
@@ -163,7 +226,7 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
             <button
               type="button"
               className="inline-flex rounded-md opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2"
-              onClick={() => onClose(toast.id)}
+              onClick={handleClose}
               aria-label="Close notification"
             >
               <XIcon className="h-5 w-5" aria-hidden="true" />

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -77,7 +77,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
         }
 
         const newToast: Toast = {
-          id: Math.random().toString(36).substring(2, 9),
+          id: crypto.randomUUID(),
           type,
           title,
           message,

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -136,6 +136,9 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
   // Animate in: start invisible/translated, flip to visible on first paint
   const [isVisible, setIsVisible] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Guard against re-entrancy: close button + auto-dismiss timer can both fire
+  // during the 300ms exit window; only the first call should schedule removal.
+  const isClosingRef = useRef(false);
 
   // Enter animation — triggers on next frame so the transition actually runs
   useEffect(() => {
@@ -143,8 +146,11 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
     return () => cancelAnimationFrame(frame);
   }, []);
 
-  // Animate out, then call onClose after the transition completes (300ms)
+  // Animate out, then call onClose after the transition completes (300ms).
+  // Re-entrancy guard prevents duplicate removal timers.
   const handleClose = useCallback(() => {
+    if (isClosingRef.current) return;
+    isClosingRef.current = true;
     setIsVisible(false);
     closeTimerRef.current = setTimeout(() => onClose(toast.id), 300);
   }, [onClose, toast.id]);
@@ -184,9 +190,13 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
     info: 'text-info-700',
   };
 
-  // Only errors and warnings should interrupt screen readers immediately.
-  // Success and info use polite so they don't break the user's current reading flow.
-  const ariaLive = toast.type === 'error' || toast.type === 'warning' ? 'assertive' : 'polite';
+  // Errors and warnings interrupt screen readers immediately (assertive + alert).
+  // Success and info use polite live regions (status) so they don't break reading flow.
+  // role="alert" has an implicit assertive live region; role="status" is implicitly polite.
+  // Setting both role and aria-live explicitly makes the contract clear to AT.
+  const isUrgent = toast.type === 'error' || toast.type === 'warning';
+  const role = isUrgent ? 'alert' : 'status';
+  const ariaLive = isUrgent ? 'assertive' : 'polite';
 
   const Icon = icons[toast.type];
 
@@ -195,7 +205,7 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
       className={`pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg border shadow-lg transition-all duration-300 ease-in-out ${styles[toast.type]} ${
         isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'
       }`}
-      role="alert"
+      role={role}
       aria-live={ariaLive}
       aria-atomic="true"
     >

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -128,6 +128,13 @@ function ToastContainer({ toasts, onClose }: ToastContainerProps) {
   );
 }
 
+/**
+ * Duration of the slide-out exit animation in milliseconds.
+ * Must match the Tailwind `duration-{n}` class on the toast element.
+ * Exported so tests can advance fake timers by exactly this value.
+ */
+export const EXIT_ANIMATION_MS = 300;
+
 interface ToastItemProps {
   toast: Toast;
   onClose: (id: string) => void;
@@ -138,7 +145,7 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
   const [isVisible, setIsVisible] = useState(false);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Guard against re-entrancy: close button + auto-dismiss timer can both fire
-  // during the 300ms exit window; only the first call should schedule removal.
+  // during the EXIT_ANIMATION_MS exit window; only the first call should schedule removal.
   const isClosingRef = useRef(false);
 
   // Enter animation — triggers on next frame so the transition actually runs
@@ -147,13 +154,13 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
     return () => cancelAnimationFrame(frame);
   }, []);
 
-  // Animate out, then call onClose after the transition completes (300ms).
+  // Animate out, then call onClose after the transition completes.
   // Re-entrancy guard prevents duplicate removal timers.
   const handleClose = useCallback(() => {
     if (isClosingRef.current) return;
     isClosingRef.current = true;
     setIsVisible(false);
-    closeTimerRef.current = setTimeout(() => onClose(toast.id), 300);
+    closeTimerRef.current = setTimeout(() => onClose(toast.id), EXIT_ANIMATION_MS);
   }, [onClose, toast.id]);
 
   // Auto-dismiss timer (skipped when duration === 0)
@@ -203,7 +210,7 @@ function ToastItem({ toast, onClose }: ToastItemProps) {
 
   return (
     <div
-      className={`pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg border shadow-lg transition-all duration-300 ease-in-out ${styles[toast.type]} ${
+      className={`pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg border shadow-lg transition-[transform,opacity] duration-300 ease-in-out ${styles[toast.type]} ${
         isVisible ? 'translate-x-0 opacity-100' : 'translate-x-full opacity-0'
       }`}
       role={role}

--- a/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/web/src/components/ui/__tests__/Toast.test.tsx
@@ -13,7 +13,7 @@
 import type React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
-import { ToastProvider, useToast, type ToastType } from '../Toast';
+import { ToastProvider, useToast, EXIT_ANIMATION_MS, type ToastType } from '../Toast';
 
 // Helper: renders a button that calls showToast when clicked
 function ToastTrigger({
@@ -194,9 +194,9 @@ describe('Toast', () => {
 
     expect(getToasts()).toHaveLength(1);
 
-    // Advance past duration + exit animation (300ms)
+    // Advance past duration + exit animation
     await act(async () => {
-      vi.advanceTimersByTime(3000 + 300);
+      vi.advanceTimersByTime(3000 + EXIT_ANIMATION_MS);
     });
 
     expect(getToasts()).toHaveLength(0);
@@ -215,7 +215,7 @@ describe('Toast', () => {
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Close notification' }));
-      vi.advanceTimersByTime(300); // exit animation
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS); // exit animation
     });
 
     expect(getToasts()).toHaveLength(0);
@@ -235,7 +235,7 @@ describe('Toast', () => {
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
-      vi.advanceTimersByTime(300);
+      vi.advanceTimersByTime(EXIT_ANIMATION_MS);
     });
 
     expect(mockAction).toHaveBeenCalledOnce();

--- a/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/web/src/components/ui/__tests__/Toast.test.tsx
@@ -164,6 +164,25 @@ describe('Toast', () => {
     expect(getToasts()).toHaveLength(1);
   });
 
+  it('does not auto-dismiss when action is provided even if duration is explicitly set', async () => {
+    // action takes precedence over any caller-provided duration
+    renderWithProvider(
+      <ToastTrigger duration={1000} action={{ label: 'Retry', onClick: vi.fn() }} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
+    });
+
+    expect(getToasts()).toHaveLength(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(getToasts()).toHaveLength(1);
+  });
+
   // ─── Auto-dismiss ─────────────────────────────────────────────────────────
 
   it('auto-dismisses after the specified duration when no action', async () => {

--- a/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/web/src/components/ui/__tests__/Toast.test.tsx
@@ -10,6 +10,7 @@
  * - Close button triggers animated removal
  */
 
+import type React from 'react';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import { ToastProvider, useToast, type ToastType } from '../Toast';
@@ -40,6 +41,11 @@ function renderWithProvider(ui: React.ReactElement) {
   return render(<ToastProvider>{ui}</ToastProvider>);
 }
 
+/** Query all visible toasts regardless of role (alert for error/warning, status for success/info). */
+function getToasts() {
+  return [...screen.queryAllByRole('alert'), ...screen.queryAllByRole('status')];
+}
+
 describe('Toast', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -65,8 +71,10 @@ describe('Toast', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
       });
 
-      const alert = screen.getByRole('alert');
-      expect(alert).toHaveAttribute('aria-live', expected);
+      // role matches live region: 'alert' for assertive (error/warning), 'status' for polite (success/info)
+      const expectedRole = expected === 'assertive' ? 'alert' : 'status';
+      const el = screen.getByRole(expectedRole);
+      expect(el).toHaveAttribute('aria-live', expected);
     },
   );
 
@@ -82,7 +90,7 @@ describe('Toast', () => {
       fireEvent.click(btn);
     });
 
-    expect(screen.getAllByRole('alert')).toHaveLength(1);
+    expect(getToasts()).toHaveLength(1);
   });
 
   it('adds a second toast when type differs', async () => {
@@ -102,7 +110,7 @@ describe('Toast', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Error' }));
     });
 
-    expect(screen.getAllByRole('alert')).toHaveLength(2);
+    expect(getToasts()).toHaveLength(2);
   });
 
   // ─── Toast cap ───────────────────────────────────────────────────────────
@@ -128,8 +136,7 @@ describe('Toast', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Show 5' }));
     });
 
-    const alerts = screen.getAllByRole('alert');
-    expect(alerts).toHaveLength(4);
+    expect(getToasts()).toHaveLength(4);
     // Oldest (Toast 1) should be gone; newest (Toast 5) should be present
     expect(screen.queryByText('Message 1')).toBeNull();
     expect(screen.getByText('Message 5')).toBeTruthy();
@@ -146,7 +153,7 @@ describe('Toast', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
     });
 
-    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(getToasts()).toHaveLength(1);
 
     // Advance well past default 5000ms
     await act(async () => {
@@ -154,7 +161,7 @@ describe('Toast', () => {
     });
 
     // Toast should still be visible (not auto-dismissed)
-    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(getToasts()).toHaveLength(1);
   });
 
   // ─── Auto-dismiss ─────────────────────────────────────────────────────────
@@ -166,14 +173,14 @@ describe('Toast', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
     });
 
-    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(getToasts()).toHaveLength(1);
 
     // Advance past duration + exit animation (300ms)
     await act(async () => {
       vi.advanceTimersByTime(3000 + 300);
     });
 
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(getToasts()).toHaveLength(0);
   });
 
   // ─── Close button ─────────────────────────────────────────────────────────
@@ -185,14 +192,14 @@ describe('Toast', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
     });
 
-    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(getToasts()).toHaveLength(1);
 
     await act(async () => {
       fireEvent.click(screen.getByRole('button', { name: 'Close notification' }));
       vi.advanceTimersByTime(300); // exit animation
     });
 
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(getToasts()).toHaveLength(0);
   });
 
   // ─── Action button ────────────────────────────────────────────────────────
@@ -213,6 +220,6 @@ describe('Toast', () => {
     });
 
     expect(mockAction).toHaveBeenCalledOnce();
-    expect(screen.queryByRole('alert')).toBeNull();
+    expect(getToasts()).toHaveLength(0);
   });
 });

--- a/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/web/src/components/ui/__tests__/Toast.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Toast Component Tests
+ *
+ * Covers:
+ * - aria-live values by type (polite for success/info, assertive for error/warning)
+ * - Deduplication (identical type+title+message is not added twice)
+ * - Max 4 toasts — oldest dropped when cap is exceeded
+ * - Action presence forces duration=0 (no auto-dismiss) by default
+ * - Auto-dismiss fires after duration when no action
+ * - Close button triggers animated removal
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { ToastProvider, useToast, type ToastType } from '../Toast';
+
+// Helper: renders a button that calls showToast when clicked
+function ToastTrigger({
+  type = 'success',
+  title = 'Title',
+  message = 'Message',
+  duration,
+  action,
+}: {
+  type?: ToastType;
+  title?: string;
+  message?: string;
+  duration?: number;
+  action?: { label: string; onClick: () => void };
+}) {
+  const { showToast } = useToast();
+  return (
+    <button onClick={() => showToast(type, title, message, duration, action)}>
+      Show Toast
+    </button>
+  );
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>);
+}
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ─── aria-live ────────────────────────────────────────────────────────────
+
+  it.each([
+    ['success', 'polite'],
+    ['info', 'polite'],
+    ['error', 'assertive'],
+    ['warning', 'assertive'],
+  ] as [ToastType, string][])(
+    '%s toast has aria-live="%s"',
+    async (type, expected) => {
+      renderWithProvider(<ToastTrigger type={type} />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
+      });
+
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveAttribute('aria-live', expected);
+    },
+  );
+
+  // ─── Deduplication ───────────────────────────────────────────────────────
+
+  it('does not add a duplicate toast with the same type, title, and message', async () => {
+    renderWithProvider(<ToastTrigger />);
+    const btn = screen.getByRole('button', { name: 'Show Toast' });
+
+    await act(async () => {
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+    });
+
+    expect(screen.getAllByRole('alert')).toHaveLength(1);
+  });
+
+  it('adds a second toast when type differs', async () => {
+    function TwoToasts() {
+      const { showToast } = useToast();
+      return (
+        <>
+          <button onClick={() => showToast('success', 'Title', 'Message')}>Success</button>
+          <button onClick={() => showToast('error', 'Title', 'Message')}>Error</button>
+        </>
+      );
+    }
+    render(<ToastProvider><TwoToasts /></ToastProvider>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Success' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Error' }));
+    });
+
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+  });
+
+  // ─── Toast cap ───────────────────────────────────────────────────────────
+
+  it('caps at 4 toasts and drops the oldest when a 5th is added', async () => {
+    function ManyToasts() {
+      const { showToast } = useToast();
+      return (
+        <button
+          onClick={() => {
+            for (let i = 1; i <= 5; i++) {
+              showToast('info', `Toast ${i}`, `Message ${i}`);
+            }
+          }}
+        >
+          Show 5
+        </button>
+      );
+    }
+    render(<ToastProvider><ManyToasts /></ToastProvider>);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show 5' }));
+    });
+
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts).toHaveLength(4);
+    // Oldest (Toast 1) should be gone; newest (Toast 5) should be present
+    expect(screen.queryByText('Message 1')).toBeNull();
+    expect(screen.getByText('Message 5')).toBeTruthy();
+  });
+
+  // ─── Action disables auto-dismiss ────────────────────────────────────────
+
+  it('does not auto-dismiss when an action is provided and no explicit duration', async () => {
+    renderWithProvider(
+      <ToastTrigger action={{ label: 'Retry', onClick: vi.fn() }} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
+    });
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+
+    // Advance well past default 5000ms
+    await act(async () => {
+      vi.advanceTimersByTime(10000);
+    });
+
+    // Toast should still be visible (not auto-dismissed)
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+
+  // ─── Auto-dismiss ─────────────────────────────────────────────────────────
+
+  it('auto-dismisses after the specified duration when no action', async () => {
+    renderWithProvider(<ToastTrigger duration={3000} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
+    });
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+
+    // Advance past duration + exit animation (300ms)
+    await act(async () => {
+      vi.advanceTimersByTime(3000 + 300);
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  // ─── Close button ─────────────────────────────────────────────────────────
+
+  it('removes toast when close button is clicked (after exit animation)', async () => {
+    renderWithProvider(<ToastTrigger duration={0} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
+    });
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Close notification' }));
+      vi.advanceTimersByTime(300); // exit animation
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  // ─── Action button ────────────────────────────────────────────────────────
+
+  it('calls action.onClick and closes the toast when action button is clicked', async () => {
+    const mockAction = vi.fn();
+    renderWithProvider(
+      <ToastTrigger duration={0} action={{ label: 'Retry', onClick: mockAction }} />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Show Toast' }));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(mockAction).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});


### PR DESCRIPTION
1. aria-live by severity: success/info use "polite" (non-interrupting), error/warning keep "assertive" (immediate screen reader interrupt)
2. Max 4 toasts: oldest is dropped when the cap is exceeded
3. Deduplication: identical type+title+message is ignored
4. Action presence forces duration=0: toasts with action buttons never auto-dismiss — user must explicitly click or close
5. Slide-in/fade-out animation: enter via translate-x + opacity transition, exit animates out 300ms before removal from DOM Timer and animation lifecycle self-contained in ToastItem
6. Tests: 11 new tests covering all five behaviors


