### PR TITLE
fix: branded 404 pages, restore ProductDetailClient tests, fix applic…

### DIFF
--- a/web/src/app/[locale]/applications/[category]/[subcategory]/page.tsx
+++ b/web/src/app/[locale]/applications/[category]/[subcategory]/page.tsx
@@ -7,7 +7,7 @@ import {
   getWordPressCategoriesForApplication,
   getApplicationBreadcrumbs,
 } from '@/lib/navigation/applicationCategories';
-import { getProducts, getProductPrice } from '@/lib/graphql';
+import { getProductsByCategory, getProductPrice } from '@/lib/graphql';
 
 // Force dynamic rendering (don't pre-render at build time)
 export const dynamic = 'force-dynamic';
@@ -42,10 +42,16 @@ export default async function ApplicationSubcategoryPage({
   // Get WordPress categories to fetch products from
   const wpCategories = getWordPressCategoriesForApplication(categorySlug, subcategorySlug);
 
-  // Fetch products from WordPress
-  // Note: We're using category slugs. The GraphQL query may need adjustment
-  // to support filtering by multiple category slugs.
-  const data = await getProducts(50); // TODO: Filter by wpCategories
+  // Fetch products from WordPress — use the first mapped category slug.
+  // wpCategories may list several slugs for broad application areas; the
+  // primary slug covers the core product set for this subcategory.
+  // Full multi-category merging is tracked for Phase 2 refinement.
+  const primaryCategory = wpCategories[0];
+  if (!primaryCategory) {
+    notFound();
+  }
+
+  const data = await getProductsByCategory(primaryCategory, 50);
   const products = data.products?.nodes || [];
 
   // Get breadcrumbs
@@ -98,17 +104,6 @@ export default async function ApplicationSubcategoryPage({
         <div className="mb-8 flex items-center justify-between">
           <h2 className="text-3xl font-bold text-neutral-900">Products for {subcategory.name}</h2>
           <div className="text-neutral-700">{products.length} products</div>
-        </div>
-
-        {/* WordPress Categories Info (temporary - for debugging) */}
-        <div className="mb-8 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
-          <p className="text-sm text-neutral-700">
-            <span className="font-medium">Fetching from WordPress categories:</span>{' '}
-            {wpCategories.join(', ')}
-          </p>
-          <p className="mt-1 text-xs text-neutral-700">
-            (This is temporary debug info - will be removed in production)
-          </p>
         </div>
 
         {products.length === 0 ? (

--- a/web/src/app/[locale]/not-found.tsx
+++ b/web/src/app/[locale]/not-found.tsx
@@ -1,0 +1,58 @@
+import { Link } from '@/lib/navigation';
+
+/**
+ * Locale-scoped 404 page — rendered when notFound() is called from any route
+ * under [locale] (product pages, category pages, application pages, etc.).
+ *
+ * Inherits locale from the parent [locale]/layout.tsx via NextIntlClientProvider,
+ * so Link uses locale-aware hrefs automatically.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-6 py-24">
+      <div className="max-w-md text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary-50">
+          <svg
+            className="h-8 w-8 text-primary-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+
+        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-primary-600">
+          404
+        </p>
+        <h1 className="mb-3 text-2xl font-bold text-neutral-900">Page not found</h1>
+
+        <p className="mb-8 text-base text-neutral-600">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved. Check the URL or
+          browse our products.
+        </p>
+
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Link
+            href="/"
+            className="rounded-lg bg-primary-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-4 focus:ring-primary-500/50"
+          >
+            Go to homepage
+          </Link>
+          <Link
+            href="/products"
+            className="rounded-lg border border-neutral-300 bg-white px-6 py-3 font-semibold text-neutral-900 transition-colors hover:border-primary-500 hover:bg-primary-50 focus:outline-none focus:ring-4 focus:ring-primary-500/50"
+          >
+            Browse products
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link';
+
+/**
+ * Root 404 page - shown when no locale-aware route matches.
+ * Handles edge cases like bots hitting non-existent routes before
+ * locale middleware can intercept.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 px-6">
+      <div className="max-w-md text-center">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-primary-50">
+          <svg
+            className="h-8 w-8 text-primary-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9.172 16.172a4 4 0 015.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+
+        <p className="mb-2 text-sm font-semibold uppercase tracking-widest text-primary-600">
+          404
+        </p>
+        <h1 className="mb-3 text-2xl font-bold text-neutral-900">Page not found</h1>
+
+        <p className="mb-8 text-base text-neutral-600">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+
+        <div className="flex flex-col justify-center gap-3 sm:flex-row">
+          <Link
+            href="/"
+            className="rounded-lg bg-primary-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-4 focus:ring-primary-500/50"
+          >
+            Go to homepage
+          </Link>
+          <Link
+            href="/products"
+            className="rounded-lg border border-neutral-300 bg-white px-6 py-3 font-semibold text-neutral-900 transition-colors hover:border-primary-500 hover:bg-primary-50 focus:outline-none focus:ring-4 focus:ring-primary-500/50"
+          >
+            Browse products
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/products/__tests__/ProductDetailClient.test.tsx
+++ b/web/src/components/products/__tests__/ProductDetailClient.test.tsx
@@ -212,10 +212,7 @@ describe('ProductDetailClient', () => {
   });
 
   describe('Cart interaction', () => {
-    // TODO: Fix this test - variation state updates need investigation
-    // The enterprise VariationSelector correctly identifies variations
-    // but the parent component state update timing needs to be handled properly
-    it.skip('adds correct variation to cart on Add to Cart', async () => {
+    it('adds correct variation to cart on Add to Cart', async () => {
       const addItemMock = vi.fn();
       const openCartMock = vi.fn();
       const mockUseCart = () => ({
@@ -271,9 +268,7 @@ describe('ProductDetailClient', () => {
 });
 
 describe('Keyboard navigation and robustness', () => {
-  // TODO: Update test for new ProductDetailClient structure with ProductHero + ProductVariationSelector
-  // The new component uses ProductVariationSelector which renders differently
-  it.skip('allows tabbing to all interactive elements', async () => {
+  it('allows tabbing to all interactive elements', async () => {
     renderProductDetail();
 
     // For variable products, select a variation first to show Add to Cart button
@@ -349,10 +344,7 @@ describe('Accessibility', () => {
     expect(screen.getByRole('button', { name: /Blue/i })).toBeInTheDocument();
   });
 
-  // TODO: Update test for new ProductDetailClient structure
-  // Add to Cart now renders in ProductVariationSelector for variable products
-  // and in a separate section for simple products
-  it.skip('Add to Cart button is accessible', async () => {
+  it('Add to Cart button is accessible', async () => {
     renderProductDetail();
 
     // For variable products, must select a variation first


### PR DESCRIPTION
Action 6 - Add not-found.tsx pages
- web/src/app/not-found.tsx: Root-level branded 404 for pre-locale routes and bots
- web/src/app/[locale]/not-found.tsx: Locale-scoped 404 using Link from @/lib/navigation for locale-aware hrefs; rendered by any notFound() call under the [locale] segment

Action 7 - Restore ProductDetailClient skipped tests
- Removed it.skip from 3 tests that had stale TODO comments
- Tests cover: cart variation add (correct variationId/name), keyboard tab order (radio groups + color swatches + Add to Cart), Add to Cart accessibility
- All 3 pass with the current ProductVariationSelector + VariationSelector arch
- Suite: 2384 passed, 16 skipped (+3 restored from before)

Action 8 - Fix applications subcategory product filter TODO
- Replace getProducts(50) with getProductsByCategory(primaryCategory, 50) using the first wpCategories slug defined in applicationCategories config
- Remove debug info block that was marked temporary in the source code
- Add notFound() guard when wpCategories is empty

