### PR TITLE
chore: pre-launch risk reduction (Actions 9, 10, 11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,41 @@ on:
     branches: [ main ]
 
 jobs:
+  # ── MU-plugin sync guard ───────────────────────────────────────────────────
+  # Fails the build when bapi-graphql-fixes.php at the repo root diverges from
+  # the copy deployed inside cms/wp-content/mu-plugins/. Zero-cost safety net
+  # that eliminates the risk of forgetting to sync changes manually.
+  mu-plugin-sync:
+    name: "MU-plugin: root == cms copy"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Diff bapi-graphql-fixes.php
+        run: |
+          ROOT_FILE="bapi-graphql-fixes.php"
+          MU_FILE="cms/wp-content/mu-plugins/bapi-graphql-fixes.php"
+
+          if [ ! -f "$ROOT_FILE" ]; then
+            echo "ERROR: $ROOT_FILE not found in repo root"
+            exit 1
+          fi
+
+          if [ ! -f "$MU_FILE" ]; then
+            echo "ERROR: $MU_FILE not found — create it or update the path"
+            exit 1
+          fi
+
+          if ! diff --unified "$ROOT_FILE" "$MU_FILE"; then
+            echo ""
+            echo "ERROR: $ROOT_FILE and $MU_FILE have diverged."
+            echo "Copy the updated version to both locations and commit."
+            exit 1
+          fi
+
+          echo "OK: both copies of bapi-graphql-fixes.php are identical."
+
   web-ci:
     name: "Web: sanity, test, build"
     runs-on: ubuntu-latest
@@ -109,9 +144,6 @@ jobs:
       #     retention-days: 7
 
       - name: Build
-        env:
-          NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
-          CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
         run: pnpm run build
 
   # ── E2E smoke suite ────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           if ! diff --unified "$ROOT_FILE" "$MU_FILE"; then
             echo ""
             echo "ERROR: $ROOT_FILE and $MU_FILE have diverged."
-            echo "Copy the updated version to both locations and commit."
+            echo "Edit the root copy ($ROOT_FILE), then run:"
+            echo "  cp $ROOT_FILE $MU_FILE"
+            echo "and commit both files together."
             exit 1
           fi
 

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -77,22 +77,24 @@ jobs:
           fi
           pnpm exec playwright test \
             --project=chromium \
+            --reporter=blob \
             --shard=${{ matrix.shard }}/${{ matrix.total }}
 
-      - name: Upload Playwright report (shard ${{ matrix.shard }})
+      - name: Upload blob report (shard ${{ matrix.shard }})
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-nightly-shard-${{ matrix.shard }}-${{ github.run_id }}
-          path: web/playwright-report/
-          retention-days: 14
+          name: playwright-nightly-blob-${{ matrix.shard }}-${{ github.run_id }}
+          path: web/blob-report/
+          retention-days: 1
           if-no-files-found: ignore
 
-  # ── Merge shard blobs into a single report ─────────────────────────────────
-  # Runs after all shards complete. Uploads a combined HTML report and opens
-  # a GitHub issue when any shard fails.
+  # ── Merge shard blob reports into a single HTML report ────────────────────
+  # Runs after all shards complete regardless of pass/fail.
+  # Uses `playwright merge-reports` (requires blob reporter in shard steps).
+  # Opens a GitHub issue when any shard fails.
   e2e-nightly-report:
-    name: "E2E nightly — report & triage"
+    name: "E2E nightly — merge reports & triage"
     runs-on: ubuntu-latest
     needs: e2e-nightly
     if: always()
@@ -101,12 +103,46 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download all shard reports
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile
+        working-directory: web
+
+      - name: Download all shard blob reports
         uses: actions/download-artifact@v4
         with:
-          pattern: playwright-nightly-shard-*-${{ github.run_id }}
-          path: all-reports/
+          pattern: playwright-nightly-blob-*-${{ github.run_id }}
+          path: web/all-blob-reports/
           merge-multiple: true
+
+      - name: Merge blob reports into HTML
+        working-directory: web
+        run: |
+          pnpm exec playwright merge-reports \
+            --reporter html \
+            ./all-blob-reports
+
+      - name: Upload merged HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-nightly-report-${{ github.run_id }}
+          path: web/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore
 
       - name: Open GitHub issue on any shard failure
         if: ${{ needs.e2e-nightly.result == 'failure' }}
@@ -126,7 +162,8 @@ jobs:
                 `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 `- **Commit:** ${context.sha}`,
                 '',
-                'Download individual shard artifacts for screenshots and traces.',
+                'Download the merged HTML report artifact for screenshots and traces:',
+                `\`playwright-nightly-report-${context.runId}\``,
               ].join('\n'),
-              labels: ['bug', 'e2e'],
+              labels: ['bug'],
             });

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -10,6 +10,10 @@ on:
     - cron: '0 2 * * *'   # 02:00 UTC nightly
   workflow_dispatch:        # Allow manual trigger for ad-hoc runs
 
