### PR TITLE
Chore/quick wins docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Modern headless WordPress/WooCommerce with Next.js frontend, showcasing professional building automation products with full e-commerce capabilities.
 
+[![web CI](https://github.com/ateece-bapi/bapi-headless/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ateece-bapi/bapi-headless/actions/workflows/ci.yml)
 [![Next.js](https://img.shields.io/badge/Next.js-16.0.7-black?logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue?logo=typescript)](https://www.typescriptlang.org/)
 [![WordPress](https://img.shields.io/badge/WordPress-6.8.2-21759b?logo=wordpress)](https://wordpress.org/)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -286,6 +286,7 @@ ssh -p 17338 bapiheadlessstaging@35.224.70.159 \
 ## Test Credentials
 
 **Password:** Retrieve from secure storage (not committed to repo)
+# For test credentials, contact @ateece-bapi-team in Slack
 
 | Email | Customer Group | Description |
 |-------|----------------|-------------|

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -285,8 +285,7 @@ ssh -p 17338 bapiheadlessstaging@35.224.70.159 \
 
 ## Test Credentials
 
-**Password:** Retrieve from secure storage (not committed to repo)
-# For test credentials, contact the BAPI dev team via email
+**Password:** Retrieve from secure storage (not committed to repo). Contact the BAPI dev team via email to request access.
 
 | Email | Customer Group | Description |
 |-------|----------------|-------------|

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -286,7 +286,7 @@ ssh -p 17338 bapiheadlessstaging@35.224.70.159 \
 ## Test Credentials
 
 **Password:** Retrieve from secure storage (not committed to repo)
-# For test credentials, contact @ateece-bapi-team in Slack
+# For test credentials, contact the BAPI dev team via email
 
 | Email | Customer Group | Description |
 |-------|----------------|-------------|


### PR DESCRIPTION
Summary
Small documentation improvements with no code impact.

Changes
README.md — Added GitHub Actions CI badge above the existing stack badges so build status is visible at a glance
README.md — Added note to contact the BAPI dev team via email for test credentials (replaces vague "retrieve from secure storage" with an actionable next step)
Notes
.env.example already had PREVIEW_SECRET, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, and STRIPE_SECRET_KEY — no changes needed there
No code, tests, or config changes — docs only