### PR TITLE
feat: interactive world map with regional sales contact popups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ web/test-output/
 
 # Temporary image assets (review if needed)
 web/2026-approved-images/
+
+# Internal/confidential PDFs — keep local only
+docs/*.pdf

--- a/web/src/components/company/GlobalPresence.tsx
+++ b/web/src/components/company/GlobalPresence.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { ComposableMap, Geographies, Geography, Marker, ZoomableGroup } from 'react-simple-maps';
+import {
+  ComposableMap,
+  Geographies,
+  Geography as _Geography,
+  Marker,
+  ZoomableGroup,
+} from 'react-simple-maps';
+import React from 'react';
 import {
   BAPI_LOCATIONS,
   FACILITY_TYPE_LABELS,
@@ -8,9 +15,21 @@ import {
   getActiveFacilityTypes,
 } from '@/lib/constants/locations';
 import type { Location, FacilityType } from '@/lib/constants/locations';
-import { Building2Icon, MapPinIcon } from '@/lib/icons';
-import { useState } from 'react';
+import { getRegionForCountry } from '@/lib/constants/salesRegions';
+import type { SalesRep, SalesRegion } from '@/lib/constants/salesRegions';
+import { Building2Icon, MapPinIcon, UserIcon, MailIcon, PhoneIcon } from '@/lib/icons';
+import { useState, useRef } from 'react';
 import { Link } from '@/lib/navigation';
+
+// react-simple-maps Geography supports mouse events at runtime but its bundled
+// type declarations omit them. Extend the component type so we can attach hover
+// handlers without suppressing all type-checking on this element.
+const Geography = _Geography as React.ComponentType<
+  React.ComponentProps<typeof _Geography> & {
+    onMouseEnter?: (event: React.MouseEvent<SVGPathElement>) => void;
+    onMouseLeave?: (event: React.MouseEvent<SVGPathElement>) => void;
+  }
+>;
 
 const geoUrl = 'https://cdn.jsdelivr.net/npm/world-atlas@2/countries-110m.json';
 
@@ -89,8 +108,72 @@ export function GlobalPresence({
 }: GlobalPresenceProps = {}) {
   const [tooltip, setTooltip] = useState<{ location: Location; visible: boolean } | null>(null);
 
+  // Two separate states for map vs. popup so they can update at different rates:
+  // - activeRegionId  → immediate, drives map highlight color (feels responsive)
+  // - popupRegionInfo → debounced, drives the popup card (stays stable so user can click it)
+  const [activeRegionId, setActiveRegionId] = useState<number | null>(null);
+  const [popupRegionInfo, setPopupRegionInfo] = useState<{
+    region: SalesRegion;
+    rep: SalesRep;
+  } | null>(null);
+
+  // Debounce timer — popup content only updates after the cursor has rested on a
+  // country for ~220 ms, so moving quickly toward the popup doesn't change it.
+  const popupDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Get active facility types for legend (only show types that exist in data)
   const activeFacilityTypes = getActiveFacilityTypes();
+
+  function handleCountryEnter(countryName: string) {
+    const info = getRegionForCountry(countryName);
+
+    // Map highlight: immediate
+    setActiveRegionId(info?.region.id ?? null);
+
+    // Popup: cancel any pending update, then schedule a new one
+    if (popupDebounceRef.current) clearTimeout(popupDebounceRef.current);
+    popupDebounceRef.current = setTimeout(() => {
+      setPopupRegionInfo(info);
+      popupDebounceRef.current = null;
+    }, 220);
+  }
+
+  function handleCountryLeave() {
+    // Container-level leave — clear everything immediately
+    if (popupDebounceRef.current) {
+      clearTimeout(popupDebounceRef.current);
+      popupDebounceRef.current = null;
+    }
+    setActiveRegionId(null);
+    setPopupRegionInfo(null);
+  }
+
+  function handlePopupMouseEnter() {
+    // Mouse is now on the popup card — cancel any pending debounced update so the
+    // content doesn't change while the user is trying to read or click it.
+    if (popupDebounceRef.current) {
+      clearTimeout(popupDebounceRef.current);
+      popupDebounceRef.current = null;
+    }
+  }
+
+  function getGeographyFill(countryName: string): string {
+    if (activeRegionId === null) return '#E5E7EB'; // neutral-200 default
+    const info = getRegionForCountry(countryName);
+    if (info && info.region.id === activeRegionId) {
+      return '#93C5FD'; // blue-300 – strong contrast highlight
+    }
+    return '#F3F4F6'; // neutral-100 – dimmed non-active countries
+  }
+
+  function getGeographyStroke(countryName: string): string {
+    if (activeRegionId === null) return '#D1D5DB';
+    const info = getRegionForCountry(countryName);
+    if (info && info.region.id === activeRegionId) {
+      return '#1e6fb9'; // primary-600 – highlighted border
+    }
+    return '#E5E7EB';
+  }
 
   return (
     <section className="bg-linear-to-b from-white to-neutral-50 py-16">
@@ -110,7 +193,8 @@ export function GlobalPresence({
         </div>
 
         {/* Interactive World Map */}
