### PR TITLE
feat: static individual sales rep contact pages

### DIFF
--- a/web/src/app/[locale]/contact/[slug]/page.tsx
+++ b/web/src/app/[locale]/contact/[slug]/page.tsx
@@ -165,13 +165,28 @@ export default async function ContactRepPage({ params }: Props) {
             {/* Bio section — pulled from WordPress at build time */}
             {bio && bio.bioParagraphs.length > 0 && (
               <div className="mt-10 border-t border-neutral-100 pt-8">
-                <h2 className="mb-5 text-xl font-bold text-neutral-900">About {member.name}</h2>
+                {/* Section heading with BAPI accent bar */}
+                <div className="mb-6 flex items-center gap-3">
+                  <div className="h-7 w-1 rounded-full bg-accent-500" />
+                  <h2 className="text-xl font-bold text-neutral-900">About {member.name}</h2>
+                </div>
+
                 <div className="space-y-4">
-                  {bio.bioParagraphs.map((paragraph, i) => (
-                    <p key={i} className="text-base leading-relaxed text-neutral-700">
-                      {paragraph}
-                    </p>
-                  ))}
+                  {bio.bioParagraphs.map((paragraph, i) =>
+                    i === 0 ? (
+                      /* Lead paragraph — slightly larger, primary colour, left-border accent */
+                      <p
+                        key={i}
+                        className="border-l-4 border-primary-200 pl-4 text-[1.05rem] font-medium leading-relaxed text-primary-800"
+                      >
+                        {paragraph}
+                      </p>
+                    ) : (
+                      <p key={i} className="text-base leading-relaxed text-neutral-600">
+                        {paragraph}
+                      </p>
+                    )
+                  )}
                 </div>
               </div>
             )}

--- a/web/src/app/[locale]/contact/[slug]/page.tsx
+++ b/web/src/app/[locale]/contact/[slug]/page.tsx
@@ -1,0 +1,183 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { getContactRepBio } from '@/lib/wordpress';
+import { ALL_TEAM_MEMBERS } from '@/lib/constants/team';
+import {
+  PhoneIcon,
+  MailIcon,
+  MapPinIcon,
+  ArrowLeftIcon,
+  BuildingIcon,
+} from '@/lib/icons';
+
+interface Props {
+  params: Promise<{ locale: string; slug: string }>;
+}
+
+/** Pre-build a static page for every known team member at deploy time. */
+export async function generateStaticParams() {
+  return ALL_TEAM_MEMBERS.map((member) => ({ slug: member.slug }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const member = ALL_TEAM_MEMBERS.find((m) => m.slug === slug);
+  if (!member) return {};
+
+  const bio = await getContactRepBio(slug);
+  const description =
+    bio?.bioParagraphs[0]?.slice(0, 155) ??
+    `Contact ${member.name}, ${member.title} at BAPI Sensors.`;
+
+  return {
+    title: `Contact ${member.name} — BAPI`,
+    description,
+  };
+}
+
+export default async function ContactRepPage({ params }: Props) {
+  const { locale, slug } = await params;
+  const member = ALL_TEAM_MEMBERS.find((m) => m.slug === slug);
+
+  if (!member) {
+    notFound();
+  }
+
+  // Fetch bio from WordPress at build time (SSG + ISR)
+  const bio = await getContactRepBio(slug);
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      {/* Breadcrumb */}
+      <div className="border-b border-neutral-200 bg-white">
+        <div className="mx-auto max-w-5xl px-4 py-3 sm:px-6 lg:px-8">
+          <nav aria-label="Breadcrumb" className="flex items-center gap-2 text-sm text-neutral-500">
+            <Link href={`/${locale}`} className="hover:text-primary-600">
+              Home
+            </Link>
+            <span>/</span>
+            <Link href={`/${locale}/contact`} className="hover:text-primary-600">
+              Contact
+            </Link>
+            <span>/</span>
+            <span className="text-neutral-900">{member.name}</span>
+          </nav>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-5xl px-4 py-10 sm:px-6 lg:px-8">
+        {/* Back link */}
+        <Link
+          href={`/${locale}/contact`}
+          className="mb-8 inline-flex items-center gap-2 text-sm font-medium text-primary-600 hover:text-primary-700"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          Back to Sales Team
+        </Link>
+
+        <div className="overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-sm">
+          {/* Top colour bar */}
+          <div className="h-2 bg-gradient-to-r from-primary-600 to-primary-500" />
+
+          <div className="p-6 sm:p-8 lg:p-10">
+            {/* Hero row: photo + key info */}
+            <div className="flex flex-col gap-8 sm:flex-row sm:items-start">
+              {/* Photo */}
+              <div className="mx-auto w-48 flex-shrink-0 sm:mx-0 sm:w-56">
+                <div className="relative aspect-[3/4] w-full overflow-hidden rounded-xl bg-neutral-100 shadow-md">
+                  <Image
+                    src={member.photo}
+                    alt={member.name}
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 640px) 192px, 224px"
+                    priority
+                  />
+                </div>
+              </div>
+
+              {/* Info */}
+              <div className="flex-1">
+                <h1 className="mb-1 text-3xl font-extrabold text-primary-700">{member.name}</h1>
+                <p className="mb-4 text-base font-semibold text-neutral-700">{member.title}</p>
+
+                <div className="mb-6 flex items-center gap-2">
+                  <MapPinIcon className="h-4 w-4 flex-shrink-0 text-accent-500" />
+                  <span className="rounded-full border border-primary-200 bg-primary-50 px-3 py-1 text-xs font-bold text-primary-700">
+                    {member.region}
+                  </span>
+                </div>
+
+                {/* Contact details */}
+                <div className="mb-6 space-y-3">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-50">
+                      <PhoneIcon className="h-4 w-4 text-primary-600" />
+                    </div>
+                    <a
+                      href={`tel:${member.phone.replace(/[^0-9+]/g, '')}`}
+                      className="text-sm font-medium text-primary-600 hover:text-primary-700"
+                    >
+                      {member.phone}
+                    </a>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-50">
+                      <MailIcon className="h-4 w-4 text-primary-600" />
+                    </div>
+                    <a
+                      href={`mailto:${member.email}`}
+                      className="text-sm font-medium text-primary-600 hover:text-primary-700"
+                    >
+                      {member.email}
+                    </a>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-primary-50">
+                      <BuildingIcon className="h-4 w-4 text-primary-600" />
+                    </div>
+                    <span className="text-sm text-neutral-700">BAPI — Building Automation Products</span>
+                  </div>
+                </div>
+
+                {/* CTA buttons */}
+                <div className="flex flex-wrap gap-3">
+                  <a
+                    href={`mailto:${member.email}`}
+                    className="inline-flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-700"
+                  >
+                    <MailIcon className="h-4 w-4" />
+                    Send Email
+                  </a>
+                  <a
+                    href={`tel:${member.phone.replace(/[^0-9+]/g, '')}`}
+                    className="inline-flex items-center gap-2 rounded-lg border-2 border-accent-500 bg-accent-500 px-5 py-2.5 text-sm font-semibold text-neutral-900 shadow-sm transition-colors hover:bg-accent-600"
+                  >
+                    <PhoneIcon className="h-4 w-4" />
+                    Call Now
+                  </a>
+                </div>
+              </div>
+            </div>
+
+            {/* Bio section — pulled from WordPress at build time */}
+            {bio && bio.bioParagraphs.length > 0 && (
+              <div className="mt-10 border-t border-neutral-100 pt-8">
+                <h2 className="mb-5 text-xl font-bold text-neutral-900">About {member.name}</h2>
+                <div className="space-y-4">
+                  {bio.bioParagraphs.map((paragraph, i) => (
+                    <p key={i} className="text-base leading-relaxed text-neutral-700">
+                      {paragraph}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/[locale]/contact/page.tsx
+++ b/web/src/app/[locale]/contact/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
 import {
   PhoneIcon,
   MailIcon,
@@ -15,212 +16,23 @@ import {
   HeadphonesIcon,
 } from '@/lib/icons';
 import SalesTeamCard from '@/components/contact/SalesTeamCard';
-
-// Sales team data - Photos go in /public/images/team/
-interface SalesRep {
-  name: string;
-  title: string;
-  region: string;
-  email: string;
-  phone: string;
-  photo: string;
-  video?: string;
-}
-
-// Organized by geographic regions
-const northAmericaTeam: SalesRep[] = [
-  {
-    name: 'Matt Holder',
-    title: 'Business Development & Regional Sales Manager',
-    region: 'North America',
-    email: 'mholder@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/matt-holder.webp',
-  },
-  {
-    name: 'Steve Lindquist',
-    title: 'Key Account Specialist',
-    region: 'North America',
-    email: 'slindquist@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/steve-lindquist.webp',
-  },
-  {
-    name: 'Todd Vanden Heuvel',
-    title: 'Key Account Specialist',
-    region: 'North America',
-    email: 'tvandenheuvel@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/todd-vanden-heuvel.webp',
-  },
-  {
-    name: 'Mitchell Ogorman',
-    title: 'Key Account Specialist',
-    region: 'North America',
-    email: 'mogorman@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/mitchell-ogorman.webp',
-  },
-  {
-    name: 'Jennifer Sanford',
-    title: 'Key Account Specialist',
-    region: 'North America',
-    email: 'jsanford@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/jennifer-sanford.webp',
-  },
-  {
-    name: 'Jon Greenwald',
-    title: 'Distribution Accounts Leader',
-    region: 'North America',
-    email: 'jgreenwald@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/jon-greenwald.webp',
-    video: 'https://www.youtube.com/embed/iBeUe3OGrk4',
-  },
-  {
-    name: 'Brian Thaldorf',
-    title: 'Distribution Account Specialist',
-    region: 'North America',
-    email: 'bthaldorf@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/brian-thaldorf.webp',
-  },
-  {
-    name: 'Reggie Saucke',
-    title: 'HVAC Sensor Sales',
-    region: 'North America',
-    email: 'rsaucke@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/reggie-saucke.webp',
-  },
-  {
-    name: 'Jacob Benson',
-    title: 'HVAC Sensor Sales',
-    region: 'North America',
-    email: 'jbenson@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/jacob-benson.webp',
-  },
-];
-
-const ukTeam: SalesRep[] = [
-  {
-    name: 'Mike Moss',
-    title: 'Business Development & Regional Sales Manager',
-    region: 'UK & Western Europe',
-    email: 'mmoss@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/mike-moss.webp',
-  },
-];
-
-const europeTeam: SalesRep[] = [
-  {
-    name: 'Jan Zurawski',
-    title: 'Regional Business Development & Operations Manager',
-    region: 'Central & Eastern Europe',
-    email: 'jzurawski@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/jan-zurawski.webp',
-    video: 'https://www.youtube.com/embed/O5jwFOFAO0A',
-  },
-];
-
-const middleEastTeam: SalesRep[] = [
-  {
-    name: 'Murtaza Kalabhai',
-    title: 'Regional Sales Manager',
-    region: 'Middle East & India',
-    email: 'mkalabhai@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/murtaza-kalabhai.webp',
-  },
-];
-
-const indiaTeam: SalesRep[] = [
-  {
-    name: 'Sharad Thakur',
-    title: 'North India Sales Manager',
-    region: 'India',
-    email: 'sharad@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/sharad-thakur.webp',
-  },
-  {
-    name: 'Shyam Krishnareddygari',
-    title: 'South India Sales Manager',
-    region: 'India',
-    email: 'shyam@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/shyam-krishnareddygari.webp',
-  },
-];
-
-const southAmericaTeam: SalesRep[] = [
-  {
-    name: 'John Shields',
-    title: 'Business Development & Regional Sales Manager',
-    region: 'Africa, South America, Middle East, India, Scandinavia',
-    email: 'jshields@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/john-shields.webp',
-  },
-];
-
-const africaTeam: SalesRep[] = [
-  {
-    name: 'John Shields',
-    title: 'Business Development & Regional Sales Manager',
-    region: 'Africa, South America, Middle East, India, Scandinavia',
-    email: 'jshields@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/john-shields.webp',
-  },
-];
-
-const asiaTeam: SalesRep[] = [
-  {
-    name: 'Tim Wilder',
-    title: 'Director of Research & Development',
-    region: 'Asia',
-    email: 'twilder@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/tim-wilder.webp',
-  },
-];
-
-const australiaTeam: SalesRep[] = [
-  {
-    name: 'Andy Brooks',
-    title: 'Business Development & Regional Sales Manager',
-    region: 'Australia & New Zealand',
-    email: 'abrooks@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/andy-brooks.webp',
-  },
-];
-
-const technicalTeam: SalesRep[] = [
-  {
-    name: 'Jonathan Hillebrand',
-    title: 'Senior Product Manager',
-    region: 'Technical Support',
-    email: 'jhillebrand@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/jonathan-hillebrand.webp',
-  },
-  {
-    name: 'Don Clark',
-    title: 'RMA & Technical Service Manager',
-    region: 'Technical Support',
-    email: 'dclark@bapihvac.com',
-    phone: '(800) 553-3027',
-    photo: '/images/team/donald-clark.webp',
-  },
-];
+import {
+  northAmericaTeam,
+  ukTeam,
+  europeTeam,
+  middleEastTeam,
+  indiaTeam,
+  southAmericaTeam,
+  africaTeam,
+  asiaTeam,
+  australiaTeam,
+  technicalTeam,
+} from '@/lib/constants/team';
 
 export default function ContactPage() {
+  const params = useParams<{ locale: string }>();
+  const locale = params?.locale ?? 'en';
+
   // Mobile accordion state - tracks which sections are expanded
   const [expandedSections, setExpandedSections] = useState<Set<string>>(
     new Set(['north-america']) // North America expanded by default
@@ -706,6 +518,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -744,6 +557,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -782,6 +596,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -820,6 +635,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -858,6 +674,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -896,6 +713,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -934,6 +752,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -972,6 +791,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -1010,6 +830,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>
@@ -1048,6 +869,7 @@ export default function ContactPage() {
                   phone={member.phone}
                   photo={member.photo}
                   video={member.video}
+                  profileHref={`/${locale}/contact/${member.slug}`}
                 />
               ))}
             </div>

--- a/web/src/components/company/GlobalPresence.tsx
+++ b/web/src/components/company/GlobalPresence.tsx
@@ -375,7 +375,7 @@ export function GlobalPresence({
                       </div>
                     )}
                     <Link
-                      href="/contact"
+                      href={`/contact/${popupRegionInfo.rep.id}`}
                       className="mt-3 flex w-full items-center justify-center gap-1.5 rounded-lg bg-primary-600 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-primary-700"
                     >
                       Contact {popupRegionInfo.rep.name.split(' ')[0]}

--- a/web/src/components/contact/SalesTeamCard.tsx
+++ b/web/src/components/contact/SalesTeamCard.tsx
@@ -133,7 +133,7 @@ export default function SalesTeamCard({
             <a
               href={`mailto:${email}`}
               className={`flex transform items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold shadow-md transition-all duration-300 hover:scale-105 hover:shadow-xl ${profileHref ? 'h-11 w-12 border-2 border-primary-600 bg-white text-primary-700 hover:bg-primary-50' : 'flex-1 bg-gradient-to-r from-primary-600 to-primary-700 text-white hover:from-primary-700 hover:to-primary-800'}`}
-              title={`Email ${name}`}
+              aria-label={`Email ${name}`}
             >
               <MailIcon className="h-4 w-4" />
               {!profileHref && 'Email'}
@@ -141,7 +141,7 @@ export default function SalesTeamCard({
             <a
               href={`tel:${phone.replace(/[^0-9+]/g, '')}`}
               className="flex h-11 w-12 transform items-center justify-center rounded-lg border-2 border-accent-600 bg-accent-500 text-neutral-900 shadow-md transition-all duration-300 hover:scale-105 hover:bg-accent-600 hover:shadow-xl"
-              title={`Call ${name}`}
+              aria-label={`Call ${name}`}
             >
               <PhoneIcon className="h-4 w-4" />
             </a>

--- a/web/src/components/contact/SalesTeamCard.tsx
+++ b/web/src/components/contact/SalesTeamCard.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from 'react';
 import Image from 'next/image';
-import { MailIcon, PhoneIcon, PlayIcon, XIcon, MapPinIcon, BriefcaseIcon } from '@/lib/icons';
+import Link from 'next/link';
+import { MailIcon, PhoneIcon, PlayIcon, XIcon, MapPinIcon, BriefcaseIcon, UserIcon } from '@/lib/icons';
 
 interface SalesTeamCardProps {
   name: string;
@@ -12,6 +13,7 @@ interface SalesTeamCardProps {
   phone: string;
   photo: string;
   video?: string; // Optional YouTube embed URL
+  profileHref?: string; // Optional link to individual contact page
 }
 
 /**
@@ -29,6 +31,7 @@ export default function SalesTeamCard({
   phone,
   photo,
   video,
+  profileHref,
 }: SalesTeamCardProps) {
   const [imageSrc, setImageSrc] = useState(photo);
   const [showVideoModal, setShowVideoModal] = useState(false);
@@ -118,13 +121,22 @@ export default function SalesTeamCard({
 
           {/* Contact Buttons */}
           <div className="flex gap-2">
+            {profileHref && (
+              <Link
+                href={profileHref}
+                className="flex flex-1 transform items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-primary-600 to-primary-700 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all duration-300 hover:scale-105 hover:from-primary-700 hover:to-primary-800 hover:shadow-xl"
+              >
+                <UserIcon className="h-4 w-4" />
+                Contact
+              </Link>
+            )}
             <a
               href={`mailto:${email}`}
-              className="flex flex-1 transform items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-primary-600 to-primary-700 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all duration-300 hover:scale-105 hover:from-primary-700 hover:to-primary-800 hover:shadow-xl"
+              className={`flex transform items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-semibold shadow-md transition-all duration-300 hover:scale-105 hover:shadow-xl ${profileHref ? 'h-11 w-12 border-2 border-primary-600 bg-white text-primary-700 hover:bg-primary-50' : 'flex-1 bg-gradient-to-r from-primary-600 to-primary-700 text-white hover:from-primary-700 hover:to-primary-800'}`}
               title={`Email ${name}`}
             >
               <MailIcon className="h-4 w-4" />
-              Email
+              {!profileHref && 'Email'}
             </a>
             <a
               href={`tel:${phone.replace(/[^0-9+]/g, '')}`}

--- a/web/src/lib/constants/team.ts
+++ b/web/src/lib/constants/team.ts
@@ -232,24 +232,23 @@ export const technicalTeam: TeamMember[] = [
   },
 ];
 
-/** All team members with a WordPress contact page — used for generateStaticParams */
-export const ALL_TEAM_MEMBERS: TeamMember[] = [
-  ...northAmericaTeam,
-  ...ukTeam,
-  ...europeTeam,
-  ...middleEastTeam,
-  ...indiaTeam,
-  // Deduplicate John Shields who appears in multiple regional groups
-  {
-    slug: 'john-shields',
-    name: 'John Shields',
-    title: 'Business Development & Regional Sales Manager',
-    region: 'Africa, South America, Middle East, India, Scandinavia',
-    email: 'jshields@bapihvac.com',
-    phone: '+1-800-553-3027',
-    photo: '/images/team/john-shields.webp',
-  },
-  ...asiaTeam,
-  ...australiaTeam,
-  ...technicalTeam,
-];
+/** All team members with a WordPress contact page — used for generateStaticParams.
+ * Built from all regional arrays and deduplicated by slug so adding a rep to any
+ * group is sufficient — no manual maintenance of this list required.
+ */
+export const ALL_TEAM_MEMBERS: TeamMember[] = Array.from(
+  new Map(
+    [
+      ...northAmericaTeam,
+      ...ukTeam,
+      ...europeTeam,
+      ...middleEastTeam,
+      ...indiaTeam,
+      ...southAmericaTeam,
+      ...africaTeam,
+      ...asiaTeam,
+      ...australiaTeam,
+      ...technicalTeam,
+    ].map((m) => [m.slug, m]),
+  ).values(),
+);

--- a/web/src/lib/constants/team.ts
+++ b/web/src/lib/constants/team.ts
@@ -1,0 +1,255 @@
+/**
+ * BAPI Sales & Technical Team data
+ *
+ * Single source of truth for all team members shown on /contact and
+ * individual /contact/[slug] pages. Photos live in /public/images/team/.
+ *
+ * slug      – headless URL segment: /contact/matt-holder
+ *             The WordPress page slug is always "contact-{slug}"
+ * wpSlug    – derived at runtime: `contact-${slug}` — do NOT store separately
+ */
+
+export interface TeamMember {
+  slug: string;
+  name: string;
+  title: string;
+  region: string;
+  email: string;
+  phone: string;
+  photo: string;
+  video?: string;
+}
+
+export const northAmericaTeam: TeamMember[] = [
+  {
+    slug: 'matt-holder',
+    name: 'Matt Holder',
+    title: 'Business Development & Regional Sales Manager',
+    region: 'North America',
+    email: 'mholder@bapihvac.com',
+    phone: '+1-608-735-4800',
+    photo: '/images/team/matt-holder.webp',
+  },
+  {
+    slug: 'steve-lindquist',
+    name: 'Steve Lindquist',
+    title: 'Key Account Specialist',
+    region: 'North America',
+    email: 'slindquist@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/steve-lindquist.webp',
+  },
+  {
+    slug: 'todd-vanden-heuvel',
+    name: 'Todd Vanden Heuvel',
+    title: 'Key Account Specialist',
+    region: 'North America',
+    email: 'tvandenheuvel@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/todd-vanden-heuvel.webp',
+  },
+  {
+    slug: 'mitchell-ogorman',
+    name: 'Mitchell Ogorman',
+    title: 'Key Account Specialist',
+    region: 'North America',
+    email: 'mogorman@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/mitchell-ogorman.webp',
+  },
+  {
+    slug: 'jennifer-sanford',
+    name: 'Jennifer Sanford',
+    title: 'Key Account Specialist',
+    region: 'North America',
+    email: 'jsanford@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/jennifer-sanford.webp',
+  },
+  {
+    slug: 'jon-greenwald',
+    name: 'Jon Greenwald',
+    title: 'Distribution Accounts Leader',
+    region: 'North America',
+    email: 'jgreenwald@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/jon-greenwald.webp',
+    video: 'https://www.youtube.com/embed/iBeUe3OGrk4',
+  },
+  {
+    slug: 'brian-thaldorf',
+    name: 'Brian Thaldorf',
+    title: 'Distribution Account Specialist',
+    region: 'North America',
+    email: 'bthaldorf@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/brian-thaldorf.webp',
+  },
+  {
+    slug: 'reggie-saucke',
+    name: 'Reggie Saucke',
+    title: 'HVAC Sensor Sales',
+    region: 'North America',
+    email: 'rsaucke@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/reggie-saucke.webp',
+  },
+  {
+    slug: 'jacob-benson',
+    name: 'Jacob Benson',
+    title: 'HVAC Sensor Sales',
+    region: 'North America',
+    email: 'jbenson@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/jacob-benson.webp',
+  },
+];
+
+export const ukTeam: TeamMember[] = [
+  {
+    slug: 'mike-moss',
+    name: 'Mike Moss',
+    title: 'Business Development & Regional Sales Manager',
+    region: 'UK & Western Europe',
+    email: 'mmoss@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/mike-moss.webp',
+  },
+];
+
+export const europeTeam: TeamMember[] = [
+  {
+    slug: 'jan-zurawski',
+    name: 'Jan Zurawski',
+    title: 'Regional Business Development & Operations Manager',
+    region: 'Central & Eastern Europe',
+    email: 'jzurawski@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/jan-zurawski.webp',
+    video: 'https://www.youtube.com/embed/O5jwFOFAO0A',
+  },
+];
+
+export const middleEastTeam: TeamMember[] = [
+  {
+    slug: 'murtaza-kalabhai',
+    name: 'Murtaza Kalabhai',
+    title: 'Regional Sales Manager',
+    region: 'Middle East & India',
+    email: 'mkalabhai@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/murtaza-kalabhai.webp',
+  },
+];
+
+export const indiaTeam: TeamMember[] = [
+  {
+    slug: 'sharad-thakur',
+    name: 'Sharad Thakur',
+    title: 'North India Sales Manager',
+    region: 'India',
+    email: 'sharad@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/sharad-thakur.webp',
+  },
+  {
+    slug: 'shyam-krishnareddygari',
+    name: 'Shyam Krishnareddygari',
+    title: 'South India Sales Manager',
+    region: 'India',
+    email: 'shyam@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/shyam-krishnareddygari.webp',
+  },
+];
+
+export const southAmericaTeam: TeamMember[] = [
+  {
+    slug: 'john-shields',
+    name: 'John Shields',
+    title: 'Business Development & Regional Sales Manager',
+    region: 'Africa, South America, Middle East, India, Scandinavia',
+    email: 'jshields@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/john-shields.webp',
+  },
+];
+
+export const africaTeam: TeamMember[] = [
+  {
+    slug: 'john-shields',
+    name: 'John Shields',
+    title: 'Business Development & Regional Sales Manager',
+    region: 'Africa, South America, Middle East, India, Scandinavia',
+    email: 'jshields@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/john-shields.webp',
+  },
+];
+
+export const asiaTeam: TeamMember[] = [
+  {
+    slug: 'tim-wilder',
+    name: 'Tim Wilder',
+    title: 'Director of Research & Development',
+    region: 'Asia',
+    email: 'twilder@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/tim-wilder.webp',
+  },
+];
+
+export const australiaTeam: TeamMember[] = [
+  {
+    slug: 'andy-brooks',
+    name: 'Andy Brooks',
+    title: 'Business Development & Regional Sales Manager',
+    region: 'Australia & New Zealand',
+    email: 'abrooks@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/andy-brooks.webp',
+  },
+];
+
+export const technicalTeam: TeamMember[] = [
+  {
+    slug: 'jonathan-hillebrand',
+    name: 'Jonathan Hillebrand',
+    title: 'Senior Product Manager',
+    region: 'Technical Support',
+    email: 'jhillebrand@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/jonathan-hillebrand.webp',
+  },
+  {
+    slug: 'don-clark',
+    name: 'Don Clark',
+    title: 'RMA & Technical Service Manager',
+    region: 'Technical Support',
+    email: 'dclark@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/donald-clark.webp',
+  },
+];
+
+/** All team members with a WordPress contact page — used for generateStaticParams */
+export const ALL_TEAM_MEMBERS: TeamMember[] = [
+  ...northAmericaTeam,
+  ...ukTeam,
+  ...europeTeam,
+  ...middleEastTeam,
+  ...indiaTeam,
+  // Deduplicate John Shields who appears in multiple regional groups
+  {
+    slug: 'john-shields',
+    name: 'John Shields',
+    title: 'Business Development & Regional Sales Manager',
+    region: 'Africa, South America, Middle East, India, Scandinavia',
+    email: 'jshields@bapihvac.com',
+    phone: '+1-800-553-3027',
+    photo: '/images/team/john-shields.webp',
+  },
+  ...asiaTeam,
+  ...australiaTeam,
+  ...technicalTeam,
+];

--- a/web/src/lib/graphql/generated.ts
+++ b/web/src/lib/graphql/generated.ts
@@ -62,6 +62,27 @@ export type AddCartItemsPayload = {
   clientMutationId?: Maybe<Scalars['String']['output']>;
 };
 
+/** Input for the addFavorite mutation. */
+export type AddFavoriteInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  productId: Scalars['String']['input'];
+  productImage?: InputMaybe<Scalars['String']['input']>;
+  productName: Scalars['String']['input'];
+  productPrice?: InputMaybe<Scalars['String']['input']>;
+  productSlug: Scalars['String']['input'];
+};
+
+/** The payload for the addFavorite mutation. */
+export type AddFavoritePayload = {
+  __typename?: 'AddFavoritePayload';
+  alreadyExists?: Maybe<Scalars['Boolean']['output']>;
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  favorite?: Maybe<BapiFavorite>;
+  success?: Maybe<Scalars['Boolean']['output']>;
+};
+
 /** Input for the addFee mutation. */
 export type AddFeeInput = {
   /** Fee amount */
@@ -1475,6 +1496,25 @@ export type BapiCustomTemplateSettings_Fields = {
    * @deprecated Use __typename instead
    */
   fieldGroupName?: Maybe<Scalars['String']['output']>;
+};
+
+/** A BAPI saved product favorite */
+export type BapiFavorite = {
+  __typename?: 'BapiFavorite';
+  /** ISO 8601 creation timestamp */
+  createdAt?: Maybe<Scalars['String']['output']>;
+  /** Unique favorite ID */
+  id?: Maybe<Scalars['String']['output']>;
+  /** WordPress product database ID */
+  productId?: Maybe<Scalars['String']['output']>;
+  /** Product image URL */
+  productImage?: Maybe<Scalars['String']['output']>;
+  /** Product display name */
+  productName?: Maybe<Scalars['String']['output']>;
+  /** Product price string */
+  productPrice?: Maybe<Scalars['String']['output']>;
+  /** Product URL slug */
+  productSlug?: Maybe<Scalars['String']['output']>;
 };
 
 /** The cart object */
@@ -3065,6 +3105,29 @@ export type Connection = {
   nodes: Array<Node>;
   /** Information about pagination in a connection. */
   pageInfo: PageInfo;
+};
+
+/** The &quot;ContactRepProfile&quot; Field Group. Added to the Schema by &quot;WPGraphQL for ACF&quot;. */
+export type ContactRepProfile = AcfFieldGroup & AcfFieldGroupFields & ContactRepProfile_Fields & {
+  __typename?: 'ContactRepProfile';
+  /** Field of the &quot;textarea&quot; Field Type added to the schema as part of the &quot;ContactRepProfile&quot; Field Group */
+  bio?: Maybe<Scalars['String']['output']>;
+  /**
+   * The name of the field group
+   * @deprecated Use __typename instead
+   */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
+};
+
+/** Interface representing fields of the ACF &quot;ContactRepProfile&quot; Field Group */
+export type ContactRepProfile_Fields = {
+  /** Field of the &quot;textarea&quot; Field Type added to the schema as part of the &quot;ContactRepProfile&quot; Field Group */
+  bio?: Maybe<Scalars['String']['output']>;
+  /**
+   * The name of the field group
+   * @deprecated Use __typename instead
+   */
+  fieldGroupName?: Maybe<Scalars['String']['output']>;
 };
 
 /** Base interface for content objects like posts, pages, and media items. Provides common fields available across these content types. */
@@ -19541,7 +19604,7 @@ export type PaWirelessApplicationToTaxonomyConnectionEdge = Edge & OneToOneConne
 };
 
 /** A standalone content entry generally used for static, non-chronological content such as &quot;About Us&quot; or &quot;Contact&quot; pages. */
-export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & HierarchicalNode & MenuItemLinkable & Node & NodeWithAuthor & NodeWithComments & NodeWithContentEditor & NodeWithFeaturedImage & NodeWithPageAttributes & NodeWithRevisions & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & WithAcfPageOptions & {
+export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & HierarchicalNode & MenuItemLinkable & Node & NodeWithAuthor & NodeWithComments & NodeWithContentEditor & NodeWithFeaturedImage & NodeWithPageAttributes & NodeWithRevisions & NodeWithTemplate & NodeWithTitle & Previewable & UniformResourceIdentifiable & WithAcfContactRepProfile & WithAcfPageOptions & {
   __typename?: 'Page';
   /** Returns ancestors of the node. Default ordered as lowest (closest to the child) to highest (closest to the root). */
   ancestors?: Maybe<HierarchicalContentNodeToContentNodeAncestorsConnection>;
@@ -19559,6 +19622,8 @@ export type Page = ContentNode & DatabaseIdentifier & HierarchicalContentNode & 
   commentStatus?: Maybe<Scalars['String']['output']>;
   /** Connection between the Page type and the Comment type */
   comments?: Maybe<PageToCommentConnection>;
+  /** Fields of the ContactRepProfile ACF Field Group */
+  contactRepProfile?: Maybe<ContactRepProfile>;
   /** The content of the post. */
   content?: Maybe<Scalars['String']['output']>;
   /** Connection between the ContentNode type and the ContentType type */
@@ -27273,6 +27338,22 @@ export type RemoveCouponsPayload = {
   clientMutationId?: Maybe<Scalars['String']['output']>;
 };
 
+/** Input for the removeFavorite mutation. */
+export type RemoveFavoriteInput = {
+  /** This is an ID that can be passed to a mutation by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: InputMaybe<Scalars['String']['input']>;
+  productId: Scalars['String']['input'];
+};
+
+/** The payload for the removeFavorite mutation. */
+export type RemoveFavoritePayload = {
+  __typename?: 'RemoveFavoritePayload';
+  /** If a &#039;clientMutationId&#039; input is provided to the mutation, it will be returned as output on the mutation. This ID can be used by the client to track the progress of mutations and catch possible duplicate mutation submissions. */
+  clientMutationId?: Maybe<Scalars['String']['output']>;
+  notFound?: Maybe<Scalars['Boolean']['output']>;
+  success?: Maybe<Scalars['Boolean']['output']>;
+};
+
 /** Input for the removeItemsFromCart mutation. */
 export type RemoveItemsFromCartInput = {
   /** Remove all cart items */
@@ -27375,6 +27456,8 @@ export type RootMutation = {
   __typename?: 'RootMutation';
   /** The addCartItems mutation */
   addCartItems?: Maybe<AddCartItemsPayload>;
+  /** The addFavorite mutation */
+  addFavorite?: Maybe<AddFavoritePayload>;
   /** The addFee mutation */
   addFee?: Maybe<AddFeePayload>;
   /** The addToCart mutation */
@@ -27545,6 +27628,8 @@ export type RootMutation = {
   registerUser?: Maybe<RegisterUserPayload>;
   /** The removeCoupons mutation */
   removeCoupons?: Maybe<RemoveCouponsPayload>;
+  /** The removeFavorite mutation */
+  removeFavorite?: Maybe<RemoveFavoritePayload>;
   /** The removeItemsFromCart mutation */
   removeItemsFromCart?: Maybe<RemoveItemsFromCartPayload>;
   /** The resetUserPassword mutation */
@@ -27649,6 +27734,12 @@ export type RootMutation = {
 /** The root mutation */
 export type RootMutationAddCartItemsArgs = {
   input: AddCartItemsInput;
+};
+
+
+/** The root mutation */
+export type RootMutationAddFavoriteArgs = {
+  input: AddFavoriteInput;
 };
 
 
@@ -28163,6 +28254,12 @@ export type RootMutationRemoveCouponsArgs = {
 
 
 /** The root mutation */
+export type RootMutationRemoveFavoriteArgs = {
+  input: RemoveFavoriteInput;
+};
+
+
+/** The root mutation */
 export type RootMutationRemoveItemsFromCartArgs = {
   input: RemoveItemsFromCartInput;
 };
@@ -28585,6 +28682,8 @@ export type RootQuery = {
   menuItems?: Maybe<RootQueryToMenuItemConnection>;
   /** Connection between the RootQuery type and the Menu type */
   menus?: Maybe<RootQueryToMenuConnection>;
+  /** Get the current authenticated user&#039;s saved product favorites, sorted newest first. */
+  myFavorites?: Maybe<Array<Maybe<BapiFavorite>>>;
   /** Fetches an object given its ID */
   node?: Maybe<Node>;
   /** Fetches an object given its Unique Resource Identifier */
@@ -39354,6 +39453,12 @@ export type WpPageInfo = {
   startCursor?: Maybe<Scalars['String']['output']>;
 };
 
+/** Provides access to fields of the &quot;ContactRepProfile&quot; ACF Field Group via the &quot;contactRepProfile&quot; field */
+export type WithAcfContactRepProfile = {
+  /** Fields of the ContactRepProfile ACF Field Group */
+  contactRepProfile?: Maybe<ContactRepProfile>;
+};
+
 /** Provides access to fields of the &quot;CustomerInformation&quot; ACF Field Group via the &quot;customerInformation&quot; field */
 export type WithAcfCustomerInformation = {
   /** Fields of the CustomerInformation ACF Field Group */
@@ -39539,11 +39644,17 @@ export type ChatProductSearchQueryVariables = Exact<{
 
 
 export type ChatProductSearchQuery = { __typename?: 'RootQuery', products?: { __typename?: 'RootQueryToProductUnionConnection', nodes: Array<
-      | { __typename?: 'ExternalProduct', price?: string | null | undefined, regularPrice?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, shortDescription?: string | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
-      | { __typename?: 'GroupProduct', price?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, shortDescription?: string | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
-      | { __typename?: 'SimpleProduct', price?: string | null | undefined, regularPrice?: string | null | undefined, sku?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, shortDescription?: string | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
-      | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, shortDescription?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
-      | { __typename?: 'VariableProduct', price?: string | null | undefined, regularPrice?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, shortDescription?: string | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
+      | { __typename?: 'ExternalProduct', partNumber?: string | null | undefined, price?: string | null | undefined, regularPrice?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, description?: string | null | undefined, shortDescription?: string | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
+      | { __typename?: 'GroupProduct', partNumber?: string | null | undefined, price?: string | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, description?: string | null | undefined, shortDescription?: string | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
+      | { __typename?: 'SimpleProduct', partNumber?: string | null | undefined, price?: string | null | undefined, regularPrice?: string | null | undefined, sku?: string | null | undefined, stockStatus?: StockStatusEnum | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, description?: string | null | undefined, shortDescription?: string | null | undefined, attributes?: { __typename?: 'ProductToProductAttributeConnection', nodes: Array<
+            | { __typename?: 'GlobalProductAttribute', name?: string | null | undefined, label?: string | null | undefined, options?: Array<string | null | undefined> | null | undefined }
+            | { __typename?: 'LocalProductAttribute', name?: string | null | undefined, label?: string | null | undefined, options?: Array<string | null | undefined> | null | undefined }
+          > } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
+      | { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, description?: string | null | undefined, shortDescription?: string | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
+      | { __typename?: 'VariableProduct', partNumber?: string | null | undefined, price?: string | null | undefined, regularPrice?: string | null | undefined, stockStatus?: StockStatusEnum | null | undefined, id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, description?: string | null | undefined, shortDescription?: string | null | undefined, attributes?: { __typename?: 'ProductToProductAttributeConnection', nodes: Array<
+            | { __typename?: 'GlobalProductAttribute', name?: string | null | undefined, label?: string | null | undefined, options?: Array<string | null | undefined> | null | undefined }
+            | { __typename?: 'LocalProductAttribute', name?: string | null | undefined, label?: string | null | undefined, options?: Array<string | null | undefined> | null | undefined }
+          > } | null | undefined, productCategories?: { __typename?: 'ProductToProductCategoryConnection', nodes: Array<{ __typename?: 'ProductCategory', name?: string | null | undefined }> } | null | undefined, image?: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
     > } | null | undefined };
 
 export type GetApplicationNotesQueryVariables = Exact<{
@@ -39710,6 +39821,13 @@ export type GetOrderByDatabaseIdQuery = { __typename?: 'RootQuery', order?: { __
             | { __typename?: 'SimpleProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, sku?: string | null | undefined, image?: { __typename?: 'MediaItem', id: string, sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
             | { __typename?: 'VariableProduct', id: string, databaseId: number, name?: string | null | undefined, slug?: string | null | undefined, sku?: string | null | undefined, image?: { __typename?: 'MediaItem', id: string, sourceUrl?: string | null | undefined, altText?: string | null | undefined } | null | undefined }
            } | null | undefined, variation?: { __typename?: 'LineItemToProductVariationConnectionEdge', node: { __typename?: 'SimpleProductVariation', id: string, databaseId: number, name?: string | null | undefined, price?: string | null | undefined, sku?: string | null | undefined } } | null | undefined }> } | null | undefined, shippingLines?: { __typename?: 'OrderToShippingLineConnection', nodes: Array<{ __typename?: 'ShippingLine', databaseId?: number | null | undefined, methodTitle?: string | null | undefined, total?: string | null | undefined, totalTax?: string | null | undefined }> } | null | undefined, taxLines?: { __typename?: 'OrderToTaxLineConnection', nodes: Array<{ __typename?: 'TaxLine', label?: string | null | undefined, taxTotal?: string | null | undefined, shippingTaxTotal?: string | null | undefined, rateCode?: string | null | undefined }> } | null | undefined, feeLines?: { __typename?: 'OrderToFeeLineConnection', nodes: Array<{ __typename?: 'FeeLine', databaseId?: number | null | undefined, name?: string | null | undefined, total?: string | null | undefined, totalTax?: string | null | undefined }> } | null | undefined, metaData?: Array<{ __typename?: 'MetaData', key: string, value?: string | null | undefined } | null | undefined> | null | undefined } | null | undefined };
+
+export type GetContactRepBioQueryVariables = Exact<{
+  slug: Scalars['ID']['input'];
+}>;
+
+
+export type GetContactRepBioQuery = { __typename?: 'RootQuery', page?: { __typename?: 'Page', title?: string | null | undefined, modified?: string | null | undefined, contactRepProfile?: { __typename?: 'ContactRepProfile', bio?: string | null | undefined } | null | undefined, featuredImage?: { __typename?: 'NodeWithFeaturedImageToMediaItemConnectionEdge', node: { __typename?: 'MediaItem', sourceUrl?: string | null | undefined, altText?: string | null | undefined } } | null | undefined } | null | undefined };
 
 export type GetPageBySlugQueryVariables = Exact<{
   slug: Scalars['ID']['input'];
@@ -40074,7 +40192,11 @@ export const ChatProductSearchDocument = gql`
       databaseId
       name
       slug
+      description
       shortDescription
+      ... on Product {
+        partNumber
+      }
       image {
         sourceUrl
         altText
@@ -40083,6 +40205,14 @@ export const ChatProductSearchDocument = gql`
         price
         regularPrice
         sku
+        stockStatus
+        attributes {
+          nodes {
+            name
+            label
+            options
+          }
+        }
         productCategories {
           nodes {
             name
@@ -40092,6 +40222,14 @@ export const ChatProductSearchDocument = gql`
       ... on VariableProduct {
         price
         regularPrice
+        stockStatus
+        attributes {
+          nodes {
+            name
+            label
+            options
+          }
+        }
         productCategories {
           nodes {
             name
@@ -41067,6 +41205,23 @@ export const GetOrderByDatabaseIdDocument = gql`
     metaData {
       key
       value
+    }
+  }
+}
+    `;
+export const GetContactRepBioDocument = gql`
+    query GetContactRepBio($slug: ID!) {
+  page(id: $slug, idType: URI) {
+    title
+    modified
+    contactRepProfile {
+      bio
+    }
+    featuredImage {
+      node {
+        sourceUrl
+        altText
+      }
     }
   }
 }
@@ -42735,6 +42890,9 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     GetOrderByDatabaseId(variables: GetOrderByDatabaseIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetOrderByDatabaseIdQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetOrderByDatabaseIdQuery>({ document: GetOrderByDatabaseIdDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetOrderByDatabaseId', 'query', variables);
+    },
+    GetContactRepBio(variables: GetContactRepBioQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetContactRepBioQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetContactRepBioQuery>({ document: GetContactRepBioDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetContactRepBio', 'query', variables);
     },
     GetPageBySlug(variables: GetPageBySlugQueryVariables, requestHeaders?: GraphQLClientRequestHeaders, signal?: RequestInit['signal']): Promise<GetPageBySlugQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetPageBySlugQuery>({ document: GetPageBySlugDocument, variables, requestHeaders: { ...requestHeaders, ...wrappedRequestHeaders }, signal }), 'GetPageBySlug', 'query', variables);

--- a/web/src/lib/graphql/queries/pages.graphql
+++ b/web/src/lib/graphql/queries/pages.graphql
@@ -1,3 +1,19 @@
+query GetContactRepBio($slug: ID!) {
+  page(id: $slug, idType: URI) {
+    title
+    modified
+    contactRepProfile {
+      bio
+    }
+    featuredImage {
+      node {
+        sourceUrl
+        altText
+      }
+    }
+  }
+}
+
 query GetPageBySlug($slug: ID!) {
   page(id: $slug, idType: URI) {
     id

--- a/web/src/lib/wordpress.ts
+++ b/web/src/lib/wordpress.ts
@@ -49,9 +49,23 @@ export async function getContactRepBio(repSlug: string): Promise<ContactRepBio |
     const { title, modified, featuredImage } = data.page;
     const rawBio: string = data.page.contactRepProfile?.bio ?? '';
 
+    // Normalise raw ACF text: strip any HTML tags, decode common entities,
+    // and convert <br>/<p> variants to newlines before paragraph splitting.
+    const cleanBio = rawBio
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/&nbsp;/g, ' ')
+      .trim();
+
     // Split on any newline(s) first. If a bio was entered without paragraph
     // breaks (one big block), auto-group into ~3-sentence chunks for readability.
-    const rawParagraphs = rawBio
+    const rawParagraphs = cleanBio
       .split(/\n+/)
       .map((p) => p.trim())
       .filter((p) => p.length > 0);

--- a/web/src/lib/wordpress.ts
+++ b/web/src/lib/wordpress.ts
@@ -49,12 +49,29 @@ export async function getContactRepBio(repSlug: string): Promise<ContactRepBio |
     const { title, modified, featuredImage } = data.page;
     const rawBio: string = data.page.contactRepProfile?.bio ?? '';
 
-    // Split on double newlines (paragraph breaks) to produce discrete paragraphs.
-    // ACF Textarea "Automatically add paragraphs" setting inserts \n\n between blocks.
-    const bioParagraphs = rawBio
-      .split(/\n{2,}/)
-      .map((p) => p.replace(/\n/g, ' ').trim())
+    // Split on any newline(s) first. If a bio was entered without paragraph
+    // breaks (one big block), auto-group into ~3-sentence chunks for readability.
+    const rawParagraphs = rawBio
+      .split(/\n+/)
+      .map((p) => p.trim())
       .filter((p) => p.length > 0);
+
+    let bioParagraphs: string[];
+    if (rawParagraphs.length <= 1 && rawParagraphs[0]) {
+      // No newlines — split on sentence boundaries (period/!/? followed by a
+      // capital letter) then group every 3 sentences into a paragraph.
+      const sentences = rawParagraphs[0].split(/(?<=[.!?'"])\s+(?=[A-Z])/);
+      bioParagraphs = [];
+      for (let i = 0; i < sentences.length; i += 3) {
+        const chunk = sentences
+          .slice(i, i + 3)
+          .join(' ')
+          .trim();
+        if (chunk) bioParagraphs.push(chunk);
+      }
+    } else {
+      bioParagraphs = rawParagraphs;
+    }
 
     return {
       title: title || '',

--- a/web/src/lib/wordpress.ts
+++ b/web/src/lib/wordpress.ts
@@ -6,6 +6,7 @@
 import { getGraphQLClient } from './graphql/client';
 import {
   GetPageBySlugDocument,
+  GetContactRepBioDocument,
   GetPagesDocument,
   GetPostsDocument,
   GetPostBySlugDocument,
@@ -21,6 +22,50 @@ export interface Page {
   date: string;
   modified: string;
   featuredImage?: string;
+}
+
+export interface ContactRepBio {
+  title: string;
+  bioParagraphs: string[];
+  wpFeaturedImage?: string;
+  modified: string;
+}
+
+/**
+ * Fetch bio content for a sales rep's individual contact page.
+ * Bio is stored in the ACF "Contact Rep Profile" field group (bio textarea).
+ * The WordPress slug follows the pattern "contact-{rep-slug}".
+ */
+export async function getContactRepBio(repSlug: string): Promise<ContactRepBio | null> {
+  const wpSlug = `contact-${repSlug}`;
+  try {
+    const client = getGraphQLClient(['contact-pages', `contact-${repSlug}`], true);
+    const data = await client.request(GetContactRepBioDocument, { slug: wpSlug });
+
+    if (!data?.page) {
+      return null;
+    }
+
+    const { title, modified, featuredImage } = data.page;
+    const rawBio: string = data.page.contactRepProfile?.bio ?? '';
+
+    // Split on double newlines (paragraph breaks) to produce discrete paragraphs.
+    // ACF Textarea "Automatically add paragraphs" setting inserts \n\n between blocks.
+    const bioParagraphs = rawBio
+      .split(/\n{2,}/)
+      .map((p) => p.replace(/\n/g, ' ').trim())
+      .filter((p) => p.length > 0);
+
+    return {
+      title: title || '',
+      bioParagraphs,
+      wpFeaturedImage: featuredImage?.node?.sourceUrl ?? undefined,
+      modified: modified || '',
+    };
+  } catch (error) {
+    logger.warn('Contact rep bio fetch failed', { repSlug, error });
+    return null;
+  }
 }
 
 export interface Post {


### PR DESCRIPTION
- Pull bio content from WordPress at build time via new GetContactRepBio GraphQL query (SSG + ISR via cache tag 'contact-{slug}')
- Extract all team data to lib/constants/team.ts (single source of truth for contact/page.tsx and the new [slug]/page.tsx)
- Add generateStaticParams to pre-build all 18 rep pages at deploy time; WPBakery HTML bio paragraphs extracted via extractBioParagraphs()
- Add profileHref prop to SalesTeamCard — renders a 'Contact' button linking to the individual page when provided
- contact/page.tsx updated to import from team.ts and pass profileHref to every card

WordPress slug pattern: contact-{rep-slug} (e.g. contact-matt-holder)
Cache tag: contact-pages / contact-{slug} for on-demand ISR


