### PR TITLE
feat: GraphQL complexity monitoring + Stripe production runbook

### DIFF
--- a/bapi-graphql-fixes.php
+++ b/bapi-graphql-fixes.php
@@ -54,6 +54,42 @@ add_filter('graphql_connection_max_query_amount', function($max, $source, $args,
 }, 10, 5);
 
 // ---------------------------------------------------------------------------
+// GraphQL Query Complexity Monitoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Log high-complexity GraphQL queries to PHP error log.
+ *
+ * WPGraphQL Smart Cache sets the X-GraphQL-Complexity response header and
+ * blocks queries that exceed the configured max (currently 2000). This hook
+ * fires before the limit check so we can log anything approaching the ceiling.
+ *
+ * Alert threshold mirrors the Next.js frontend: 1500 (75% of max 2000).
+ */
+add_filter('graphql_request_results', function ($response, $schema, $operation, $variables, $query) {
+    $complexity_threshold = 1500;
+
+    // WPGraphQL Smart Cache exposes per-request complexity via this constant.
+    // It may not be set if the Smart Cache plugin is inactive.
+    if (!defined('GRAPHQL_REQUEST_COMPLEXITY')) {
+        return $response;
+    }
+
+    $complexity = (int) GRAPHQL_REQUEST_COMPLEXITY;
+
+    if ($complexity >= $complexity_threshold) {
+        error_log(sprintf(
+            '[BAPI GraphQL] High complexity query detected: %d (threshold: %d). Operation: %s',
+            $complexity,
+            $complexity_threshold,
+            $operation ?: 'unnamed'
+        ));
+    }
+
+    return $response;
+}, 10, 5);
+
+// ---------------------------------------------------------------------------
 // BAPI Favorites — stored as JSON in WordPress user meta (bapi_favorites)
 // ---------------------------------------------------------------------------
 

--- a/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
+++ b/cms/wp-content/mu-plugins/bapi-graphql-fixes.php
@@ -54,6 +54,42 @@ add_filter('graphql_connection_max_query_amount', function($max, $source, $args,
 }, 10, 5);
 
 // ---------------------------------------------------------------------------
+// GraphQL Query Complexity Monitoring
+// ---------------------------------------------------------------------------
+
+/**
+ * Log high-complexity GraphQL queries to PHP error log.
+ *
+ * WPGraphQL Smart Cache sets the X-GraphQL-Complexity response header and
+ * blocks queries that exceed the configured max (currently 2000). This hook
+ * fires before the limit check so we can log anything approaching the ceiling.
+ *
+ * Alert threshold mirrors the Next.js frontend: 1500 (75% of max 2000).
+ */
+add_filter('graphql_request_results', function ($response, $schema, $operation, $variables, $query) {
+    $complexity_threshold = 1500;
+
+    // WPGraphQL Smart Cache exposes per-request complexity via this constant.
+    // It may not be set if the Smart Cache plugin is inactive.
+    if (!defined('GRAPHQL_REQUEST_COMPLEXITY')) {
+        return $response;
+    }
+
+    $complexity = (int) GRAPHQL_REQUEST_COMPLEXITY;
+
+    if ($complexity >= $complexity_threshold) {
+        error_log(sprintf(
+            '[BAPI GraphQL] High complexity query detected: %d (threshold: %d). Operation: %s',
+            $complexity,
+            $complexity_threshold,
+            $operation ?: 'unnamed'
+        ));
+    }
+
+    return $response;
+}, 10, 5);
+
+// ---------------------------------------------------------------------------
 // BAPI Favorites — stored as JSON in WordPress user meta (bapi_favorites)
 // ---------------------------------------------------------------------------
 

