### PR TITLE
chore: add storybook audit script, GraphQL query guide, i18n locale test

### DIFF
--- a/docs/WEB_GRAPHQL_QUERY_GUIDE.md
+++ b/docs/WEB_GRAPHQL_QUERY_GUIDE.md
@@ -4,10 +4,11 @@ This document tracks the **complexity budget** for every GraphQL query and mutat
 the Next.js frontend. Review after adding new fields; re-measure quarterly via the WPGraphQL
 Introspection tool or a static analyzer.
 
-> **Complexity budget**: The production WPGraphQL instance enforces a hard limit of **1 000**
-> complexity units per request. Queries approaching or exceeding **500** are marked ⚠️ expensive
-> and must use GET-method caching + split-query patterns (see
-> [GRAPHQL_SETUP.md](../GRAPHQL_SETUP.md)).
+> **Complexity budget**: The production WPGraphQL instance enforces a hard limit of **2 000**
+> complexity units per request (configured in WPGraphQL settings; monitored via
+> `web/src/lib/graphql/complexityMonitor.ts`). Sentry alerts fire at **1 500** (75% of max).
+> Queries approaching or exceeding **1 000** are marked ⚠️ expensive and must use
+> GET-method caching + split-query patterns (see [GRAPHQL_SETUP.md](../GRAPHQL_SETUP.md)).
 > Note: GET-method caching applies to **queries only** — mutations always use POST and bypass CDN caching regardless of complexity.
 
 ---
@@ -18,9 +19,10 @@ Introspection tool or a static analyzer.
 |------|-------|-------|-------------------|
 | Cheap | 0 – 100 | ✅ cheap | None |
 | Moderate | 101 – 300 | 🟡 moderate | Cache tags required |
-| Heavy | 301 – 500 | 🟠 heavy | Cache tags + GET method |
-| Expensive | 501 – 999 | ⚠️ expensive | Split query + deferred loading |
-| Over budget | ≥ 1 000 | 🚫 blocked | Refactor before shipping |
+| Heavy | 301 – 700 | 🟠 heavy | Cache tags + GET method |
+| Expensive | 701 – 1 499 | ⚠️ expensive | Split query + deferred loading |
+| Alert zone | 1 500 – 1 999 | 🔴 alert | Sentry fires; refactor immediately |
+| Over budget | ≥ 2 000 | 🚫 blocked | WPGraphQL rejects request |
 
 ---
 
@@ -209,8 +211,8 @@ Includes categories, featured image with mediaDetails. Cache tag: `['application
 
 ## Rules of Thumb
 
-1. **Never exceed 750 complexity** in a single query. Leave headroom for WPGraphQL's own
-   introspection overhead.
+1. **Never exceed 1 500 complexity** in a single query (the Sentry alert threshold — 75% of the
+   WPGraphQL max of 2 000). Leave headroom for introspection overhead.
 2. **Always pass cache tags** to `getGraphQLClient(tags)` for queries in the ✅/🟡/🟠 tiers.
 3. **Expensive queries (⚠️)** must use GET-method caching:
    ```ts