+permissions:
+  contents: read
+  issues: write   # Required for the failure triage step that opens GitHub issues
+
 jobs:
   e2e-nightly:
     name: "E2E nightly (shard ${{ matrix.shard }}/${{ matrix.total }})"
@@ -71,8 +75,8 @@ jobs:
           E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
           E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
         run: |
-          if [ -z "$PLAYWRIGHT_BASE_URL" ]; then
-            echo "PREVIEW_INTEGRATION_URL not configured — skipping nightly E2E run"
+          if [ -z "$PLAYWRIGHT_BASE_URL" ] || [ -z "$E2E_USERNAME" ] || [ -z "$E2E_PASSWORD" ]; then
+            echo "Required secrets not fully configured (PREVIEW_INTEGRATION_URL, E2E_USERNAME, E2E_PASSWORD) — skipping nightly E2E run"
             exit 0
           fi
           pnpm exec playwright test \
@@ -122,6 +126,7 @@ jobs:
         working-directory: web
 
       - name: Download all shard blob reports
+        id: download-blobs
         uses: actions/download-artifact@v4
         with:
           pattern: playwright-nightly-blob-*-${{ github.run_id }}
@@ -129,8 +134,15 @@ jobs:
           merge-multiple: true
 
       - name: Merge blob reports into HTML
+        # Skip when no blobs were produced (e.g. all shards gracefully skipped
+        # because required secrets were absent). The download step still succeeds
+        # in that case but leaves the target directory empty.
         working-directory: web
         run: |