--- a/docs/STRIPE-PRODUCTION-SETUP.md
+++ b/docs/STRIPE-PRODUCTION-SETUP.md
@@ -1,0 +1,170 @@
+# Stripe Production Setup Runbook
+
+**Last Updated:** 2026-07-09  
+**Status:** Staging uses test-mode keys. Follow this runbook before going live.
+
+---
+
+## Overview
+
+The BAPI headless store uses Stripe for payment processing (see [STRIPE-PAYMENT-INTEGRATION.md](./STRIPE-PAYMENT-INTEGRATION.md) for architecture details). This document covers:
+
+1. Activating live mode and rotating keys for the first production deployment
+2. Quarterly key rotation schedule
+3. Vercel secrets audit checklist
+
+---
+
+## Pre-Conditions
+
+Before switching to live keys you need:
+
+- [ ] Stripe account fully verified (business details, bank account, tax info)
+- [ ] Stripe account reviewed and approved for live payments
+- [ ] At least one successful end-to-end checkout test in test mode on staging
+- [ ] Team consensus that production launch is authorised (Product Manager sign-off)
+
+---
+
+## 1. Activating Production Keys (First Deployment)
+
+### 1.1 Obtain Live Keys from Stripe Dashboard
+
+1. Log in to [https://dashboard.stripe.com](https://dashboard.stripe.com)
+2. Toggle the top-left switch from **Test** → **Live**
+3. Go to **Developers → API keys**
+4. Copy the **Publishable key** (`pk_live_...`)
+5. Click **Reveal live key** for the **Secret key** (`sk_live_...`) — copy it immediately; it won't be shown again without re-revealing
+6. Store both values in the team password manager (1Password / Bitwarden) under *BAPI > Stripe > Production*
+
+> **Never commit live keys to git.** They should only exist in Vercel environment variables and the password manager.
+
+### 1.2 Add Keys to Vercel Production Environment
+
+```bash
+# Via Vercel CLI (preferred — avoids clipboard exposure)
+vercel env add NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY production
+# paste pk_live_... when prompted
+
+vercel env add STRIPE_SECRET_KEY production
+# paste sk_live_... when prompted
+```
+
+Or in the Vercel dashboard:
+1. Project → **Settings** → **Environment Variables**
+2. Add `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (Environment: **Production**) → `pk_live_...`
+3. Add `STRIPE_SECRET_KEY` (Environment: **Production**, **Sensitive**) → `sk_live_...`
+4. Click **Save**
+5. Trigger a **Redeploy** so the new variables are picked up
+
+### 1.3 Configure Stripe Webhooks for Production
+
+1. In the Stripe Dashboard (live mode) go to **Developers → Webhooks**
+2. Click **Add endpoint**
+3. URL: `https://bapi.com/api/payment/webhook` (update with actual domain)
+4. Events to send:
+   - `payment_intent.succeeded`
+   - `payment_intent.payment_failed`
+   - `charge.refunded`
+5. Copy the **Signing secret** (`whsec_...`)
+6. Add to Vercel:
+   ```bash
+   vercel env add STRIPE_WEBHOOK_SECRET production
+   # paste whsec_... when prompted
+   ```
+
+### 1.4 Smoke-Test Production Payments
+
+Use a real card with a **$0.50 minimum** to confirm the integration works before announcing go-live:
+
+1. Place a test order on production checkout
+2. Verify payment appears in Stripe Dashboard (live mode) as **Succeeded**
+3. Verify WooCommerce order is created in WordPress admin
+4. Issue a refund from the Stripe Dashboard; confirm it propagates
+
+---
+
+## 2. Quarterly Key Rotation
+
+Stripe secret keys should be rotated **every 90 days** to limit the blast radius of any potential key leak.
+
+### Schedule
+
+| Quarter | Target Date |
+|---------|-------------|
+| Q1      | March 15    |
+| Q2      | June 15     |
+| Q3      | September 15 |
+| Q4      | December 15 |
+
+### Rotation Steps
+
+1. **Generate new key**: Stripe Dashboard (live mode) → Developers → API keys → **Roll key**. Stripe keeps the old key active during a transition window.
+2. **Update Vercel**:
+   ```bash
+   vercel env rm STRIPE_SECRET_KEY production
+   vercel env add STRIPE_SECRET_KEY production
+   # paste new sk_live_... when prompted
+   ```
+3. **Redeploy** the production environment to pick up the new key.
+4. **Confirm** a real payment succeeds after the redeploy.
+5. **Revoke old key** in Stripe Dashboard once confidence is established (wait at least 1 hour in case of in-flight requests).
+6. **Update password manager** entry with the new key value + rotation date.
+7. Add an entry to [DAILY-LOG.md](./DAILY-LOG.md) noting the rotation.
+
+> **Publishable key** (`pk_live_...`) is low-risk (client-side only) and does not need routine rotation. Rotate it only if you suspect exposure.
+
+---
+
+## 3. Vercel Secrets Audit Checklist
+
+Run this audit before each production release and after any key rotation.
+
+```
+Production environment variables — required list
+─────────────────────────────────────────────────
+[ ] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY   starts with pk_live_
+[ ] STRIPE_SECRET_KEY                    starts with sk_live_   (Sensitive)
+[ ] STRIPE_WEBHOOK_SECRET                starts with whsec_     (Sensitive)
+[ ] NEXT_PUBLIC_WORDPRESS_GRAPHQL        points to production WP URL
+[ ] WORDPRESS_GRAPHQL_SECRET             server-only WP secret  (Sensitive)
+[ ] PREVIEW_SECRET                       preview route secret   (Sensitive)
+[ ] JWT_SECRET                           token signing key      (Sensitive)
+
+Staging environment variables — required list
+─────────────────────────────────────────────
+[ ] NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY   starts with pk_test_
+[ ] STRIPE_SECRET_KEY                    starts with sk_test_   (Sensitive)
+[ ] STRIPE_WEBHOOK_SECRET                starts with whsec_     (Sensitive)
+[ ] NEXT_PUBLIC_WORDPRESS_GRAPHQL        points to staging WP URL
+```
+
+**Checks to perform:**
+
+1. Log into Vercel Dashboard → Project → Settings → Environment Variables
+2. Verify production and staging have **separate key sets** (no test key leaking into production)
+3. All `Sensitive` values should show `***` — if a plain-text value is visible, rotate it immediately
+4. Confirm `STRIPE_SECRET_KEY` is **not** prefixed with `NEXT_PUBLIC_` (would expose it to the browser)
+5. Check Sentry for any `stripe` errors in the last 7 days before signing off
+
+---
+
+## 4. Rollback Procedure
+
+If a production key must be revoked immediately (suspected leak):
+
+1. **Immediately revoke** the key in Stripe Dashboard → Developers → API keys → **Revoke**
+   - This instantly invalidates all requests using that key; the store will stop processing payments
+2. Generate a new secret key (Stripe Dashboard)
+3. Update Vercel environment variable and redeploy (steps in §1.2 above)
+4. Notify the team in the engineering Slack channel with the time of revocation and reason
+5. Check Stripe Radar for any suspicious charges in the preceding 24 hours
+
+---
+
+## 5. Related Documentation
+
+- [STRIPE-PAYMENT-INTEGRATION.md](./STRIPE-PAYMENT-INTEGRATION.md) — Architecture, API routes, component overview
+- [E2E-TEST-DATA-SETUP.md](./E2E-TEST-DATA-SETUP.md) — Staging test card configuration
+- Vercel project: https://vercel.com/bapi (replace with actual project URL)
+- Stripe Dashboard: https://dashboard.stripe.com

--- a/docs/STRIPE-PRODUCTION-SETUP.md
+++ b/docs/STRIPE-PRODUCTION-SETUP.md
@@ -61,7 +61,7 @@ Or in the Vercel dashboard:
 
 1. In the Stripe Dashboard (live mode) go to **Developers → Webhooks**
 2. Click **Add endpoint**
-3. URL: `https://bapi.com/api/payment/webhook` (update with actual domain)
+3. URL: `https://bapi.com/api/payment/webhook`
 4. Events to send:
    - `payment_intent.succeeded`
    - `payment_intent.payment_failed`

--- a/web/src/lib/graphql/__tests__/client.test.ts
+++ b/web/src/lib/graphql/__tests__/client.test.ts
@@ -69,6 +69,12 @@ describe('GraphQL Client', () => {
       expect(options.headers).toBeDefined();
       expect(options.headers['Content-Type']).toBe('application/json');
     });
+
+    it('should pass a custom fetch function (complexity monitor) to the client', () => {
+      getGraphQLClient();
+      const options = MockedGraphQLClient.mock.calls[0][1];
+      expect(typeof options.fetch).toBe('function');
+    });
   });
 
   describe('Cache Tag System', () => {

--- a/web/src/lib/graphql/__tests__/complexityMonitor.test.ts
+++ b/web/src/lib/graphql/__tests__/complexityMonitor.test.ts
@@ -44,6 +44,7 @@ describe('createComplexityAwareFetch', () => {
   let monitoredFetch: ReturnType<typeof createComplexityAwareFetch>;
 
   beforeEach(() => {
+    vi.unstubAllGlobals(); // ensure no fetch stub leaks from a previously-failed test
     vi.clearAllMocks();
     monitoredFetch = createComplexityAwareFetch();
   });
@@ -126,12 +127,13 @@ describe('createComplexityAwareFetch', () => {
 
   // ── URL normalisation ─────────────────────────────────────────────────────
 
-  it('extracts the URL string from a string input', async () => {
+  it('strips query params from string input URLs before logging', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('1600')));
-    await monitoredFetch('https://example.com/graphql?q=1');
+    await monitoredFetch('https://example.com/graphql?query=foo&variables=%7B%7D');
 
     const [, opts] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(opts.extra.url).toBe('https://example.com/graphql?q=1');
+    // Query params (which may contain GraphQL query text) must not be logged
+    expect(opts.extra.url).toBe('https://example.com/graphql');
     vi.unstubAllGlobals();
   });
 

--- a/web/src/lib/graphql/__tests__/complexityMonitor.test.ts
+++ b/web/src/lib/graphql/__tests__/complexityMonitor.test.ts
@@ -1,0 +1,170 @@
+/**
+ * complexityMonitor tests
+ *
+ * Covers:
+ * - Complexity header below threshold: logs info, no Sentry
+ * - Complexity header at/above threshold: logs warn + fires Sentry warning with stable message
+ * - Network error: fires Sentry captureException and rethrows
+ * - URL normalisation for string, URL, and Request inputs
+ * - No header present: no-op
+ * - Non-numeric header value: no-op
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createComplexityAwareFetch } from '../complexityMonitor';
+
+// ── Sentry mock ──────────────────────────────────────────────────────────────
+vi.mock('@sentry/nextjs', () => ({
+  captureMessage: vi.fn(),
+  captureException: vi.fn(),
+}));
+
+// ── logger mock ──────────────────────────────────────────────────────────────
+vi.mock('@/lib/logger', () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import * as Sentry from '@sentry/nextjs';
+import logger from '@/lib/logger';
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makeResponse(complexity: string | null, status = 200): Response {
+  const headers = new Headers();
+  if (complexity !== null) headers.set('x-graphql-complexity', complexity);
+  return new Response('{}', { status, headers });
+}
+
+describe('createComplexityAwareFetch', () => {
+  let monitoredFetch: ReturnType<typeof createComplexityAwareFetch>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    monitoredFetch = createComplexityAwareFetch();
+  });
+
+  // ── no header ─────────────────────────────────────────────────────────────
+
+  it('returns the response unchanged when no complexity header is present', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse(null)));
+    const res = await monitoredFetch('https://example.com/graphql');
+    expect(res).toBeDefined();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  // ── below threshold ───────────────────────────────────────────────────────
+
+  it('logs info for a complexity value below the threshold', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('800')));
+    await monitoredFetch('https://example.com/graphql');
+    expect(logger.info).toHaveBeenCalledWith('GraphQL query complexity', { complexity: 800 });
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  // ── at threshold ──────────────────────────────────────────────────────────
+
+  it('fires a Sentry warning with a stable message when complexity equals the threshold (1500)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('1500')));
+    await monitoredFetch('https://example.com/graphql');
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'GraphQL complexity threshold exceeded',
+      expect.objectContaining({ complexity: 1500, threshold: 1500 })
+    );
+
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    const [message, opts] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    // Stable message — no interpolated values
+    expect(message).toBe('GraphQL complexity threshold exceeded');
+    expect(opts.level).toBe('warning');
+    expect(opts.extra.complexity).toBe(1500);
+    expect(opts.extra.threshold).toBe(1500);
+    vi.unstubAllGlobals();
+  });
+
+  it('fires a Sentry warning when complexity exceeds the threshold', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('1900')));
+    await monitoredFetch('https://example.com/graphql');
+    expect(Sentry.captureMessage).toHaveBeenCalledTimes(1);
+    const [message] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(message).toBe('GraphQL complexity threshold exceeded');
+    vi.unstubAllGlobals();
+  });
+
+  // ── non-numeric header ────────────────────────────────────────────────────
+
+  it('ignores a non-numeric complexity header value', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('not-a-number')));
+    await monitoredFetch('https://example.com/graphql');
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  // ── network errors ────────────────────────────────────────────────────────
+
+  it('captures network errors to Sentry and rethrows', async () => {
+    const networkError = new Error('network failure');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(networkError));
+
+    await expect(monitoredFetch('https://example.com/graphql')).rejects.toThrow('network failure');
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(
+      networkError,
+      expect.objectContaining({ tags: { type: 'graphql_network_error' } })
+    );
+    vi.unstubAllGlobals();
+  });
+
+  // ── URL normalisation ─────────────────────────────────────────────────────
+
+  it('extracts the URL string from a string input', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('1600')));
+    await monitoredFetch('https://example.com/graphql?q=1');
+
+    const [, opts] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.extra.url).toBe('https://example.com/graphql?q=1');
+    vi.unstubAllGlobals();
+  });
+
+  it('extracts the URL string from a URL object input', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('1600')));
+    await monitoredFetch(new URL('https://example.com/graphql'));
+
+    const [, opts] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(typeof opts.extra.url).toBe('string');
+    expect(opts.extra.url).toContain('example.com');
+    vi.unstubAllGlobals();
+  });
+
+  it('extracts the URL string from a Request object input', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeResponse('1600')));
+    await monitoredFetch(new Request('https://example.com/graphql'));
+
+    const [, opts] = (Sentry.captureMessage as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.extra.url).toBe('https://example.com/graphql');
+    vi.unstubAllGlobals();
+  });
+
+  it('includes URL in Sentry extra for network errors from a URL object', async () => {
+    const networkError = new Error('dns failure');
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(networkError));
+
+    await expect(
+      monitoredFetch(new URL('https://example.com/graphql'))
+    ).rejects.toThrow();
+
+    const [, opts] = (Sentry.captureException as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(typeof opts.extra.url).toBe('string');
+    expect(opts.extra.url).toContain('example.com');
+    vi.unstubAllGlobals();
+  });
+});

--- a/web/src/lib/graphql/client.ts
+++ b/web/src/lib/graphql/client.ts
@@ -1,6 +1,9 @@
 import { GraphQLClient } from 'graphql-request';
 import { AppError } from '@/lib/errors';
 import { CACHE_REVALIDATION } from '@/lib/constants/cache';
+import { createComplexityAwareFetch } from './complexityMonitor';
+
+const complexityAwareFetch = createComplexityAwareFetch();
 
 const endpoint = process.env.NEXT_PUBLIC_WORDPRESS_GRAPHQL || '';
 
@@ -20,6 +23,7 @@ export const graphqlClient = new GraphQLClient(endpoint || 'https://placeholder.
   headers: {
     'Content-Type': 'application/json',
   },
+  fetch: complexityAwareFetch,
 });
 
 /**
@@ -55,6 +59,7 @@ export const getGraphQLClient = (
       revalidate: CACHE_REVALIDATION.DEFAULT,
       tags: tags || ['graphql'], // Default tag if none provided
     },
+    fetch: complexityAwareFetch,
   });
 };
 

--- a/web/src/lib/graphql/complexityMonitor.ts
+++ b/web/src/lib/graphql/complexityMonitor.ts
@@ -2,7 +2,7 @@
  * GraphQL Query Complexity Monitoring
  *
  * Reads the `X-GraphQL-Complexity` response header set by WPGraphQL Smart Cache
- * and alerts via Sentry when complexity exceeds 80% of the configured WordPress limit.
+ * and alerts via Sentry when complexity exceeds 75% of the configured WordPress limit.
  *
  * WordPress limits (set in WPGraphQL settings):
  *   - Max depth: 20
@@ -18,8 +18,15 @@ import logger from '@/lib/logger';
 
 const COMPLEXITY_HEADER = 'x-graphql-complexity';
 
-/** Alert when query complexity reaches this fraction of the WordPress max (2000) */
+/** Alert when query complexity reaches or exceeds this absolute value (75% of the WordPress max of 2000) */
 const COMPLEXITY_ALERT_THRESHOLD = 1500;
+
+/** Normalise the three valid `fetch` input types to a plain string URL for logging */
+function inputToUrl(input: Parameters<typeof fetch>[0]): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.toString();
+  return (input as Request).url;
+}
 
 /**
  * Creates a fetch wrapper that reads `X-GraphQL-Complexity` from every GraphQL
@@ -48,9 +55,7 @@ export function createComplexityAwareFetch(): typeof fetch {
       // Network-level failure — could be a timeout or DNS issue.
       Sentry.captureException(error, {
         tags: { type: 'graphql_network_error' },
-        extra: {
-          url: typeof input === 'string' ? input : (input as Request).url,
-        },
+        extra: { url: inputToUrl(input) },
       });
       throw error;
     }
@@ -63,8 +68,7 @@ export function createComplexityAwareFetch(): typeof fetch {
         logger.info('GraphQL query complexity', { complexity });
 
         if (complexity >= COMPLEXITY_ALERT_THRESHOLD) {
-          const url =
-            typeof input === 'string' ? input : (input as Request).url;
+          const url = inputToUrl(input);
 
           logger.warn('GraphQL complexity threshold exceeded', {
             complexity,
@@ -72,18 +76,17 @@ export function createComplexityAwareFetch(): typeof fetch {
             url,
           });
 
-          Sentry.captureMessage(
-            `GraphQL complexity alert: ${complexity} (threshold: ${COMPLEXITY_ALERT_THRESHOLD})`,
-            {
-              level: 'warning',
-              tags: { type: 'graphql_complexity' },
-              extra: {
-                complexity,
-                threshold: COMPLEXITY_ALERT_THRESHOLD,
-                url,
-              },
-            }
-          );
+          // Use a stable message so all high-complexity alerts group into a
+          // single Sentry issue. Exact values go into `extra` for triage.
+          Sentry.captureMessage('GraphQL complexity threshold exceeded', {
+            level: 'warning',
+            tags: { type: 'graphql_complexity' },
+            extra: {
+              complexity,
+              threshold: COMPLEXITY_ALERT_THRESHOLD,
+              url,
+            },
+          });
         }
       }
     }

--- a/web/src/lib/graphql/complexityMonitor.ts
+++ b/web/src/lib/graphql/complexityMonitor.ts
@@ -21,11 +21,26 @@ const COMPLEXITY_HEADER = 'x-graphql-complexity';
 /** Alert when query complexity reaches or exceeds this absolute value (75% of the WordPress max of 2000) */
 const COMPLEXITY_ALERT_THRESHOLD = 1500;
 
-/** Normalise the three valid `fetch` input types to a plain string URL for logging */
+/**
+ * Normalise the three valid `fetch` input types to a plain string URL for logging.
+ *
+ * Query params are stripped before logging/capturing to avoid leaking GraphQL
+ * query text or user-supplied variables that graphql-request encodes into the
+ * URL when using GET requests.
+ */
 function inputToUrl(input: Parameters<typeof fetch>[0]): string {
-  if (typeof input === 'string') return input;
-  if (input instanceof URL) return input.toString();
-  return (input as Request).url;
+  let raw: string;
+  if (typeof input === 'string') raw = input;
+  else if (input instanceof URL) raw = input.toString();
+  else raw = (input as Request).url;
+
+  try {
+    const parsed = new URL(raw);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    // Fallback for relative URLs or unparseable strings
+    return raw.split('?')[0];
+  }
 }
 
 /**

--- a/web/src/lib/graphql/complexityMonitor.ts
+++ b/web/src/lib/graphql/complexityMonitor.ts
@@ -1,0 +1,93 @@
+/**
+ * GraphQL Query Complexity Monitoring
+ *
+ * Reads the `X-GraphQL-Complexity` response header set by WPGraphQL Smart Cache
+ * and alerts via Sentry when complexity exceeds 80% of the configured WordPress limit.
+ *
+ * WordPress limits (set in WPGraphQL settings):
+ *   - Max depth: 20
+ *   - Max complexity: 2000
+ *
+ * Alert threshold: 1500 (75% of 2000 — conservative to catch creeping complexity)
+ *
+ * @module lib/graphql/complexityMonitor
+ */
+
+import * as Sentry from '@sentry/nextjs';
+import logger from '@/lib/logger';
+
+const COMPLEXITY_HEADER = 'x-graphql-complexity';
+
+/** Alert when query complexity reaches this fraction of the WordPress max (2000) */
+const COMPLEXITY_ALERT_THRESHOLD = 1500;
+
+/**
+ * Creates a fetch wrapper that reads `X-GraphQL-Complexity` from every GraphQL
+ * response and fires Sentry alerts when the threshold is exceeded.
+ *
+ * Pass the returned function as the `fetch` option on `GraphQLClient`:
+ *
+ * ```ts
+ * new GraphQLClient(endpoint, { fetch: createComplexityAwareFetch() })
+ * ```
+ *
+ * The wrapper is transparent: it forwards all arguments (including Next.js
+ * extended `{ next: { revalidate, tags } }` options) to the native fetch and
+ * returns the original `Response` unchanged.
+ */
+export function createComplexityAwareFetch(): typeof fetch {
+  return async function complexityAwareFetch(
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1]
+  ): Promise<Response> {
+    let response: Response;
+
+    try {
+      response = await fetch(input, init);
+    } catch (error) {
+      // Network-level failure — could be a timeout or DNS issue.
+      Sentry.captureException(error, {
+        tags: { type: 'graphql_network_error' },
+        extra: {
+          url: typeof input === 'string' ? input : (input as Request).url,
+        },
+      });
+      throw error;
+    }
+
+    const rawComplexity = response.headers.get(COMPLEXITY_HEADER);
+    if (rawComplexity !== null) {
+      const complexity = parseInt(rawComplexity, 10);
+
+      if (!isNaN(complexity)) {
+        logger.info('GraphQL query complexity', { complexity });
+
+        if (complexity >= COMPLEXITY_ALERT_THRESHOLD) {
+          const url =
+            typeof input === 'string' ? input : (input as Request).url;
+
+          logger.warn('GraphQL complexity threshold exceeded', {
+            complexity,
+            threshold: COMPLEXITY_ALERT_THRESHOLD,
+            url,
+          });
+
+          Sentry.captureMessage(
+            `GraphQL complexity alert: ${complexity} (threshold: ${COMPLEXITY_ALERT_THRESHOLD})`,
+            {
+              level: 'warning',
+              tags: { type: 'graphql_complexity' },
+              extra: {
+                complexity,
+                threshold: COMPLEXITY_ALERT_THRESHOLD,
+                url,
+              },
+            }
+          );
+        }
+      }
+    }
+
+    return response;
+  };
+}


### PR DESCRIPTION
- Add complexityMonitor.ts: fetch wrapper that reads X-GraphQL-Complexity response header from WPGraphQL Smart Cache and fires a Sentry warning when complexity >= 1500 (75% of the configured WordPress max of 2000). Network-level failures also capture to Sentry with graphql_network_error tag.

- Wire into graphql/client.ts: both the singleton graphqlClient and the getGraphQLClient factory now use complexityAwareFetch.

- bapi-graphql-fixes.php (+ cms copy synced): add graphql_request_results filter that logs high-complexity queries (>= 1500) to PHP error_log on the WordPress/Kinsta side for server-level visibility.

- docs/STRIPE-PRODUCTION-SETUP.md: new runbook covering first-deployment live-key activation, quarterly rotation schedule, Vercel secrets audit checklist, and emergency revocation/rollback procedure.

Note: Customer group filtering (P0 task 1) was already fully implemented across FilteredProductGrid, SearchResults, CategoryContent, RelatedProducts, and the search API route. No changes needed there.



