### PR TITLE
fix: mobile menu products crash, WTB call button width, remove produc…

### DIFF
--- a/web/src/app/[locale]/support/page.tsx
+++ b/web/src/app/[locale]/support/page.tsx
@@ -160,14 +160,6 @@ export default async function SupportPage() {
               <ul className="space-y-2 text-neutral-700">
                 <li>
                   <Link
-                    href="/resources/selector"
-                    className="duration-normal text-primary-500 transition-colors hover:text-primary-600"
-                  >
-                    {t('resources.toolsUtilities.links.productSelector')}
-                  </Link>
-                </li>
-                <li>
-                  <Link
                     href="/resources/cross-reference"
                     className="duration-normal text-primary-500 transition-colors hover:text-primary-600"
                   >

--- a/web/src/app/[locale]/where-to-buy/page.tsx
+++ b/web/src/app/[locale]/where-to-buy/page.tsx
@@ -810,7 +810,7 @@ export default function WhereToBuyPage() {
                           {distributor.phone && (
                             <a
                               href={`tel:${distributor.phone}`}
-                              className="flex transform items-center justify-center gap-2 rounded-lg border-2 border-accent-600 bg-accent-500 px-3 py-2 text-sm font-semibold text-neutral-900 shadow-md transition-all duration-300 hover:scale-105 hover:bg-accent-600 hover:shadow-xl"
+                              className={`flex transform items-center justify-center gap-2 rounded-lg border-2 border-accent-600 bg-accent-500 px-3 py-2 text-sm font-semibold text-neutral-900 shadow-md transition-all duration-300 hover:scale-105 hover:bg-accent-600 hover:shadow-xl${!distributor.email ? ' col-span-2' : ''}`}
                             >
                               <PhoneIcon className="h-4 w-4" />
                               Call

--- a/web/src/components/layout/Header/components/MobileMenu.tsx
+++ b/web/src/components/layout/Header/components/MobileMenu.tsx
@@ -87,13 +87,18 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
               {item.megaMenu && expandedIndex === index && (
                 <div className="space-y-4 rounded-lg border-l-4 border-primary-500 bg-primary-50/30 px-2 py-3">
                   {item.megaMenu.columns.map((column) => {
-                    const IconComponent = column.icon;
+                    const IconComponent = typeof column.icon === 'string' ? null : column.icon;
+                    const iconPath = typeof column.icon === 'string' ? column.icon : null;
                     return (
                       <div key={column.title} className="space-y-2">
                         <div className="flex items-center gap-2 border-b border-primary-200 px-3 pb-1.5">
-                          {IconComponent && (
+                          {(iconPath || IconComponent) && (
                             <div className="rounded bg-primary-100 p-1">
-                              <IconComponent className="h-3 w-3 text-primary-700" />
+                              {iconPath ? (
+                                <img src={iconPath} alt="" aria-hidden="true" className="h-3 w-3 object-contain" />
+                              ) : IconComponent ? (
+                                <IconComponent className="h-3 w-3 text-primary-700" />
+                              ) : null}
                             </div>
                           )}
                           <div className="text-xs font-black uppercase tracking-wider text-primary-800">
@@ -102,7 +107,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
                         </div>
                         <ul className="space-y-1">
                           {column.links.map((link) => (
-                            <li key={link.href}>
+                            <li key={`${link.href}-${link.label}`}>
                               <Link
                                 href={link.href}
                                 onClick={onClose}

--- a/web/src/components/layout/Header/config.ts
+++ b/web/src/components/layout/Header/config.ts
@@ -401,11 +401,6 @@ export const getMegaMenuItems = (t: any): MegaMenuItem[] => [
               href: '/wireless-site-verification/',
               description: t('resources.toolsGuides.siteVerificationDesc'),
             },
-            {
-              label: t('resources.toolsGuides.productSelector'),
-              href: '/resources/selector',
-              description: t('resources.toolsGuides.productSelectorDesc'),
-            },
           ],
         },
       ],


### PR DESCRIPTION
- MobileMenu: handle string image paths as column icons (Products uses webp paths, not React components) — fixes crash when expanding Products on mobile
- MobileMenu: use composite key (href+label) to fix duplicate key warning from two humidity links sharing the same href
- Where to Buy: call button spans full width when no email address is present
- Resources nav + Support page: remove Product Selector link (deferred to Phase 2)