-        <div className="relative mb-12 rounded-2xl bg-white p-6 shadow-lg">
+        {/* onMouseLeave on the card (not per-country) so the panel stays reachable */}
+        <div className="relative mb-12 rounded-2xl bg-white p-6 shadow-lg" onMouseLeave={handleCountryLeave}>
           <div className="relative" style={{ height: '500px' }}>
             <ComposableMap
               projection="geoMercator"
@@ -124,20 +208,23 @@ export function GlobalPresence({
                 {/* World Geography Base Layer */}
                 <Geographies geography={geoUrl}>
                   {({ geographies }: { geographies: GeoFeature[] }) =>
-                    geographies.map((geo: GeoFeature) => (
-                      <Geography
-                        key={geo.rsmKey}
-                        geography={geo}
-                        fill="#E5E7EB" // neutral-200
-                        stroke="#D1D5DB" // neutral-300
-                       
-                        style={{
-                          default: { outline: 'none' },
-                          hover: { outline: 'none', fill: '#D1D5DB' },
-                          pressed: { outline: 'none' },
-                        }}
-                      />
-                    ))
+                    geographies.map((geo: GeoFeature) => {
+                      const countryName = geo.properties.name as string;
+                      return (
+                        <Geography
+                          key={geo.rsmKey}
+                          geography={geo}
+                          fill={getGeographyFill(countryName)}
+                          stroke={getGeographyStroke(countryName)}
+                          onMouseEnter={() => handleCountryEnter(countryName)}
+                          style={{
+                            default: { outline: 'none' },
+                            hover: { outline: 'none' },
+                            pressed: { outline: 'none' },
+                          }}
+                        />
+                      );
+                    })
                   }
                 </Geographies>
 
@@ -179,7 +266,7 @@ export function GlobalPresence({
               </ZoomableGroup>
             </ComposableMap>
 
-            {/* Hover Tooltip */}
+            {/* Facility marker tooltip — top-center, pointer-events: none */}
             {tooltip?.visible &&
               (() => {
                 const translation = locationTranslations?.facilities[tooltip.location.id];
@@ -215,9 +302,88 @@ export function GlobalPresence({
                   </div>
                 );
               })()}
+
+            {/* Regional sales contact popup — bottom-right corner, anchored */}
+            {/* onMouseEnter cancels the debounce so content freezes the moment the */}
+            {/* user's cursor arrives — they can always click what they originally saw. */}
+            <div
+              onMouseEnter={handlePopupMouseEnter}
+              className={`absolute bottom-4 right-4 z-40 w-64 transition-all duration-200 ${
+                popupRegionInfo
+                  ? 'pointer-events-auto translate-y-0 opacity-100'
+                  : 'pointer-events-none translate-y-2 opacity-0'
+              }`}
+            >
+              {popupRegionInfo && (
+                <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white/95 shadow-xl backdrop-blur-sm">
+                  {/* Colored top bar */}
+                  <div className="h-1 w-full bg-primary-600" />
+                  <div className="p-4">
+                    <p className="mb-0.5 text-xs font-semibold uppercase tracking-wider text-primary-600">
+                      {popupRegionInfo.region.name}
+                    </p>
+                    <p className="mb-3 text-xs text-neutral-500">
+                      {popupRegionInfo.region.description}
+                    </p>
+                    <div className="flex items-center gap-3">
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary-100">
+                        <UserIcon className="h-5 w-5 text-primary-600" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold leading-tight text-neutral-900">
+                          {popupRegionInfo.rep.name}
+                        </p>
+                        <p className="text-xs leading-tight text-neutral-500">
+                          Regional Sales
+                        </p>
+                      </div>
+                    </div>
+                    {(popupRegionInfo.rep.email || popupRegionInfo.rep.phone) && (
+                      <div className="mt-3 space-y-1.5 border-t border-neutral-100 pt-3">
+                        {popupRegionInfo.rep.email && (
+                          <a
+                            href={`mailto:${popupRegionInfo.rep.email}`}
+                            className="flex items-center gap-2 text-xs text-neutral-600 hover:text-primary-600"
+                          >
+                            <MailIcon className="h-3.5 w-3.5 shrink-0" />
+                            <span className="truncate">{popupRegionInfo.rep.email}</span>
+                          </a>
+                        )}
+                        {popupRegionInfo.rep.phone && (
+                          <a
+                            href={`tel:${popupRegionInfo.rep.phone}`}
+                            className="flex items-center gap-2 text-xs text-neutral-600 hover:text-primary-600"
+                          >
+                            <PhoneIcon className="h-3.5 w-3.5 shrink-0" />
+                            {popupRegionInfo.rep.phone}
+                          </a>
+                        )}
+                      </div>
+                    )}
+                    <Link
+                      href="/contact"
+                      className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-700"
+                    >
+                      Contact {popupRegionInfo.rep.name.split(' ')[0]}
+                    </Link>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Interaction hint — center-bottom, fades out when a region is active */}
+            <div
+              className={`pointer-events-none absolute bottom-3 left-1/2 z-30 -translate-x-1/2 transition-opacity duration-200 ${
+                popupRegionInfo ? 'opacity-0' : 'opacity-100'
+              }`}
+            >
+              <span className="rounded-full bg-white/80 px-3 py-1 text-xs text-neutral-400 shadow backdrop-blur-sm">
+                Hover a country to find your regional contact
+              </span>
+            </div>
           </div>
 
-          {/* Map Legend - Only show active facility types */}
+          {/* Map Legend */}
           <div className="mt-6 border-t border-neutral-200 pt-6">
             <div className="flex flex-wrap justify-center gap-6 text-sm">
               {activeFacilityTypes.map((type) => {
@@ -249,6 +415,15 @@ export function GlobalPresence({
               })}
             </div>
           </div>
+
+          {/* Mobile fallback — touch devices can't hover */}
+          <p className="mt-4 text-center text-xs text-neutral-400 md:hidden">
+            Visit our{' '}
+            <Link href="/contact" className="text-primary-600 underline">
+              contact page
+            </Link>{' '}
+            to reach your regional sales rep.
+          </p>
         </div>
 
         {/* Location Cards Grid */}

--- a/web/src/components/company/GlobalPresence.tsx
+++ b/web/src/components/company/GlobalPresence.tsx
@@ -18,7 +18,7 @@ import type { Location, FacilityType } from '@/lib/constants/locations';
 import { getRegionForCountry } from '@/lib/constants/salesRegions';
 import type { SalesRep, SalesRegion } from '@/lib/constants/salesRegions';
 import { Building2Icon, MapPinIcon, UserIcon, MailIcon, PhoneIcon } from '@/lib/icons';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { Link } from '@/lib/navigation';
 
 // react-simple-maps Geography supports mouse events at runtime but its bundled
@@ -121,6 +121,13 @@ export function GlobalPresence({
   // country for ~220 ms, so moving quickly toward the popup doesn't change it.
   const popupDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Clear any pending timer on unmount to prevent state updates on dead components.
+  useEffect(() => {
+    return () => {
+      if (popupDebounceRef.current) clearTimeout(popupDebounceRef.current);
+    };
+  }, []);
+
   // Get active facility types for legend (only show types that exist in data)
   const activeFacilityTypes = getActiveFacilityTypes();
 
@@ -130,12 +137,19 @@ export function GlobalPresence({
     // Map highlight: immediate
     setActiveRegionId(info?.region.id ?? null);
 
-    // Popup: cancel any pending update, then schedule a new one
+    // Popup: if the country has no region (ocean, unmapped territory) clear
+    // immediately so the highlight and popup are never out of sync.
+    // Otherwise debounce so the card stays stable while the user moves to click it.
     if (popupDebounceRef.current) clearTimeout(popupDebounceRef.current);
-    popupDebounceRef.current = setTimeout(() => {
-      setPopupRegionInfo(info);
+    if (!info) {
+      setPopupRegionInfo(null);
       popupDebounceRef.current = null;
-    }, 220);
+    } else {
+      popupDebounceRef.current = setTimeout(() => {
+        setPopupRegionInfo(info);
+        popupDebounceRef.current = null;
+      }, 220);
+    }
   }
 
   function handleCountryLeave() {

--- a/web/src/lib/constants/salesRegions.ts
+++ b/web/src/lib/constants/salesRegions.ts
@@ -1,0 +1,444 @@
+/**
+ * BAPI Global Sales Regions
+ *
+ * 15 sales territories with regional managers, based on BAPI internal
+ * territory map (REV.26.1.0). Used to power the interactive world map
+ * hover experience: hovering a country highlights its entire BAPI region
+ * and surfaces the correct sales contact.
+ *
+ * Country names match Natural Earth 110m dataset (world-atlas@2) as used
+ * by react-simple-maps. Use geo.properties.name for lookups.
+ *
+ * Regions:
+ *  1  – North America          (Matt Holder)
+ *  2  – South America          (John Shields)
+ *  3  – Northern Europe        (John Shields)
+ *  4  – Western Europe         (Mike Moss)
+ *  5  – Eastern Europe         (Mike Moss)
+ *  6  – Southern Europe/Turkey (Jan Zurawski)
+ *  7  – West & Central Africa  (John Shields)
+ *  8  – East & Southern Africa (John Shields)
+ *  9  – Middle East & N. Africa(Murtaza Kalabhai)
+ * 10  – South Asia             (Murtaza Kalabhai)
+ * 11  – China & Mongolia       (Tim Wilder)
+ * 12  – East Asia              (Tim Wilder)
+ * 13  – Southeast Asia         (Tim Wilder)
+ * 14  – Australia & Pacific    (Andy Brooks)
+ * 15  – Russia & Central Asia  (John Shields)
+ */
+
+export interface SalesRep {
+  id: string;
+  name: string;
+  title: string;
+  email?: string;
+  phone?: string;
+  regions: number[];
+}
+
+export interface SalesRegion {
+  id: number;
+  name: string;
+  repId: string;
+  description: string;
+}
+
+export const SALES_REPS: SalesRep[] = [
+  {
+    id: 'matt-holder',
+    name: 'Matt Holder',
+    title: 'Business Development & Regional Sales',
+    regions: [1],
+  },
+  {
+    id: 'john-shields',
+    name: 'John Shields',
+    title: 'Business Development & Regional Sales',
+    regions: [2, 3, 7, 8, 15],
+  },
+  {
+    id: 'mike-moss',
+    name: 'Mike Moss',
+    title: 'Business Development & Regional Sales',
+    regions: [4, 5],
+  },
+  {
+    id: 'jan-zurawski',
+    name: 'Jan Zurawski',
+    title: 'Business Development & Regional Sales',
+    regions: [6],
+  },
+  {
+    id: 'murtaza-kalabhai',
+    name: 'Murtaza Kalabhai',
+    title: 'Business Development & Regional Sales',
+    regions: [9, 10],
+  },
+  {
+    id: 'tim-wilder',
+    name: 'Tim Wilder',
+    title: 'Business Development & Regional Sales',
+    regions: [11, 12, 13],
+  },
+  {
+    id: 'andy-brooks',
+    name: 'Andy Brooks',
+    title: 'Business Development & Regional Sales',
+    regions: [14],
+  },
+];
+
+export const SALES_REGIONS: SalesRegion[] = [
+  {
+    id: 1,
+    name: 'North America',
+    repId: 'matt-holder',
+    description: 'USA, Canada, Mexico & Caribbean',
+  },
+  {
+    id: 2,
+    name: 'South America',
+    repId: 'john-shields',
+    description: 'All South American countries',
+  },
+  {
+    id: 3,
+    name: 'Scandinavia & Baltic',
+    repId: 'john-shields',
+    description: 'Norway, Sweden, Finland, Denmark, Iceland, Greenland & Baltic States',
+  },
+  {
+    id: 4,
+    name: 'Western Europe',
+    repId: 'mike-moss',
+    description: 'UK, Ireland, France, Benelux, Spain & Portugal',
+  },
+  {
+    id: 5,
+    name: 'Central Europe',
+    repId: 'mike-moss',
+    description: 'Germany, Austria, Switzerland, Italy, Czech Republic, Slovakia & Slovenia',
+  },
+  {
+    id: 6,
+    name: 'Eastern Europe & Balkans',
+    repId: 'jan-zurawski',
+    description: 'Poland, Ukraine, Belarus, Hungary, Romania, Bulgaria & the Balkans',
+  },
+  {
+    id: 7,
+    name: 'West & Central Africa',
+    repId: 'john-shields',
+    description: 'West Africa, Central Africa & North Africa',
+  },
+  {
+    id: 8,
+    name: 'East & Southern Africa',
+    repId: 'john-shields',
+    description: 'East Africa, Southern Africa & Indian Ocean islands',
+  },
+  {
+    id: 9,
+    name: 'Middle East & Turkey',
+    repId: 'murtaza-kalabhai',
+    description: 'Turkey, Arabian Peninsula, Levant, Iran, Egypt & Caucasus',
+  },
+  {
+    id: 10,
+    name: 'South Asia',
+    repId: 'murtaza-kalabhai',
+    description: 'India, Pakistan, Bangladesh, Sri Lanka & Nepal',
+  },
+  {
+    id: 11,
+    name: 'China & Mongolia',
+    repId: 'tim-wilder',
+    description: 'China & Mongolia',
+  },
+  {
+    id: 12,
+    name: 'East Asia',
+    repId: 'tim-wilder',
+    description: 'Japan, South Korea, North Korea & Taiwan',
+  },
+  {
+    id: 13,
+    name: 'Southeast Asia',
+    repId: 'tim-wilder',
+    description: 'Vietnam, Thailand, Malaysia, Indonesia, Philippines & neighbors',
+  },
+  {
+    id: 14,
+    name: 'Australia & Pacific',
+    repId: 'andy-brooks',
+    description: 'Australia, New Zealand & Pacific Islands',
+  },
+  {
+    id: 15,
+    name: 'Russia & Kazakhstan',
+    repId: 'john-shields',
+    description: 'Russia & Kazakhstan',
+  },
+];
+
+/**
+ * Map from Natural Earth country name → BAPI region ID.
+ *
+ * Country names must match what react-simple-maps / world-atlas@2 exposes in
+ * `geo.properties.name`.  Uncommon variants are included as aliases.
+ */
+export const COUNTRY_TO_REGION: Record<string, number> = {
+  // ── Region 1: North America ──────────────────────────────────────────────
+  'United States of America': 1,
+  Canada: 1,
+  Mexico: 1,
+  Guatemala: 1,
+  Belize: 1,
+  Honduras: 1,
+  'El Salvador': 1,
+  Nicaragua: 1,
+  'Costa Rica': 1,
+  Panama: 1,
+  Cuba: 1,
+  Jamaica: 1,
+  Haiti: 1,
+  'Dominican Rep.': 1,
+  'Puerto Rico': 1,
+  'Trinidad and Tobago': 1,
+  Bahamas: 1,
+  Barbados: 1,
+  'Antigua and Barb.': 1,
+  'St. Kitts and Nevis': 1,
+  Grenada: 1,
+  'St. Vincent and the Grenadines': 1,
+  Dominica: 1,
+  'St. Lucia': 1,
+
+  // ── Region 2: South America ──────────────────────────────────────────────
+  Brazil: 2,
+  Argentina: 2,
+  Chile: 2,
+  Peru: 2,
+  Colombia: 2,
+  Venezuela: 2,
+  Bolivia: 2,
+  Ecuador: 2,
+  Paraguay: 2,
+  Uruguay: 2,
+  Guyana: 2,
+  Suriname: 2,
+  'Fr. Guiana': 2,
+  'Falkland Is.': 2,
+
+  // ── Region 3: Scandinavia, Baltic & Greenland ──────────────────────────────
+  Norway: 3,
+  Sweden: 3,
+  Finland: 3,
+  Denmark: 3,
+  Iceland: 3,
+  Greenland: 3,
+  Estonia: 3,
+  Latvia: 3,
+  Lithuania: 3,
+  'Faroe Is.': 3,
+
+  // ── Region 4: Western Europe (UK, Ireland, France, Iberia, Benelux) ───────
+  'United Kingdom': 4,
+  Ireland: 4,
+  France: 4,
+  Netherlands: 4,
+  Belgium: 4,
+  Luxembourg: 4,
+  Spain: 4,
+  Portugal: 4,
+  Andorra: 4,
+  Monaco: 4,
+
+  // ── Region 5: Central Europe (German-speaking + Italy cluster) ───────────
+  Germany: 5,
+  Austria: 5,
+  Switzerland: 5,
+  Liechtenstein: 5,
+  Italy: 5,
+  Slovenia: 5,
+  Czechia: 5,
+  'Czech Rep.': 5,
+  Slovakia: 5,
+
+  // ── Region 6: Eastern Europe & Balkans ────────────────────────────────────
+  Poland: 6,
+  Ukraine: 6,
+  Belarus: 6,
+  Moldova: 6,
+  Romania: 6,
+  Bulgaria: 6,
+  Hungary: 6,
+  Croatia: 6,
+  Serbia: 6,
+  'Bosnia and Herz.': 6,
+  Montenegro: 6,
+  'North Macedonia': 6,
+  Macedonia: 6,
+  Albania: 6,
+  Kosovo: 6,
+  Greece: 6,
+  Malta: 6,
+
+  // ── Region 7: West & Central Africa (incl. North Africa) ─────────────────
+  Morocco: 7,
+  Algeria: 7,
+  Tunisia: 7,
+  Libya: 7,
+  'W. Sahara': 7,
+  Mauritania: 7,
+  Mali: 7,
+  Niger: 7,
+  Chad: 7,
+  Senegal: 7,
+  Gambia: 7,
+  'Guinea-Bissau': 7,
+  Guinea: 7,
+  'Sierra Leone': 7,
+  Liberia: 7,
+  "Côte d'Ivoire": 7,
+  Ghana: 7,
+  Togo: 7,
+  Benin: 7,
+  Nigeria: 7,
+  Cameroon: 7,
+  Gabon: 7,
+  'Eq. Guinea': 7,
+  Congo: 7,
+  'Central African Rep.': 7,
+  'Burkina Faso': 7,
+  'Cape Verde': 7,
+  'São Tomé and Principe': 7,
+
+  // ── Region 8: East & Southern Africa ─────────────────────────────────────
+  'Dem. Rep. Congo': 8,
+  Sudan: 7,
+  'S. Sudan': 8,
+  Ethiopia: 8,
+  Eritrea: 8,
+  Djibouti: 8,
+  Somalia: 8,
+  Somaliland: 8,
+  Kenya: 8,
+  Uganda: 8,
+  Tanzania: 8,
+  Rwanda: 8,
+  Burundi: 8,
+  Zambia: 8,
+  Zimbabwe: 8,
+  Mozambique: 8,
+  Madagascar: 8,
+  Malawi: 8,
+  Botswana: 8,
+  Namibia: 8,
+  'South Africa': 8,
+  Lesotho: 8,
+  eSwatini: 8,
+  Swaziland: 8,
+  Angola: 8,
+  Comoros: 8,
+  Seychelles: 8,
+  Mauritius: 8,
+
+  // ── Region 9: Middle East, Turkey & Caucasus ────────────────────────────
+  Turkey: 9,
+  Cyprus: 9,
+  Egypt: 9,
+  'Saudi Arabia': 9,
+  Yemen: 9,
+  Oman: 9,
+  'United Arab Emirates': 9,
+  Qatar: 9,
+  Bahrain: 9,
+  Kuwait: 9,
+  Iraq: 9,
+  Iran: 9,
+  Israel: 9,
+  Palestine: 9,
+  Jordan: 9,
+  Lebanon: 9,
+  Syria: 9,
+  Afghanistan: 9,
+  // Caucasus
+  Georgia: 9,
+  Armenia: 9,
+  Azerbaijan: 9,
+  // Central Asian stans (dark red on map, not purple Russia zone)
+  Uzbekistan: 9,
+  Turkmenistan: 9,
+  Kyrgyzstan: 9,
+  Tajikistan: 9,
+
+  // ── Region 10: South Asia ─────────────────────────────────────────────────
+  India: 10,
+  Pakistan: 10,
+  Bangladesh: 10,
+  'Sri Lanka': 10,
+  Nepal: 10,
+  Bhutan: 10,
+  Maldives: 10,
+
+  // ── Region 11: China & Mongolia ───────────────────────────────────────────
+  China: 11,
+  Mongolia: 11,
+
+  // ── Region 12: East Asia ──────────────────────────────────────────────────
+  Japan: 12,
+  'S. Korea': 12,
+  'N. Korea': 12,
+  'South Korea': 12,
+  'North Korea': 12,
+  Taiwan: 12,
+
+  // ── Region 13: Southeast Asia ─────────────────────────────────────────────
+  Vietnam: 13,
+  Thailand: 13,
+  Malaysia: 13,
+  Singapore: 13,
+  Indonesia: 13,
+  Philippines: 13,
+  Myanmar: 13,
+  Cambodia: 13,
+  Laos: 13,
+  Brunei: 13,
+  'Timor-Leste': 13,
+  'East Timor': 13,
+
+  // ── Region 14: Australia & Pacific ───────────────────────────────────────
+  Australia: 14,
+  'New Zealand': 14,
+  'Papua New Guinea': 14,
+  'Solomon Is.': 14,
+  Vanuatu: 14,
+  Fiji: 14,
+  'New Caledonia': 14,
+
+  // ── Region 15: Russia & Kazakhstan ─────────────────────────────────────
+  Russia: 15,
+  Kazakhstan: 15,
+};
+
+/** Look up a SalesRep by their id. */
+export function getSalesRep(repId: string): SalesRep | undefined {
+  return SALES_REPS.find((r) => r.id === repId);
+}
+
+/** Look up a SalesRegion and its SalesRep for a given Natural Earth country name. */
+export function getRegionForCountry(
+  countryName: string,
+): { region: SalesRegion; rep: SalesRep } | null {
+  const regionId = COUNTRY_TO_REGION[countryName];
+  if (!regionId) return null;
+
+  const region = SALES_REGIONS.find((r) => r.id === regionId);
+  if (!region) return null;
+
+  const rep = getSalesRep(region.repId);
+  if (!rep) return null;
+
+  return { region, rep };
+}

--- a/web/src/lib/constants/salesRegions.ts
+++ b/web/src/lib/constants/salesRegions.ts
@@ -12,19 +12,19 @@
  * Regions:
  *  1  – North America          (Matt Holder)
  *  2  – South America          (John Shields)
- *  3  – Northern Europe        (John Shields)
+ *  3  – Scandinavia & Baltic   (John Shields)
  *  4  – Western Europe         (Mike Moss)
- *  5  – Eastern Europe         (Mike Moss)
- *  6  – Southern Europe/Turkey (Jan Zurawski)
+ *  5  – Central Europe         (Mike Moss)
+ *  6  – Eastern Europe/Balkans (Jan Zurawski)
  *  7  – West & Central Africa  (John Shields)
  *  8  – East & Southern Africa (John Shields)
- *  9  – Middle East & N. Africa(Murtaza Kalabhai)
+ *  9  – Middle East & Turkey   (Murtaza Kalabhai)
  * 10  – South Asia             (Murtaza Kalabhai)
  * 11  – China & Mongolia       (Tim Wilder)
  * 12  – East Asia              (Tim Wilder)
  * 13  – Southeast Asia         (Tim Wilder)
  * 14  – Australia & Pacific    (Andy Brooks)
- * 15  – Russia & Central Asia  (John Shields)
+ * 15  – Russia & Kazakhstan    (John Shields)
  */
 
 export interface SalesRep {
@@ -129,7 +129,7 @@ export const SALES_REGIONS: SalesRegion[] = [
     id: 7,
     name: 'West & Central Africa',
     repId: 'john-shields',
-    description: 'West Africa, Central Africa & North Africa',
+    description: 'West & Central Africa (Morocco, Algeria, Libya & sub-Saharan west)',
   },
   {
     id: 8,
@@ -313,10 +313,10 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   'Burkina Faso': 7,
   'Cape Verde': 7,
   'São Tomé and Principe': 7,
+  Sudan: 7,
 
   // ── Region 8: East & Southern Africa ─────────────────────────────────────
   'Dem. Rep. Congo': 8,
-  Sudan: 7,
   'S. Sudan': 8,
   Ethiopia: 8,
   Eritrea: 8,
@@ -427,6 +427,18 @@ export function getSalesRep(repId: string): SalesRep | undefined {
   return SALES_REPS.find((r) => r.id === repId);
 }
 
+/**
+ * Precomputed O(1) lookup maps — built once at module load so per-render calls
+ * in GlobalPresence (called for every geography on every hover) stay fast.
+ */
+const REGION_BY_ID = new Map<number, SalesRegion>(
+  SALES_REGIONS.map((r) => [r.id, r]),
+);
+
+const REP_BY_ID = new Map<string, SalesRep>(
+  SALES_REPS.map((r) => [r.id, r]),
+);
+
 /** Look up a SalesRegion and its SalesRep for a given Natural Earth country name. */
 export function getRegionForCountry(
   countryName: string,
@@ -434,10 +446,10 @@ export function getRegionForCountry(
   const regionId = COUNTRY_TO_REGION[countryName];
   if (!regionId) return null;
 
-  const region = SALES_REGIONS.find((r) => r.id === regionId);
+  const region = REGION_BY_ID.get(regionId);
   if (!region) return null;
 
-  const rep = getSalesRep(region.repId);
+  const rep = REP_BY_ID.get(region.repId);
   if (!rep) return null;
 
   return { region, rep };


### PR DESCRIPTION
- Add salesRegions.ts with all 15 BAPI sales territories, 7 regional reps, and a country-to-region mapping covering ~150 countries (Natural Earth names)
- Update GlobalPresence to highlight entire BAPI region on country hover and display the correct sales rep in an in-map popup (bottom-right corner)
- Split hover state: immediate map highlight + 220ms debounced popup so the card stays stable while users move to click it
- Cancel debounce on popup mouseenter so content freezes on arrival
- Migrate onMouseLeave to card container (not per-country) to prevent popup disappearing when moving from map to panel
- Add interaction hint label that fades when a region is active
- Add mobile fallback note linking to /contact page
- Ignore internal BAPI PDF maps via docs/*.pdf in .gitignore
- Correct all 15 region assignments to match REV.26.1.0 territory map: UK/Ireland → region 4, Germany/Italy/Slovenia → region 5, Poland/Ukraine/Balkans → region 6, Turkey/Caucasus/Central Asia → region 9, DRC → region 8, Sudan → region 7, Kazakhstan only → region 15


