### PR TITLE
Fix/remove tim wilder sales region

### DIFF
--- a/web/src/app/[locale]/contact/page.tsx
+++ b/web/src/app/[locale]/contact/page.tsx
@@ -63,7 +63,6 @@ export default function ContactPage() {
         'india',
         'south-america',
         'africa',
-        'asia',
         'australia',
         'technical',
       ];
@@ -448,17 +447,6 @@ export default function ContactPage() {
                 Africa
               </a>
               <a
-                href="#asia"
-                className={`group flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-300 hover:scale-105 hover:shadow-md active:scale-95 ${
-                  activeSection === 'asia'
-                    ? 'bg-primary-500 text-white shadow-md'
-                    : 'border border-neutral-200 bg-white text-neutral-700 hover:bg-primary-50 hover:text-primary-600'
-                }`}
-              >
-                <GlobeIcon className="h-4 w-4" />
-                Asia
-              </a>
-              <a
                 href="#australia"
                 className={`group flex items-center gap-2 rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-300 hover:scale-105 hover:shadow-md active:scale-95 ${
                   activeSection === 'australia'
@@ -466,9 +454,9 @@ export default function ContactPage() {
                     : 'border border-neutral-200 bg-white text-neutral-700 hover:bg-primary-50 hover:text-primary-600'
                 }`}
               >
-                <Building2Icon className="h-4 w-4" />
-                <span className="hidden sm:inline">Australia & NZ</span>
-                <span className="sm:hidden">AU/NZ</span>
+                <GlobeIcon className="h-4 w-4" />
+                <span className="hidden sm:inline">Asia & Pacific</span>
+                <span className="sm:hidden">Asia/AU</span>
               </a>
               <a
                 href="#technical"

--- a/web/src/app/[locale]/contact/page.tsx
+++ b/web/src/app/[locale]/contact/page.tsx
@@ -24,7 +24,6 @@ import {
   indiaTeam,
   southAmericaTeam,
   africaTeam,
-  asiaTeam,
   australiaTeam,
   technicalTeam,
 } from '@/lib/constants/team';
@@ -758,46 +757,7 @@ export default function ContactPage() {
             </div>
           </div>
 
-          {/* Asia Sales */}
-          <div
-            id="asia"
-            className="-mx-4 mb-8 scroll-mt-32 bg-neutral-50 px-4 py-8 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8"
-          >
-            <button
-              onClick={() => toggleSection('asia')}
-              className="w-full text-left lg:cursor-default"
-              aria-expanded={expandedSections.has('asia')}
-            >
-              <h3 className="mb-6 flex items-center justify-between border-b-2 border-primary-500 pb-3 text-2xl font-bold text-neutral-900">
-                <span>
-                  <span className="mr-2">🌏</span>Asia{' '}
-                  <span className="text-lg font-normal text-neutral-700">(1)</span>
-                </span>
-                <span className="text-primary-500 lg:hidden">
-                  {expandedSections.has('asia') ? '▼' : '▶'}
-                </span>
-              </h3>
-            </button>
-            <div
-              className={`mx-auto grid max-w-3xl grid-cols-1 gap-6 sm:grid-cols-2 ${expandedSections.has('asia') ? '' : 'hidden lg:grid'}`}
-            >
-              {asiaTeam.map((member) => (
-                <SalesTeamCard
-                  key={member.email}
-                  name={member.name}
-                  title={member.title}
-                  region={member.region}
-                  email={member.email}
-                  phone={member.phone}
-                  photo={member.photo}
-                  video={member.video}
-                  profileHref={`/${locale}/contact/${member.slug}`}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Australia & New Zealand Sales */}
+          {/* Asia, Australia & Pacific Sales */}
           <div
             id="australia"
             className="-mx-4 mb-8 scroll-mt-32 bg-white px-4 py-8 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8"
@@ -809,7 +769,7 @@ export default function ContactPage() {
             >
               <h3 className="mb-6 flex items-center justify-between border-b-2 border-primary-500 pb-3 text-2xl font-bold text-neutral-900">
                 <span>
-                  <span className="mr-2">🇦🇺</span>Australia & New Zealand{' '}
+                  <span className="mr-2">🌏</span>Asia, Australia & Pacific{' '}
                   <span className="text-lg font-normal text-neutral-700">(1)</span>
                 </span>
                 <span className="text-primary-500 lg:hidden">

--- a/web/src/lib/constants/salesRegions.ts
+++ b/web/src/lib/constants/salesRegions.ts
@@ -14,7 +14,7 @@
  *  2  – South America          (John Shields)
  *  3  – Scandinavia & Baltic   (John Shields)
  *  4  – Western Europe         (Mike Moss)
- *  5  – Central Europe         (Mike Moss)
+ *  5  – Central Europe         (Jan Zurawski)
  *  6  – Eastern Europe/Balkans (Jan Zurawski)
  *  7  – West & Central Africa  (John Shields)
  *  8  – East & Southern Africa (John Shields)
@@ -60,13 +60,13 @@ export const SALES_REPS: SalesRep[] = [
     id: 'mike-moss',
     name: 'Mike Moss',
     title: 'Business Development & Regional Sales',
-    regions: [4, 5],
+    regions: [4],
   },
   {
     id: 'jan-zurawski',
     name: 'Jan Zurawski',
     title: 'Business Development & Regional Sales',
-    regions: [6],
+    regions: [5, 6],
   },
   {
     id: 'murtaza-kalabhai',
@@ -110,7 +110,7 @@ export const SALES_REGIONS: SalesRegion[] = [
   {
     id: 5,
     name: 'Central Europe',
-    repId: 'mike-moss',
+    repId: 'jan-zurawski',
     description: 'Germany, Austria, Switzerland, Italy, Czech Republic, Slovakia & Slovenia',
   },
   {

--- a/web/src/lib/constants/salesRegions.ts
+++ b/web/src/lib/constants/salesRegions.ts
@@ -20,9 +20,9 @@
  *  8  – East & Southern Africa (John Shields)
  *  9  – Middle East & Turkey   (Murtaza Kalabhai)
  * 10  – South Asia             (Murtaza Kalabhai)
- * 11  – China & Mongolia       (Tim Wilder)
- * 12  – East Asia              (Tim Wilder)
- * 13  – Southeast Asia         (Tim Wilder)
+ * 11  – China & Mongolia       (Andy Brooks)
+ * 12  – East Asia              (Andy Brooks)
+ * 13  – Southeast Asia         (Andy Brooks)
  * 14  – Australia & Pacific    (Andy Brooks)
  * 15  – Russia & Kazakhstan    (John Shields)
  */
@@ -75,16 +75,10 @@ export const SALES_REPS: SalesRep[] = [
     regions: [9, 10],
   },
   {
-    id: 'tim-wilder',
-    name: 'Tim Wilder',
-    title: 'Business Development & Regional Sales',
-    regions: [11, 12, 13],
-  },
-  {
     id: 'andy-brooks',
     name: 'Andy Brooks',
     title: 'Business Development & Regional Sales',
-    regions: [14],
+    regions: [11, 12, 13, 14],
   },
 ];
 
@@ -152,19 +146,19 @@ export const SALES_REGIONS: SalesRegion[] = [
   {
     id: 11,
     name: 'China & Mongolia',
-    repId: 'tim-wilder',
+    repId: 'andy-brooks',
     description: 'China & Mongolia',
   },
   {
     id: 12,
     name: 'East Asia',
-    repId: 'tim-wilder',
+    repId: 'andy-brooks',
     description: 'Japan, South Korea, North Korea & Taiwan',
   },
   {
     id: 13,
     name: 'Southeast Asia',
-    repId: 'tim-wilder',
+    repId: 'andy-brooks',
     description: 'Vietnam, Thailand, Malaysia, Indonesia, Philippines & neighbors',
   },
   {

--- a/web/src/lib/constants/team.ts
+++ b/web/src/lib/constants/team.ts
@@ -187,24 +187,12 @@ export const africaTeam: TeamMember[] = [
   },
 ];
 
-export const asiaTeam: TeamMember[] = [
-  {
-    slug: 'tim-wilder',
-    name: 'Tim Wilder',
-    title: 'Director of Research & Development',
-    region: 'Asia',
-    email: 'twilder@bapihvac.com',
-    phone: '+1-800-553-3027',
-    photo: '/images/team/tim-wilder.webp',
-  },
-];
-
 export const australiaTeam: TeamMember[] = [
   {
     slug: 'andy-brooks',
     name: 'Andy Brooks',
     title: 'Business Development & Regional Sales Manager',
-    region: 'Australia & New Zealand',
+    region: 'Asia, Australia & Pacific',
     email: 'abrooks@bapihvac.com',
     phone: '+1-800-553-3027',
     photo: '/images/team/andy-brooks.webp',
@@ -246,7 +234,6 @@ export const ALL_TEAM_MEMBERS: TeamMember[] = Array.from(
       ...indiaTeam,
       ...southAmericaTeam,
       ...africaTeam,
-      ...asiaTeam,
       ...australiaTeam,
       ...technicalTeam,
     ].map((m) => [m.slug, m]),


### PR DESCRIPTION
Updates the global sales territory map and contact page to reflect two personnel changes: Tim Wilder removed from the sales team, and Central Europe reassigned from Mike Moss to Jan Zurawski. Andy Brooks now covers all of Asia in addition to Australia & Pacific.

Changes
Territory Reassignments
Region	Before	After
Central Europe (5)	Mike Moss	Jan Zurawski
China & Mongolia (11)	Tim Wilder	Andy Brooks
East Asia (12)	Tim Wilder	Andy Brooks
Southeast Asia (13)	Tim Wilder	Andy Brooks
Updated rep coverage:

Mike Moss — Western Europe only (was Western + Central Europe)
Jan Zurawski — Central Europe + Eastern Europe/Balkans (was Eastern Europe/Balkans only)
Andy Brooks — Asia (China, East Asia, Southeast Asia) + Australia & Pacific (was Australia & Pacific only)
Tim Wilder — Removed

Files Changed
salesRegions.ts
Removed Tim Wilder from SALES_REPS
Updated Andy Brooks regions from [14] → [11, 12, 13, 14]
Updated Mike Moss regions from [4, 5] → [4]
Updated Jan Zurawski regions from [6] → [5, 6]
Updated repId for regions 5, 11, 12, 13 accordingly
Updated header comment to reflect new assignments
team.ts
Removed asiaTeam export (contained Tim Wilder only)
Updated Andy Brooks region label: "Australia & New Zealand" → "Asia, Australia & Pacific"
Removed ...asiaTeam from allTeamMembers spread
page.tsx
Removed asiaTeam import
Removed standalone "Asia" contact section (Tim Wilder)
Merged into existing Australia section, renamed to "Asia, Australia & Pacific"