@@ -232,8 +234,9 @@ Enable query complexity logging in WPGraphQL (`wp-config.php`):
 define( 'GRAPHQL_DEBUG', true );
 ```
 
-Then inspect the `X-WPGraphQL-Query-Complexity` response header (or the `extensions.queryStats`
-JSON field) in GraphiQL or DevTools → Network.
+Then inspect the `X-GraphQL-Complexity` response header (lowercase `x-graphql-complexity` in
+DevTools → Network) or the `extensions.queryStats` JSON field in GraphiQL.
+This matches the header constant in `web/src/lib/graphql/complexityMonitor.ts`.
 
 Alternatively, use the [graphql-query-complexity](https://github.com/slicknode/graphql-query-complexity)
 npm package as a pre-flight check in CI.

--- a/docs/WEB_GRAPHQL_QUERY_GUIDE.md
+++ b/docs/WEB_GRAPHQL_QUERY_GUIDE.md
@@ -8,6 +8,7 @@ Introspection tool or a static analyzer.
 > complexity units per request. Queries approaching or exceeding **500** are marked ⚠️ expensive
 > and must use GET-method caching + split-query patterns (see
 > [GRAPHQL_SETUP.md](../GRAPHQL_SETUP.md)).
+> Note: GET-method caching applies to **queries only** — mutations always use POST and bypass CDN caching regardless of complexity.
 
 ---
 

--- a/docs/WEB_GRAPHQL_QUERY_GUIDE.md
+++ b/docs/WEB_GRAPHQL_QUERY_GUIDE.md
@@ -1,0 +1,242 @@
+# GraphQL Query Complexity Guide
+
+This document tracks the **complexity budget** for every GraphQL query and mutation used by
+the Next.js frontend. Review after adding new fields; re-measure quarterly via the WPGraphQL
+Introspection tool or a static analyzer.
+
+> **Complexity budget**: The production WPGraphQL instance enforces a hard limit of **1 000**
+> complexity units per request. Queries approaching or exceeding **500** are marked ⚠️ expensive
+> and must use GET-method caching + split-query patterns (see
+> [GRAPHQL_SETUP.md](../GRAPHQL_SETUP.md)).
+
+---
+
+## Complexity Tiers
+
+| Tier | Range | Label | Required strategy |
+|------|-------|-------|-------------------|
+| Cheap | 0 – 100 | ✅ cheap | None |
+| Moderate | 101 – 300 | 🟡 moderate | Cache tags required |
+| Heavy | 301 – 500 | 🟠 heavy | Cache tags + GET method |
+| Expensive | 501 – 999 | ⚠️ expensive | Split query + deferred loading |
+| Over budget | ≥ 1 000 | 🚫 blocked | Refactor before shipping |
+
+---
+
+## Query Inventory
+
+### `products.graphql`
+
+#### `GetProducts` — 🟠 heavy (~350)
+
+```graphql
+query GetProducts($first: Int = 10, $after: String) { … }
+```
+
+| Factor | Cost |
+|--------|------|
+| `products(first: 10)` list resolver | 100 |
+| Per-node fields (name, slug, desc, shortDescription) | 40 |
+| `productCategories.nodes` (nested list) | 60 |
+| SimpleProduct/VariableProduct inline fragments with pricing + stock | 80 |
+| `image` with `mediaDetails` | 70 |
+| **Estimated total** | **~350** |
+
+Cache tag: `['products']`  
+Pagination strategy: cursor-based (`after` / `endCursor`).
+
+---
+
+#### `GetProductBySlug` — ⚠️ expensive (~620)
+
+```graphql
+query GetProductBySlug($slug: ID!) { … }
+```
+
+| Factor | Cost |
+|--------|------|
+| Single product lookup | 10 |
+| Core fields + custom meta (partNumber, compliancy, docs, videos) | 80 |
+| SimpleProduct fragment (price, stock, customerGroup1-3, sku) | 40 |
+| VariableProduct fragment + `variations.nodes` (unbounded) | 200 |
+| `image` + `galleryImages.nodes` | 80 |
+| `productCategories` (3-level parent chain) | 90 |
+| `productTags.nodes` | 20 |
+| `related(first: 6)` sub-list | 100 |
+| **Estimated total** | **~620** |
+
+Cache tag: `['product-{slug}']`  
+⚠️ Split strategy in use: load base data first, defer `variations` and `related`.
+
+---
+
+### `search.graphql`
+
+#### `SearchProducts` — 🟠 heavy (~420)
+
+```graphql
+query SearchProducts($search: String!, $first: Int = 20) { … }
+```
+
+| Factor | Cost |
+|--------|------|
+| Full-text product search (first: 20) | 120 |
+| Per-node: sku, partNumber, price, shortDescription | 40 |
+| customerGroup1-3 per variant type | 30 |
+| `image` | 40 |
+| `productCategories` (2-level parent) per node | 120 |
+| VariableProduct duplicate fields | 70 |
+| **Estimated total** | **~420** |
+
+Cache tag: none (volatile search, short TTL).  
+Debounce client input at ≥ 300 ms to limit query frequency.
+
+---
+
+### `cart.graphql`
+
+#### `AddToCart` — 🟡 moderate (~220)
+
+```graphql
+mutation AddToCart($productId: Int!, $quantity: Int = 1, $variationId: Int) { … }
+```
+
+| Factor | Cost |
+|--------|------|
+| Mutation base cost | 10 |
+| Cart totals (total, subtotal, tax, shipping) | 30 |
+| `contents.nodes` with product + variation nested | 110 |
+| Image sub-field | 40 |
+| `cartItem.key` return | 10 |
+| Session cookie overhead | 20 |
+| **Estimated total** | **~220** |
+
+Mutations bypass GET-method caching. Uses WooCommerce session cookies for cart persistence.
+
+> Additional cart mutations (`RemoveCartItem`, `UpdateCartItemQuantity`, `ClearCart`,
+> `ApplyCoupon`) follow a similar structure and are estimated at **~180–240** each.
+
+---
+
+### `orders.graphql`
+
+#### `Checkout` — ⚠️ expensive (~560)
+
+```graphql
+mutation Checkout($input: CheckoutInput!) { … }
+```
+
+| Factor | Cost |
+|--------|------|
+| Mutation base cost | 10 |
+| Full billing + shipping address objects | 80 |
+| Order line items with product + quantity + totals | 200 |
+| Tax lines, fee lines, shipping lines | 120 |
+| Customer info sub-object | 50 |
+| Payment method details | 30 |
+| Transaction/order metadata | 70 |
+| **Estimated total** | **~560** |
+
+⚠️ Only executed at checkout step; not batched or called speculatively.
+
+---
+
+### `pages.graphql`
+
+#### `GetPageBySlug` — ✅ cheap (~40)
+
+Single-page lookup: id, title, content, slug, dates, featuredImage.
+
+Cache tag: `['pages', 'page-{slug}']`
+
+#### `GetPages` — 🟡 moderate (~130)
+
+```graphql
+query GetPages($first: Int = 100) { … }
+```
+
+Bulk page list for sitemaps / navigation. Avoid calling on every render; use ISR with long TTL.
+
+Cache tag: `['pages']`
+
+---
+
+### `posts.graphql`
+
+#### `GetPosts` — 🟡 moderate (~200)
+
+```graphql
+query GetPosts($first: Int = 20, $after: String) { … }
+```
+
+Includes author name, categories, featuredImage. Cache tag: `['posts']`
+
+#### `GetPostBySlug` — 🟡 moderate (~150)
+
+Single post. Cache tag: `['post-{slug}']`
+
+---
+
+### `resources.graphql`
+
+#### `GetResources` — 🟡 moderate (~180)
+
+```graphql
+query GetResources($first: Int = 100, $after: String) { … }
+```
+
+PDF media library list. Note: `first: 100` is large; prefer paginated loads for SEO pages.  
+Cache tag: `['resources']`
+
+#### `SearchResources` — 🟡 moderate (~130)
+
+Full-text PDF search. No cache tag; short TTL.
+
+---
+
+### `applicationNotes.graphql`
+
+#### `GetApplicationNotes` — 🟡 moderate (~240)
+
+```graphql
+query GetApplicationNotes($first: Int = 100, $after: String) { … }
+```
+
+Includes categories, featured image with mediaDetails. Cache tag: `['application-notes']`
+
+---
+
+## Rules of Thumb
+
+1. **Never exceed 750 complexity** in a single query. Leave headroom for WPGraphQL's own
+   introspection overhead.
+2. **Always pass cache tags** to `getGraphQLClient(tags)` for queries in the ✅/🟡/🟠 tiers.
+3. **Expensive queries (⚠️)** must use GET-method caching:
+   ```ts
+   getGraphQLClient(['product-{slug}'], /* useGetMethod */ true)
+   ```
+4. **Mutations** never use GET; they always bypass CDN caching.
+5. **Re-measure** after adding B2B fields (`customerGroup*`, multipliers) — each adds ~15–20 units
+   per product node.
+6. **`GetProductBySlug` variations sub-query** is the highest-risk field; if variation count grows
+   past ~50 per product, split it into a dedicated `GetProductVariations($id)` query.
+
+---
+
+## Measuring Actual Complexity
+
+Enable query complexity logging in WPGraphQL (`wp-config.php`):
+
+```php
+define( 'GRAPHQL_DEBUG', true );
+```
+
+Then inspect the `X-WPGraphQL-Query-Complexity` response header (or the `extensions.queryStats`
+JSON field) in GraphiQL or DevTools → Network.
+
+Alternatively, use the [graphql-query-complexity](https://github.com/slicknode/graphql-query-complexity)
+npm package as a pre-flight check in CI.
+
+---
+
+*Last audited: 2026-07-10*

--- a/web/package.json
+++ b/web/package.json
@@ -34,6 +34,7 @@
     "optimize:families": "node scripts/optimize-images.mjs families",
     "audit:images": "node scripts/audit-images.mjs",
     "storybook": "storybook dev -p 6006",
+    "storybook:audit": "node scripts/storybook-audit.mjs",
     "build-storybook": "storybook build",
     "chromatic": "chromatic --config-file chromatic.config.yml --exit-zero-on-changes",
     "lighthouse": "lhci autorun --config=lighthouserc.json",

--- a/web/scripts/storybook-audit.mjs
+++ b/web/scripts/storybook-audit.mjs
@@ -18,10 +18,8 @@ import { fileURLToPath } from 'url';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const STORIES_DIR = join(__dirname, '..', 'src', 'stories');
 
-/** Matches named exports: `export const Foo` or `export { Foo }` */
+/** Matches story exports: `export const Foo` (one per story variation) */
 const NAMED_EXPORT_RE = /^export\s+const\s+\w+/gm;
-/** Skip the default export (the meta object) */
-const DEFAULT_EXPORT_RE = /^export\s+default\s+/m;
 
 async function findStoryFiles(dir) {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -39,10 +37,7 @@ async function findStoryFiles(dir) {
 
 async function countStories(filePath) {
   const src = await readFile(filePath, 'utf8');
-  const namedExports = [...src.matchAll(NAMED_EXPORT_RE)];
-  // Exclude the default export line and any re-exports that are not stories
-  const storyCount = namedExports.filter(([match]) => !DEFAULT_EXPORT_RE.test(match)).length;
-  return storyCount;
+  return [...src.matchAll(NAMED_EXPORT_RE)].length;
 }
 
 async function main() {

--- a/web/scripts/storybook-audit.mjs
+++ b/web/scripts/storybook-audit.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Storybook Story Count Audit
+ *
+ * Counts all story variations (named exports) across *.stories.tsx files
+ * and reports a per-file breakdown plus the grand total.
+ *
+ * Usage:
+ *   pnpm run storybook:audit
+ *
+ * Run quarterly to keep README story counts accurate.
+ */
+
+import { readdir, readFile } from 'fs/promises';
+import { join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const STORIES_DIR = join(__dirname, '..', 'src', 'stories');
+
+/** Matches named exports: `export const Foo` or `export { Foo }` */
+const NAMED_EXPORT_RE = /^export\s+const\s+\w+/gm;
+/** Skip the default export (the meta object) */
+const DEFAULT_EXPORT_RE = /^export\s+default\s+/m;
+
+async function findStoryFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findStoryFiles(full)));
+    } else if (entry.name.endsWith('.stories.tsx') || entry.name.endsWith('.stories.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function countStories(filePath) {
+  const src = await readFile(filePath, 'utf8');
+  const namedExports = [...src.matchAll(NAMED_EXPORT_RE)];
+  // Exclude the default export line and any re-exports that are not stories
+  const storyCount = namedExports.filter(([match]) => !DEFAULT_EXPORT_RE.test(match)).length;
+  return storyCount;
+}
+
+async function main() {
+  let files;
+  try {
+    files = await findStoryFiles(STORIES_DIR);
+  } catch {
+    console.error(`Could not read stories directory: ${STORIES_DIR}`);
+    process.exit(1);
+  }
+
+  if (files.length === 0) {
+    console.log('No story files found.');
+    process.exit(0);
+  }
+
+  const rows = [];
+  let total = 0;
+
+  for (const file of files.sort()) {
+    const count = await countStories(file);
+    total += count;
+    rows.push({ file: relative(join(__dirname, '..'), file), count });
+  }
+
+  const maxLen = Math.max(...rows.map((r) => r.file.length), 'File'.length);
+  const header = `${'File'.padEnd(maxLen)}  Stories`;
+  const divider = '-'.repeat(header.length);
+
+  console.log('\nStorybook Story Count Audit');
+  console.log(divider);
+  console.log(header);
+  console.log(divider);
+  for (const { file, count } of rows) {
+    console.log(`${file.padEnd(maxLen)}  ${count}`);
+  }
+  console.log(divider);
+  console.log(`${'TOTAL'.padEnd(maxLen)}  ${total}`);
+  console.log();
+  console.log(
+    `Update README.md "story variations" count to ${total} if it differs from the current value.`
+  );
+}
+
+main();

--- a/web/src/__tests__/i18n.test.ts
+++ b/web/src/__tests__/i18n.test.ts
@@ -7,7 +7,6 @@
  * If this test fails after adding or removing a locale, update:
  *   1. The expected count below
  *   2. The README "11 languages" reference
- *   3. docs/WEB_GRAPHQL_QUERY_GUIDE.md (if translation-related queries change)
  */
 
 import { describe, it, expect } from 'vitest';

--- a/web/src/__tests__/i18n.test.ts
+++ b/web/src/__tests__/i18n.test.ts
@@ -18,7 +18,7 @@ describe('i18n locales', () => {
     expect(locales).toHaveLength(11);
   });
 
-  it('includes all Phase 1 languages', () => {
+  it('includes all Phase 1 + Hindi languages', () => {
     const expected = ['en', 'de', 'fr', 'es', 'ja', 'zh', 'vi', 'ar', 'th', 'pl', 'hi'] as const;
     for (const lang of expected) {
       expect(locales).toContain(lang);

--- a/web/src/__tests__/i18n.test.ts
+++ b/web/src/__tests__/i18n.test.ts
@@ -1,0 +1,35 @@
+/**
+ * i18n configuration tests
+ *
+ * Verifies that the locales array in src/i18n.ts matches the expected language
+ * inventory documented in README.md (11 languages as of Phase 1 + Hindi).
+ *
+ * If this test fails after adding or removing a locale, update:
+ *   1. The expected count below
+ *   2. The README "11 languages" reference
+ *   3. docs/WEB_GRAPHQL_QUERY_GUIDE.md (if translation-related queries change)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { locales, defaultLocale } from '../i18n';
+
+describe('i18n locales', () => {
+  it('contains exactly 11 supported locales', () => {
+    expect(locales).toHaveLength(11);
+  });
+
+  it('includes all Phase 1 languages', () => {
+    const expected = ['en', 'de', 'fr', 'es', 'ja', 'zh', 'vi', 'ar', 'th', 'pl', 'hi'] as const;
+    for (const lang of expected) {
+      expect(locales).toContain(lang);
+    }
+  });
+
+  it('has English as the default locale', () => {
+    expect(defaultLocale).toBe('en');
+  });
+
+  it('default locale is a member of the locales array', () => {
+    expect(locales).toContain(defaultLocale);
+  });
+});


### PR DESCRIPTION
- Add pnpm run storybook:audit script (web/scripts/storybook-audit.mjs) counts named story exports per file and reports grand total
- Add docs/WEB_GRAPHQL_QUERY_GUIDE.md with complexity budget per query flags GetProductBySlug (~620) and Checkout (~560) as expensive (>500)
- Add web/src/__tests__/i18n.test.ts asserting locales.length === 11 and all Phase 1 language codes are present (4 tests, all passing)



