### PR TITLE
fix: correct world map sales region country assignments

### DIFF
--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -846,6 +846,13 @@
           "type": "Headquarters",
           "established": "Est. 1993"
         },
+        "salesRepUsa": {
+          "name": "North America Sales",
+          "city": "Gays Mills",
+          "country": "USA",
+          "description": "North America regional sales",
+          "type": "Business Development & Regional Sales"
+        },
         "manufacturingPoland": {
           "name": "European Manufacturing & Office",
           "city": "Nowa Wola",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -889,6 +889,20 @@
           "description": "Middle East, Turkey & South Asia regional sales",
           "type": "Business Development & Regional Sales"
         },
+        "salesRepIndia": {
+          "name": "South Asia Sales",
+          "city": "Mumbai",
+          "country": "India",
+          "description": "South Asia regional sales",
+          "type": "Business Development & Regional Sales"
+        },
+        "salesRepSea": {
+          "name": "Southeast Asia Sales",
+          "city": "Bangkok",
+          "country": "Thailand",
+          "description": "Southeast Asia regional sales",
+          "type": "Business Development & Regional Sales"
+        },
         "salesRepAustralia": {
           "name": "Asia-Pacific Sales",
           "city": "Sydney",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -851,7 +851,14 @@
           "city": "Nowa Wola",
           "country": "Poland",
           "description": "European production facility, office, and customer service center",
-          "type": "Manufacturing & Office"
+          "type": "Factory Distribution Center"
+        },
+        "salesRepPoland": {
+          "name": "Central & Eastern Europe Sales",
+          "city": "Nowa Wola",
+          "country": "Poland",
+          "description": "Central & Eastern Europe regional sales",
+          "type": "Business Development & Regional Sales"
         },
         "manufacturingVietnam": {
           "name": "Asia-Pacific Manufacturing & Office",
@@ -860,6 +867,13 @@
           "description": "New manufacturing facility and office serving Asian markets",
           "type": "Manufacturing & Office",
           "status": "Opening Soon"
+        },
+        "manufacturingUk": {
+          "name": "UK Factory Distribution Center",
+          "city": "Aldershot",
+          "country": "United Kingdom",
+          "description": "European factory distribution center",
+          "type": "Factory Distribution Center"
         },
         "salesUk": {
           "name": "UK Sales Office",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -832,9 +832,9 @@
       "title": "Our Global Presence",
       "subtitle": "From our headquarters in Wisconsin to facilities across three continents, BAPI serves customers worldwide with local expertise and global reach.",
       "mapLegend": {
-        "headquarters": "Headquarters",
-        "manufacturing": "Manufacturing & Office",
-        "sales": "Sales Office",
+        "headquarters": "BAPI Headquarters",
+        "manufacturing": "Factory Distribution Center",
+        "sales": "Business Development & Regional Sales",
         "distributionPartner": "Distribution Partner"
       },
       "facilities": {
@@ -866,7 +866,28 @@
           "city": "Aldershot",
           "country": "United Kingdom",
           "description": "European sales and customer support hub",
-          "type": "Sales Office"
+          "type": "Business Development & Regional Sales"
+        },
+        "salesRepUae": {
+          "name": "Middle East & South Asia Sales",
+          "city": "Dubai",
+          "country": "United Arab Emirates",
+          "description": "Middle East, Turkey & South Asia regional sales",
+          "type": "Business Development & Regional Sales"
+        },
+        "salesRepAustralia": {
+          "name": "Asia-Pacific Sales",
+          "city": "Sydney",
+          "country": "Australia",
+          "description": "Asia-Pacific regional sales",
+          "type": "Business Development & Regional Sales"
+        },
+        "salesRepNewzealand": {
+          "name": "New Zealand Sales",
+          "city": "Auckland",
+          "country": "New Zealand",
+          "description": "New Zealand regional sales",
+          "type": "Business Development & Regional Sales"
         }
       },
       "cta": {

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -413,12 +413,33 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               type: t('locations.facilities.headquartersUsa.type'),
               established: t('locations.facilities.headquartersUsa.established'),
             },