+          if [ -z "$(ls -A all-blob-reports 2>/dev/null)" ]; then
+            echo "No blob reports found — shards were skipped, nothing to merge"
+            exit 0
+          fi
           pnpm exec playwright merge-reports \
             --reporter html \
             ./all-blob-reports

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,132 @@
+name: E2E Nightly
+
+# Runs every night at 02:00 UTC against staging.
+# Covers the full spec suite (all 21 files), parallelised across 4 shards.
+# Non-blocking on PRs — this is a canary for regressions, not a merge gate.
+# Requires secrets: PREVIEW_INTEGRATION_URL, E2E_USERNAME, E2E_PASSWORD.
+
+on:
+  schedule:
+    - cron: '0 2 * * *'   # 02:00 UTC nightly
+  workflow_dispatch:        # Allow manual trigger for ad-hoc runs
+
+jobs:
+  e2e-nightly:
+    name: "E2E nightly (shard ${{ matrix.shard }}/${{ matrix.total }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false      # All shards run even if one fails
+      matrix:
+        shard: [1, 2, 3, 4]
+        total: [4]
+
+    defaults:
+      run:
+        working-directory: web
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      - name: Install dependencies
+        env:
+          HUSKY: 0
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright Chromium
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('web/pnpm-lock.yaml') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Playwright Chromium (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Run E2E suite (shard ${{ matrix.shard }}/${{ matrix.total }})
+        env:
+          CI: true
+          PLAYWRIGHT_BASE_URL: ${{ secrets.PREVIEW_INTEGRATION_URL }}
+          E2E_USERNAME: ${{ secrets.E2E_USERNAME }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+        run: |
+          if [ -z "$PLAYWRIGHT_BASE_URL" ]; then
+            echo "PREVIEW_INTEGRATION_URL not configured — skipping nightly E2E run"
+            exit 0
+          fi
+          pnpm exec playwright test \
+            --project=chromium \
+            --shard=${{ matrix.shard }}/${{ matrix.total }}
+
+      - name: Upload Playwright report (shard ${{ matrix.shard }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-nightly-shard-${{ matrix.shard }}-${{ github.run_id }}
+          path: web/playwright-report/
+          retention-days: 14
+          if-no-files-found: ignore
+
+  # ── Merge shard blobs into a single report ─────────────────────────────────
+  # Runs after all shards complete. Uploads a combined HTML report and opens
+  # a GitHub issue when any shard fails.
+  e2e-nightly-report:
+    name: "E2E nightly — report & triage"
+    runs-on: ubuntu-latest
+    needs: e2e-nightly
+    if: always()
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all shard reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: playwright-nightly-shard-*-${{ github.run_id }}
+          path: all-reports/
+          merge-multiple: true
+
+      - name: Open GitHub issue on any shard failure
+        if: ${{ needs.e2e-nightly.result == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `CI: Nightly E2E suite failed (${new Date().toISOString().slice(0,10)})`,
+              body: [
+                '## Nightly E2E Failure',
+                '',
+                'One or more shards of the nightly Playwright suite failed against staging.',
+                '',
+                `- **Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+                `- **Commit:** ${context.sha}`,
+                '',
+                'Download individual shard artifacts for screenshots and traces.',
+              ].join('\n'),
+              labels: ['bug', 'e2e'],
+            });

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -9,8 +9,9 @@
  * cms/wp-content/mu-plugins/bapi-graphql-fixes.php
  *
  * DUAL-FILE PATTERN: The repo root copy (bapi-graphql-fixes.php) is the development
- * source of truth. This CMS copy is the deploy artifact kept in sync manually.
- * Always edit the root copy and SCP it to Kinsta staging; never edit this file independently.
+ * source of truth. The CMS copy (cms/wp-content/mu-plugins/bapi-graphql-fixes.php) is
+ * the deploy artifact kept in sync manually. Always edit the root copy and SCP it to
+ * Kinsta staging; never edit the CMS copy independently.
  */
 
 if (!defined('ABSPATH')) {

--- a/web/src/app/[locale]/(public)/layout.tsx
+++ b/web/src/app/[locale]/(public)/layout.tsx
@@ -2,7 +2,7 @@
  * Public layout (no authentication required)
  *
  * This layout is used for public pages (homepage, products) that don't require
- * authentication. By removing ClerkProvider, these pages can be statically
+ * authentication. These pages are statically
  * generated and cached by CDN, dramatically improving performance.
  *
  * Note: This is a route group layout that nests INSIDE the root layout.

--- a/web/src/app/[locale]/account/settings/[[...rest]]/page.tsx
+++ b/web/src/app/[locale]/account/settings/[[...rest]]/page.tsx
@@ -41,7 +41,7 @@ export default async function SettingsPage({ params }: SettingsPageProps) {
       <section className="w-full py-12">
         <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
           <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-sm">
-            {/* Clerk UserProfile Component (dynamically loaded) */}
+            {/* User Profile Component (dynamically loaded) */}
             <UserProfileClient />
           </div>
 

--- a/web/src/lib/graphql/queries/customer-orders.ts
+++ b/web/src/lib/graphql/queries/customer-orders.ts
@@ -2,7 +2,7 @@ import { gql } from 'graphql-request';
 
 /**
  * GraphQL queries for fetching WooCommerce customer orders
- * Uses WordPress customer ID from user session metadata
+ * Accepts $customerId (the WordPress customer database ID), supplied by the caller from the authenticated session
  */
 
 export const GET_CUSTOMER_ORDERS = gql`

--- a/web/src/lib/graphql/queries/customer-orders.ts
+++ b/web/src/lib/graphql/queries/customer-orders.ts
@@ -2,7 +2,7 @@ import { gql } from 'graphql-request';
 
 /**
  * GraphQL queries for fetching WooCommerce customer orders
- * Uses WordPress customer ID linked in Clerk metadata
+ * Uses WordPress customer ID from user session metadata
  */
 
 export const GET_CUSTOMER_ORDERS = gql`

--- a/web/src/lib/mock-user-data.ts
+++ b/web/src/lib/mock-user-data.ts
@@ -51,7 +51,7 @@ export interface MockUserProfile {
 }
 
 /**
- * Mock user data - add your team members' Clerk user IDs here
+ * Mock user data - add your team members' WordPress user IDs here
  */
 export const MOCK_USER_DATA: Record<string, MockUserProfile> = {
   // BAPI Test Customer
@@ -162,7 +162,7 @@ export const MOCK_USER_DATA: Record<string, MockUserProfile> = {
   },
 
   // Add more test users here
-  // 'user_clerk_id_2': { ... },
+  // '<wordpress-user-id>': { ... },
 };
 
 /**

--- a/web/src/lib/mock-user-data.ts
+++ b/web/src/lib/mock-user-data.ts
@@ -4,7 +4,7 @@
  */
 
 export interface MockUserProfile {
-  userId: string; // Clerk user ID
+  userId: string; // WordPress user ID
   companyName: string;
   accountNumber: string;
   billingAddress: {


### PR DESCRIPTION
Action 9 — E2E Nightly CI
- Add .github/workflows/e2e-nightly.yml: full 21-spec Playwright suite runs nightly at 02:00 UTC, parallelised across 4 shards with --shard
- Non-blocking on PRs; opens a GitHub issue automatically on failure
- Gracefully skips when PREVIEW_INTEGRATION_URL secret is absent

Action 10 — Remove Clerk References
- ci.yml: drop NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY and CLERK_SECRET_KEY from the Build step (auth is WordPress JWT, not Clerk)
- web/.env.local.example: removed Clerk section (file is gitignored; cleaned locally to avoid confusing new devs)
- Stale Clerk comments purged from:
  - web/src/lib/graphql/queries/customer-orders.ts
  - web/src/lib/mock-user-data.ts
  - web/src/app/[locale]/account/settings/[[...rest]]/page.tsx
  - web/src/app/[locale]/(public)/layout.tsx

Action 11 — MU-Plugin Sync Guard
- ci.yml: new mu-plugin-sync job diffs bapi-graphql-fixes.php (root) against cms/wp-content/mu-plugins/bapi-graphql-fixes.php on every push and PR; fails the build if the two copies diverge
- cms/wp-content/mu-plugins/bapi-graphql-fixes.php: synced from root source of truth (comment wording had drifted)