+            'manufacturing-uk': {
+              name: t('locations.facilities.manufacturingUk.name'),
+              city: t('locations.facilities.manufacturingUk.city'),
+              country: t('locations.facilities.manufacturingUk.country'),
+              description: t('locations.facilities.manufacturingUk.description'),
+              type: t('locations.facilities.manufacturingUk.type'),
+            },
+            'sales-uk': {
+              name: t('locations.facilities.salesUk.name'),
+              city: t('locations.facilities.salesUk.city'),
+              country: t('locations.facilities.salesUk.country'),
+              description: t('locations.facilities.salesUk.description'),
+              type: t('locations.facilities.salesUk.type'),
+            },
             'manufacturing-poland': {
               name: t('locations.facilities.manufacturingPoland.name'),
               city: t('locations.facilities.manufacturingPoland.city'),
               country: t('locations.facilities.manufacturingPoland.country'),
               description: t('locations.facilities.manufacturingPoland.description'),
               type: t('locations.facilities.manufacturingPoland.type'),
+            },
+            'sales-rep-poland': {
+              name: t('locations.facilities.salesRepPoland.name'),
+              city: t('locations.facilities.salesRepPoland.city'),
+              country: t('locations.facilities.salesRepPoland.country'),
+              description: t('locations.facilities.salesRepPoland.description'),
+              type: t('locations.facilities.salesRepPoland.type'),
             },
             'manufacturing-vietnam': {
               name: t('locations.facilities.manufacturingVietnam.name'),
@@ -427,13 +448,6 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               description: t('locations.facilities.manufacturingVietnam.description'),
               type: t('locations.facilities.manufacturingVietnam.type'),
               status: t('locations.facilities.manufacturingVietnam.status'),
-            },
-            'sales-uk': {
-              name: t('locations.facilities.salesUk.name'),
-              city: t('locations.facilities.salesUk.city'),
-              country: t('locations.facilities.salesUk.country'),
-              description: t('locations.facilities.salesUk.description'),
-              type: t('locations.facilities.salesUk.type'),
             },
             'sales-rep-uae': {
               name: t('locations.facilities.salesRepUae.name'),

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -17,26 +17,10 @@ import {
 } from '@/lib/icons';
 
 /**
- * Lazy load GlobalPresence component to improve initial page load
- * This component is below the fold and includes heavy map rendering
- * Deferring it reduces Total Blocking Time (TBT) significantly
+ * GlobalPresence is rendered via a client-side-only wrapper (ssr: false) to
+ * avoid floating-point hydration mismatches from react-simple-maps projection math.
  */
-const GlobalPresence = dynamic(
-  () => import('@/components/company/GlobalPresence').then((mod) => ({ default: mod.GlobalPresence })),
-  {
-    ssr: false, // Map uses client-side projection math — SSR produces floating-point mismatch
-    loading: () => (
-      <div className="bg-neutral-50 py-12 lg:py-16">
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-          <div className="animate-pulse space-y-8">
-            <div className="mx-auto h-8 w-64 rounded bg-neutral-200"></div>
-            <div className="mx-auto h-96 rounded-2xl bg-neutral-200"></div>
-          </div>
-        </div>
-      </div>
-    ),
-  }
-);
+import { GlobalPresenceDynamic as GlobalPresence } from '@/components/company/GlobalPresenceDynamic';
 
 /**
  * Homepage - Main landing page for BAPI Headless E-Commerce

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -456,6 +456,20 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               description: t('locations.facilities.salesRepUae.description'),
               type: t('locations.facilities.salesRepUae.type'),
             },
+            'sales-rep-india': {
+              name: t('locations.facilities.salesRepIndia.name'),
+              city: t('locations.facilities.salesRepIndia.city'),
+              country: t('locations.facilities.salesRepIndia.country'),
+              description: t('locations.facilities.salesRepIndia.description'),
+              type: t('locations.facilities.salesRepIndia.type'),
+            },
+            'sales-rep-sea': {
+              name: t('locations.facilities.salesRepSea.name'),
+              city: t('locations.facilities.salesRepSea.city'),
+              country: t('locations.facilities.salesRepSea.country'),
+              description: t('locations.facilities.salesRepSea.description'),
+              type: t('locations.facilities.salesRepSea.type'),
+            },
             'sales-rep-australia': {
               name: t('locations.facilities.salesRepAustralia.name'),
               city: t('locations.facilities.salesRepAustralia.city'),

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -435,6 +435,27 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               description: t('locations.facilities.salesUk.description'),
               type: t('locations.facilities.salesUk.type'),
             },
+            'sales-rep-uae': {
+              name: t('locations.facilities.salesRepUae.name'),
+              city: t('locations.facilities.salesRepUae.city'),
+              country: t('locations.facilities.salesRepUae.country'),
+              description: t('locations.facilities.salesRepUae.description'),
+              type: t('locations.facilities.salesRepUae.type'),
+            },
+            'sales-rep-australia': {
+              name: t('locations.facilities.salesRepAustralia.name'),
+              city: t('locations.facilities.salesRepAustralia.city'),
+              country: t('locations.facilities.salesRepAustralia.country'),
+              description: t('locations.facilities.salesRepAustralia.description'),
+              type: t('locations.facilities.salesRepAustralia.type'),
+            },
+            'sales-rep-newzealand': {
+              name: t('locations.facilities.salesRepNewzealand.name'),
+              city: t('locations.facilities.salesRepNewzealand.city'),
+              country: t('locations.facilities.salesRepNewzealand.country'),
+              description: t('locations.facilities.salesRepNewzealand.description'),
+              type: t('locations.facilities.salesRepNewzealand.type'),
+            },
           },
           cta: {
             text: t('locations.cta.text'),

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -24,7 +24,7 @@ import {
 const GlobalPresence = dynamic(
   () => import('@/components/company/GlobalPresence').then((mod) => ({ default: mod.GlobalPresence })),
   {
-    ssr: true, // Keep SSR for SEO
+    ssr: false, // Map uses client-side projection math — SSR produces floating-point mismatch
     loading: () => (
       <div className="bg-neutral-50 py-12 lg:py-16">
         <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/web/src/app/[locale]/(public)/page.tsx
+++ b/web/src/app/[locale]/(public)/page.tsx
@@ -413,6 +413,13 @@ export default async function Home({ params }: { params: Promise<{ locale: strin
               type: t('locations.facilities.headquartersUsa.type'),
               established: t('locations.facilities.headquartersUsa.established'),
             },
+            'sales-rep-usa': {
+              name: t('locations.facilities.salesRepUsa.name'),
+              city: t('locations.facilities.salesRepUsa.city'),
+              country: t('locations.facilities.salesRepUsa.country'),
+              description: t('locations.facilities.salesRepUsa.description'),
+              type: t('locations.facilities.salesRepUsa.type'),
+            },
             'manufacturing-uk': {
               name: t('locations.facilities.manufacturingUk.name'),
               city: t('locations.facilities.manufacturingUk.city'),

--- a/web/src/app/[locale]/company/page.tsx
+++ b/web/src/app/[locale]/company/page.tsx
@@ -1,8 +1,14 @@
 import { Metadata } from 'next';
 import { Link } from '@/lib/navigation';
+import dynamic from 'next/dynamic';
 import { Building2Icon, UsersIcon, TargetIcon, AwardIcon, MapPinIcon, PhoneIcon, MailIcon } from '@/lib/icons';
 import PageContainer from '@/components/layout/PageContainer';
-import { GlobalPresence } from '@/components/company/GlobalPresence';
+// SSR disabled — map uses client-side projection math that produces a floating-point
+// mismatch between Node.js and the browser, causing a React hydration error.
+const GlobalPresence = dynamic(
+  () => import('@/components/company/GlobalPresence').then((mod) => ({ default: mod.GlobalPresence })),
+  { ssr: false },
+);
 import { generatePageMetadata } from '@/lib/metadata';
 import { getTranslations } from 'next-intl/server';
 import { locales } from '@/i18n';

--- a/web/src/app/[locale]/company/page.tsx
+++ b/web/src/app/[locale]/company/page.tsx
@@ -3,12 +3,7 @@ import { Link } from '@/lib/navigation';
 import dynamic from 'next/dynamic';
 import { Building2Icon, UsersIcon, TargetIcon, AwardIcon, MapPinIcon, PhoneIcon, MailIcon } from '@/lib/icons';
 import PageContainer from '@/components/layout/PageContainer';
-// SSR disabled — map uses client-side projection math that produces a floating-point
-// mismatch between Node.js and the browser, causing a React hydration error.
-const GlobalPresence = dynamic(
-  () => import('@/components/company/GlobalPresence').then((mod) => ({ default: mod.GlobalPresence })),
-  { ssr: false },
-);
+import { GlobalPresenceDynamic as GlobalPresence } from '@/components/company/GlobalPresenceDynamic';
 import { generatePageMetadata } from '@/lib/metadata';
 import { getTranslations } from 'next-intl/server';
 import { locales } from '@/i18n';

--- a/web/src/components/company/GlobalPresence.tsx
+++ b/web/src/components/company/GlobalPresence.tsx
@@ -281,7 +281,7 @@ export function GlobalPresence({
                   }
                 </Geographies>
 
-                {/* Location Markers */}
+{/* Location Markers — icon style matches BAPI internal world map legend */}
                 {BAPI_LOCATIONS.map((location) => (
                   <Marker
                     key={location.id}
@@ -289,31 +289,38 @@ export function GlobalPresence({
                     onMouseEnter={() => setTooltip({ location, visible: true })}
                     onMouseLeave={() => setTooltip(null)}
                   >
-                    {/* Marker Circle */}
-                    <circle
-                      r={location.type === 'headquarters' ? 8 : 6}
-                      fill={FACILITY_TYPE_COLORS[location.type]}
-                      stroke="white"
-                      strokeWidth={2}
-                      className="cursor-pointer transition-all duration-200 hover:scale-125"
-                      style={{
-                        filter:
-                          location.type === 'headquarters'
-                            ? 'drop-shadow(0 4px 6px rgba(20, 121, 188, 0.4))'
-                            : 'drop-shadow(0 2px 4px rgba(0, 0, 0, 0.2))',
-                      }}
-                    />
-                    {/* Pulse Animation for Headquarters */}
-                    {location.type === 'headquarters' && (
-                      <circle
-                        r={8}
-                        fill="none"
-                        stroke={FACILITY_TYPE_COLORS[location.type]}
-                       
-                        opacity={0.6}
-                        className="animate-ping"
-                      />
-                    )}
+                    <g
+                      className="cursor-pointer"
+                      style={{ filter: 'drop-shadow(0 2px 4px rgba(0,0,0,0.3))' }}
+                    >
+                      {/* BAPI Headquarters — pulsing blue badge */}
+                      {location.type === 'headquarters' && (
+                        <>
+                          <circle r={12} fill="none" stroke="#166fb9" strokeWidth={2} opacity={0.4} className="animate-ping" />
+                          <circle r={10} fill="#166fb9" stroke="white" strokeWidth={2} />
+                          <text fill="white" textAnchor="middle" dominantBaseline="central" fontSize="7" fontWeight="bold" y="1">HQ</text>
+                        </>
+                      )}
+                      {/* Factory Distribution Center — grey badge with upward arrow */}
+                      {location.type === 'manufacturing' && (
+                        <>
+                          <circle r={9} fill="#6B7280" stroke="white" strokeWidth={1.5} />
+                          <path d="M0,-6 L3.5,-1.5 L2,-1.5 L2,4.5 L-2,4.5 L-2,-1.5 L-3.5,-1.5 Z" fill="white" />
+                        </>
+                      )}
+                      {/* Business Development & Regional Sales — blue badge with person icon */}
+                      {location.type === 'sales' && (
+                        <>
+                          <circle r={9} fill="#60A5FA" stroke="white" strokeWidth={1.5} />
+                          <circle r={2.5} fill="white" cx="0" cy="-3" />
+                          <path d="M-3.5,5 C-3.5,0 3.5,0 3.5,5 Z" fill="white" />
+                        </>
+                      )}
+                      {/* Distribution Partner */}
+                      {location.type === 'distribution-partner' && (
+                        <circle r={8} fill="#9CA3AF" stroke="white" strokeWidth={1.5} />
+                      )}
+                    </g>
                   </Marker>
                 ))}
               </ZoomableGroup>
@@ -455,10 +462,19 @@ export function GlobalPresence({
 
                 return (
                   <div key={type} className="flex items-center gap-2">
-                    <div
-                      className="h-4 w-4 rounded-full"
-                      style={{ backgroundColor: FACILITY_TYPE_COLORS[type] }}
-                    />
+                    {/* Mini icon badge matching the map marker style */}
+                    <svg width="20" height="20" viewBox="-10 -10 20 20" className="shrink-0" aria-hidden="true">
+                      {type === 'headquarters' && (
+                        <><circle r={9} fill="#166fb9" /><text fill="white" textAnchor="middle" dominantBaseline="central" fontSize="6" fontWeight="bold" y="0.5">HQ</text></>
+                      )}
+                      {type === 'manufacturing' && (
+                        <><circle r={9} fill="#6B7280" /><path d="M0,-5.5 L3,-1 L1.5,-1 L1.5,4 L-1.5,4 L-1.5,-1 L-3,-1 Z" fill="white" /></>
+                      )}
+                      {type === 'sales' && (
+                        <><circle r={9} fill="#60A5FA" /><circle r={2} fill="white" cx="0" cy="-2.5" /><path d="M-3,4.5 C-3,0.5 3,0.5 3,4.5 Z" fill="white" /></>
+                      )}
+                      {type === 'distribution-partner' && <circle r={8} fill="#9CA3AF" />}
+                    </svg>
                     <span className="text-neutral-700">
                       {locationTranslations?.mapLegend[translationKey] ||
                         FACILITY_TYPE_LABELS[type]}

--- a/web/src/components/company/GlobalPresenceDynamic.tsx
+++ b/web/src/components/company/GlobalPresenceDynamic.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+/**
+ * Client-side-only wrapper for GlobalPresence.
+ *
+ * `ssr: false` must live inside a Client Component — it cannot be used in a
+ * Server Component (page.tsx). GlobalPresence uses react-simple-maps which
+ * computes SVG projection transforms in floating-point; Node.js and V8 produce
+ * slightly different results, causing React hydration errors. Skipping SSR
+ * entirely avoids the mismatch.
+ */
+import dynamic from 'next/dynamic';
+import type { ComponentProps } from 'react';
+import type { GlobalPresence as GlobalPresenceType } from './GlobalPresence';
+
+const GlobalPresenceLazy = dynamic(
+  () => import('./GlobalPresence').then((mod) => ({ default: mod.GlobalPresence })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="bg-neutral-50 py-12 lg:py-16">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="animate-pulse space-y-8">
+            <div className="mx-auto h-8 w-64 rounded bg-neutral-200"></div>
+            <div className="mx-auto h-96 rounded-2xl bg-neutral-200"></div>
+          </div>
+        </div>
+      </div>
+    ),
+  },
+);
+
+export function GlobalPresenceDynamic(
+  props: ComponentProps<typeof GlobalPresenceType>,
+) {
+  return <GlobalPresenceLazy {...props} />;
+}

--- a/web/src/lib/constants/locations.ts
+++ b/web/src/lib/constants/locations.ts
@@ -155,6 +155,37 @@ export const BAPI_LOCATIONS: Location[] = [
     },
   },
   {
+    id: 'sales-rep-india',
+    name: 'South Asia Sales',
+    city: 'Mumbai',
+    region: 'Maharashtra',
+    country: 'India',
+    coordinates: [72.8777, 19.076], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'South Asia regional sales',
+    salesRep: {
+      name: 'Murtaza Kalabhai',
+      territory: 'South Asia',
+    },
+  },
+  // BAPI map shows both a Factory Distribution Center AND a Business Dev marker here
+  {
+    id: 'sales-rep-sea',
+    name: 'Southeast Asia Sales',
+    city: 'Bangkok',
+    region: 'Bangkok',
+    country: 'Thailand',
+    coordinates: [100.5018, 13.7563], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'Southeast Asia regional sales',
+    salesRep: {
+      name: 'Andy Brooks',
+      territory: 'Southeast Asia',
+    },
+  },
+  {
     id: 'sales-rep-australia',
     name: 'Asia-Pacific Sales',
     city: 'Sydney',

--- a/web/src/lib/constants/locations.ts
+++ b/web/src/lib/constants/locations.ts
@@ -80,6 +80,22 @@ export const BAPI_LOCATIONS: Location[] = [
     status: 'operational',
     description: 'European production facility, office, and customer service center',
   },
+  // BAPI map shows both a Factory Distribution Center AND a Business Dev marker here
+  {
+    id: 'sales-rep-poland',
+    name: 'Central & Eastern Europe Sales',
+    city: 'Nowa Wola',
+    region: 'Podkarpackie',
+    country: 'Poland',
+    coordinates: [21.0333, 50.5833], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'Central & Eastern Europe regional sales',
+    salesRep: {
+      name: 'Jan Zurawski',
+      territory: 'Central & Eastern Europe',
+    },
+  },
   {
     id: 'manufacturing-vietnam',
     name: 'Asia-Pacific Manufacturing & Office',
@@ -94,6 +110,18 @@ export const BAPI_LOCATIONS: Location[] = [
 
   // === SALES OFFICES ===
   // Per Mike Moss: UK should be listed as sales office (not distribution)
+  // BAPI map shows both a Factory Distribution Center AND a Business Dev marker here
+  {
+    id: 'manufacturing-uk',
+    name: 'UK Factory Distribution Center',
+    city: 'Aldershot',
+    region: 'Hampshire',
+    country: 'United Kingdom',
+    coordinates: [-0.7629, 51.2485], // [lng, lat]
+    type: 'manufacturing',
+    status: 'operational',
+    description: 'European factory distribution center',
+  },
   {
     id: 'sales-uk',
     name: 'UK Sales Office',
@@ -104,6 +132,10 @@ export const BAPI_LOCATIONS: Location[] = [
     type: 'sales',
     status: 'operational',
     description: 'European sales and customer support hub',
+    salesRep: {
+      name: 'Mike Moss',
+      territory: 'Western Europe',
+    },
   },
 
   // === SALES REPRESENTATIVE LOCATIONS ===

--- a/web/src/lib/constants/locations.ts
+++ b/web/src/lib/constants/locations.ts
@@ -106,43 +106,54 @@ export const BAPI_LOCATIONS: Location[] = [
     description: 'European sales and customer support hub',
   },
 
-  // TODO: Add sales staff locations (awaiting data from Mike Moss)
-  // Per Mike Moss: "include the locations of our sales staff"
-  // Example structure:
-  // {
-  //   id: 'sales-rep-midwest',
-  //   name: 'Midwest Sales Representative',
-  //   city: 'Chicago',
-  //   region: 'Illinois',
-  //   country: 'USA',
-  //   coordinates: [-87.6298, 41.8781],
-  //   type: 'sales',
-  //   status: 'operational',
-  //   description: 'Midwest territory sales and support',
-  //   salesRep: {
-  //     name: 'John Doe',
-  //     territory: 'IL, WI, MI, IN, OH',
-  //   },
-  // },
+  // === SALES REPRESENTATIVE LOCATIONS ===
+  {
+    id: 'sales-rep-uae',
+    name: 'Middle East & South Asia Sales',
+    city: 'Dubai',
+    region: 'Dubai',
+    country: 'United Arab Emirates',
+    coordinates: [55.2708, 25.2048], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'Middle East, Turkey & South Asia regional sales',
+    salesRep: {
+      name: 'Murtaza Kalabhai',
+      territory: 'Middle East, Turkey & South Asia',
+    },
+  },
+  {
+    id: 'sales-rep-australia',
+    name: 'Asia-Pacific Sales',
+    city: 'Sydney',
+    region: 'New South Wales',
+    country: 'Australia',
+    coordinates: [151.2093, -33.8688], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'Asia-Pacific regional sales',
+    salesRep: {
+      name: 'Andy Brooks',
+      territory: 'Asia, Australia & Pacific',
+    },
+  },
+  {
+    id: 'sales-rep-newzealand',
+    name: 'New Zealand Sales',
+    city: 'Auckland',
+    region: 'Auckland',
+    country: 'New Zealand',
+    coordinates: [174.7633, -36.8485], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'New Zealand regional sales',
+    salesRep: {
+      name: 'Andy Brooks',
+      territory: 'Asia, Australia & Pacific',
+    },
+  },
 
   // TODO: Add distribution partner locations (awaiting data from Mike Moss)
-  // Per Mike Moss: "possibly even distribution partners"
-  // Example structure:
-  // {
-  //   id: 'partner-germany',
-  //   name: 'European Distribution Partner',
-  //   city: 'Munich',
-  //   region: 'Bavaria',
-  //   country: 'Germany',
-  //   coordinates: [11.5820, 48.1351],
-  //   type: 'distribution-partner',
-  //   status: 'operational',
-  //   description: 'Authorized distributor for Central Europe',
-  //   partner: {
-  //     companyName: 'Example GmbH',
-  //     website: 'https://example.com',
-  //   },
-  // },
 ];
 
 /**

--- a/web/src/lib/constants/locations.ts
+++ b/web/src/lib/constants/locations.ts
@@ -54,6 +54,7 @@ export interface Location {
  */
 export const BAPI_LOCATIONS: Location[] = [
   // === HEADQUARTERS ===
+  // BAPI map shows both the HQ marker AND a Business Dev person marker here
   {
     id: 'headquarters-usa',
     name: 'Global Headquarters',
@@ -65,6 +66,21 @@ export const BAPI_LOCATIONS: Location[] = [
     status: 'operational',
     description: 'Corporate headquarters and primary manufacturing facility',
     established: '1993',
+  },
+  {
+    id: 'sales-rep-usa',
+    name: 'North America Sales',
+    city: 'Gays Mills',
+    region: 'Wisconsin',
+    country: 'USA',
+    coordinates: [-90.8543, 43.3297], // [lng, lat]
+    type: 'sales',
+    status: 'operational',
+    description: 'North America regional sales',
+    salesRep: {
+      name: 'Matt Holder',
+      territory: 'North America',
+    },
   },
 
   // === MANUFACTURING & OFFICE FACILITIES ===

--- a/web/src/lib/constants/locations.ts
+++ b/web/src/lib/constants/locations.ts
@@ -165,28 +165,24 @@ export const BAPI_LOCATIONS: Location[] = [
  * - Added 'distribution-partner' for third-party distributors
  */
 export const FACILITY_TYPE_LABELS: Record<FacilityType, string> = {
-  headquarters: 'Headquarters',
-  manufacturing: 'Manufacturing & Office',
-  sales: 'Sales Office',
+  headquarters: 'BAPI Headquarters',
+  manufacturing: 'Factory Distribution Center',
+  sales: 'Business Development & Regional Sales',
   'distribution-partner': 'Distribution Partner',
 };
 
 /**
- * Facility type colors for map markers
- *
- * Per Mike Moss: All manufacturing facilities (Poland, Vietnam) use same color
- *
- * Color palette:
- * - Blue (#166fb9): BAPI primary (Web/Digital) - headquarters
- * - Green (#10B981): Manufacturing facilities (consistent color for all)
- * - Yellow (#FFC843): BAPI accent - sales offices
- * - Gray (#6B7280): Distribution partners
+ * Facility type colors for map markers — matches BAPI internal world map legend:
+ * - Blue (#166fb9): BAPI Headquarters (pulsing blue badge)
+ * - Gray (#6B7280): Factory Distribution Center (grey arrow badge)
+ * - Blue-400 (#60A5FA): Business Development & Regional Sales (blue person badge)
+ * - Gray-400 (#9CA3AF): Distribution Partners
  */
 export const FACILITY_TYPE_COLORS: Record<FacilityType, string> = {
-  headquarters: '#166fb9', // BAPI Blue (Web/Digital) - primary facility
-  manufacturing: '#10B981', // Green-500 - all manufacturing (Poland + Vietnam same)
-  sales: '#FFC843', // BAPI Yellow - sales offices
-  'distribution-partner': '#6B7280', // Gray-500 - third-party partners
+  headquarters: '#166fb9', // BAPI Blue — pulsing HQ badge
+  manufacturing: '#6B7280', // Gray-500 — Factory Distribution Center grey arrow
+  sales: '#60A5FA',         // Blue-400 — Business Development & Regional Sales person
+  'distribution-partner': '#9CA3AF', // Gray-400 — third-party partners
 };
 
 /**

--- a/web/src/lib/constants/salesRegions.ts
+++ b/web/src/lib/constants/salesRegions.ts
@@ -123,7 +123,7 @@ export const SALES_REGIONS: SalesRegion[] = [
     id: 7,
     name: 'West & Central Africa',
     repId: 'john-shields',
-    description: 'West & Central Africa (Morocco, Algeria, Libya & sub-Saharan west)',
+    description: 'West & Central Africa (North Africa incl. Egypt, Morocco, Algeria & Libya; sub-Saharan west)',
   },
   {
     id: 8,
@@ -135,7 +135,7 @@ export const SALES_REGIONS: SalesRegion[] = [
     id: 9,
     name: 'Middle East & Turkey',
     repId: 'murtaza-kalabhai',
-    description: 'Turkey, Arabian Peninsula, Levant, Iran, Egypt, Caucasus, Kazakhstan & Pakistan',
+    description: 'Turkey, Arabian Peninsula, Levant, Iran, Caucasus, Kazakhstan & Pakistan',
   },
   {
     id: 10,
@@ -287,6 +287,7 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   Algeria: 7,
   Tunisia: 7,
   Libya: 7,
+  Egypt: 7,
   'W. Sahara': 7,
   Mauritania: 7,
   Mali: 7,
@@ -345,7 +346,6 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   // ── Region 9: Middle East, Turkey & Caucasus ────────────────────────────
   Turkey: 9,
   Cyprus: 9,
-  Egypt: 9,
   'Saudi Arabia': 9,
   Yemen: 9,
   Oman: 9,

--- a/web/src/lib/constants/salesRegions.ts
+++ b/web/src/lib/constants/salesRegions.ts
@@ -11,20 +11,20 @@
  *
  * Regions:
  *  1  – North America          (Matt Holder)
- *  2  – South America          (John Shields)
- *  3  – Scandinavia & Baltic   (John Shields)
+ *  2  – Latin America          (John Shields)
+ *  3  – Scandinavia            (John Shields)
  *  4  – Western Europe         (Mike Moss)
  *  5  – Central Europe         (Jan Zurawski)
  *  6  – Eastern Europe/Balkans (Jan Zurawski)
  *  7  – West & Central Africa  (John Shields)
  *  8  – East & Southern Africa (John Shields)
  *  9  – Middle East & Turkey   (Murtaza Kalabhai)
- * 10  – South Asia             (Murtaza Kalabhai)
+ * 10  – South Asia & Myanmar   (Murtaza Kalabhai)
  * 11  – China & Mongolia       (Andy Brooks)
  * 12  – East Asia              (Andy Brooks)
  * 13  – Southeast Asia         (Andy Brooks)
  * 14  – Australia & Pacific    (Andy Brooks)
- * 15  – Russia & Kazakhstan    (John Shields)
+ * 15  – Russia                 (John Shields)
  */
 
 export interface SalesRep {
@@ -87,37 +87,37 @@ export const SALES_REGIONS: SalesRegion[] = [
     id: 1,
     name: 'North America',
     repId: 'matt-holder',
-    description: 'USA, Canada, Mexico & Caribbean',
+    description: 'USA & Canada',
   },
   {
     id: 2,
-    name: 'South America',
+    name: 'Latin America',
     repId: 'john-shields',
-    description: 'All South American countries',
+    description: 'Mexico, Central America, Caribbean & South America',
   },
   {
     id: 3,
-    name: 'Scandinavia & Baltic',
+    name: 'Scandinavia',
     repId: 'john-shields',
-    description: 'Norway, Sweden, Finland, Denmark, Iceland, Greenland & Baltic States',
+    description: 'Norway, Sweden, Finland, Denmark, Iceland, Greenland & Faroe Islands',
   },
   {
     id: 4,
     name: 'Western Europe',
     repId: 'mike-moss',
-    description: 'UK, Ireland, France, Benelux, Spain & Portugal',
+    description: 'UK, Ireland, France, Spain & Portugal',
   },
   {
     id: 5,
     name: 'Central Europe',
     repId: 'jan-zurawski',
-    description: 'Germany, Austria, Switzerland, Italy, Czech Republic, Slovakia & Slovenia',
+    description: 'Germany, Austria, Switzerland, Italy, Benelux, Czech Republic, Slovakia & Slovenia',
   },
   {
     id: 6,
     name: 'Eastern Europe & Balkans',
     repId: 'jan-zurawski',
-    description: 'Poland, Ukraine, Belarus, Hungary, Romania, Bulgaria & the Balkans',
+    description: 'Poland, Ukraine, Baltic States, Hungary, Romania, Bulgaria & the Balkans',
   },
   {
     id: 7,
@@ -135,13 +135,13 @@ export const SALES_REGIONS: SalesRegion[] = [
     id: 9,
     name: 'Middle East & Turkey',
     repId: 'murtaza-kalabhai',
-    description: 'Turkey, Arabian Peninsula, Levant, Iran, Egypt & Caucasus',
+    description: 'Turkey, Arabian Peninsula, Levant, Iran, Egypt, Caucasus, Kazakhstan & Pakistan',
   },
   {
     id: 10,
     name: 'South Asia',
     repId: 'murtaza-kalabhai',
-    description: 'India, Pakistan, Bangladesh, Sri Lanka & Nepal',
+    description: 'India, Bangladesh, Sri Lanka, Nepal & Myanmar',
   },
   {
     id: 11,
@@ -169,9 +169,9 @@ export const SALES_REGIONS: SalesRegion[] = [
   },
   {
     id: 15,
-    name: 'Russia & Kazakhstan',
+    name: 'Russia',
     repId: 'john-shields',
-    description: 'Russia & Kazakhstan',
+    description: 'Russia & Belarus',
   },
 ];
 
@@ -185,30 +185,33 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   // ── Region 1: North America ──────────────────────────────────────────────
   'United States of America': 1,
   Canada: 1,
-  Mexico: 1,
-  Guatemala: 1,
-  Belize: 1,
-  Honduras: 1,
-  'El Salvador': 1,
-  Nicaragua: 1,
-  'Costa Rica': 1,
-  Panama: 1,
-  Cuba: 1,
-  Jamaica: 1,
-  Haiti: 1,
-  'Dominican Rep.': 1,
-  'Puerto Rico': 1,
-  'Trinidad and Tobago': 1,
-  Bahamas: 1,
-  Barbados: 1,
-  'Antigua and Barb.': 1,
-  'St. Kitts and Nevis': 1,
-  Grenada: 1,
-  'St. Vincent and the Grenadines': 1,
-  Dominica: 1,
-  'St. Lucia': 1,
 
-  // ── Region 2: South America ──────────────────────────────────────────────
+  // ── Region 2: Latin America ───────────────────────────────────────────────
+  // Central America & Mexico
+  Mexico: 2,
+  Guatemala: 2,
+  Belize: 2,
+  Honduras: 2,
+  'El Salvador': 2,
+  Nicaragua: 2,
+  'Costa Rica': 2,
+  Panama: 2,
+  // Caribbean
+  Cuba: 2,
+  Jamaica: 2,
+  Haiti: 2,
+  'Dominican Rep.': 2,
+  'Puerto Rico': 2,
+  'Trinidad and Tobago': 2,
+  Bahamas: 2,
+  Barbados: 2,
+  'Antigua and Barb.': 2,
+  'St. Kitts and Nevis': 2,
+  Grenada: 2,
+  'St. Vincent and the Grenadines': 2,
+  Dominica: 2,
+  'St. Lucia': 2,
+  // South America
   Brazil: 2,
   Argentina: 2,
   Chile: 2,
@@ -225,35 +228,32 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   'French Guiana': 2,
   'Falkland Is.': 2,
 
-  // ── Region 3: Scandinavia, Baltic & Greenland ──────────────────────────────
+  // ── Region 3: Scandinavia & Greenland ──────────────────────────────────────
   Norway: 3,
   Sweden: 3,
   Finland: 3,
   Denmark: 3,
   Iceland: 3,
   Greenland: 3,
-  Estonia: 3,
-  Latvia: 3,
-  Lithuania: 3,
   'Faroe Is.': 3,
 
-  // ── Region 4: Western Europe (UK, Ireland, France, Iberia, Benelux) ───────
+  // ── Region 4: Western Europe (UK, Ireland, France & Iberia) ──────────────
   'United Kingdom': 4,
   Ireland: 4,
   France: 4,
-  Netherlands: 4,
-  Belgium: 4,
-  Luxembourg: 4,
   Spain: 4,
   Portugal: 4,
   Andorra: 4,
   Monaco: 4,
 
-  // ── Region 5: Central Europe (German-speaking + Italy cluster) ───────────
+  // ── Region 5: Central Europe (German-speaking, Benelux + Italy cluster) ──
   Germany: 5,
   Austria: 5,
   Switzerland: 5,
   Liechtenstein: 5,
+  Netherlands: 5,
+  Belgium: 5,
+  Luxembourg: 5,
   Italy: 5,
   Slovenia: 5,
   Czechia: 5,
@@ -263,7 +263,6 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   // ── Region 6: Eastern Europe & Balkans ────────────────────────────────────
   Poland: 6,
   Ukraine: 6,
-  Belarus: 6,
   Moldova: 6,
   Romania: 6,
   Bulgaria: 6,
@@ -278,6 +277,10 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   Kosovo: 6,
   Greece: 6,
   Malta: 6,
+  // Baltic States
+  Estonia: 6,
+  Latvia: 6,
+  Lithuania: 6,
 
   // ── Region 7: West & Central Africa (incl. North Africa) ─────────────────
   Morocco: 7,
@@ -362,20 +365,22 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   Georgia: 9,
   Armenia: 9,
   Azerbaijan: 9,
-  // Central Asian stans (dark red on map, not purple Russia zone)
+  // Central Asian stans
   Uzbekistan: 9,
   Turkmenistan: 9,
   Kyrgyzstan: 9,
   Tajikistan: 9,
+  Kazakhstan: 9,
+  Pakistan: 9,
 
-  // ── Region 10: South Asia ─────────────────────────────────────────────────
+  // ── Region 10: South Asia & Myanmar ──────────────────────────────────────
   India: 10,
-  Pakistan: 10,
   Bangladesh: 10,
   'Sri Lanka': 10,
   Nepal: 10,
   Bhutan: 10,
   Maldives: 10,
+  Myanmar: 10,
 
   // ── Region 11: China & Mongolia ───────────────────────────────────────────
   China: 11,
@@ -396,7 +401,6 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   Singapore: 13,
   Indonesia: 13,
   Philippines: 13,
-  Myanmar: 13,
   Cambodia: 13,
   Laos: 13,
   Brunei: 13,
@@ -412,9 +416,9 @@ export const COUNTRY_TO_REGION: Record<string, number> = {
   Fiji: 14,
   'New Caledonia': 14,
 
-  // ── Region 15: Russia & Kazakhstan ─────────────────────────────────────
+  // ── Region 15: Russia ───────────────────────────────────────────────────
   Russia: 15,
-  Kazakhstan: 15,
+  Belarus: 15,
 };
 
 /** Look up a SalesRep by their id. */


### PR DESCRIPTION
Per Christian Ellefson's feedback (Asana):

- Mexico, Central America & Caribbean → Latin America (region 2) Region 2 renamed 'Latin America', description updated to cover Mexico, Central America, Caribbean & South America. Region 1 (North America) now USA & Canada only.

- Benelux (Netherlands, Belgium, Luxembourg) → Central Europe (region 5) Moved from Western Europe (region 4) per feedback.

- Baltic States (Estonia, Latvia, Lithuania) → Eastern Europe (region 6) Moved from Scandinavia (region 3). Region 3 renamed 'Scandinavia'.

- Belarus → Russia (region 15) Moved from Eastern Europe (region 6). Region 15 renamed 'Russia', description updated to 'Russia & Belarus'.

- Kazakhstan → Middle East (region 9) Moved from Russia (region 15). Region 9 description updated.

- Pakistan → Middle East (region 9) Moved from South Asia (region 10). Region 9 description updated.

- Myanmar → South Asia (region 10) Moved from Southeast Asia (region 13). Region 10 description updated.

Note: French Guiana (South America overlay) was already fixed in PR #631. Note: Andy Brooks is already assigned to Southeast Asia (region 13) — Tim Wilder was removed in PR #629/630.


