### PR TITLE
fix: replace social media icons with brand SVGs and correct URLs

### DIFF
--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Image from 'next/image';
 import { Link } from '@/lib/navigation';
-import { LinkedinIcon, YoutubeIcon } from '@/lib/icons';
+import { LinkedinIcon, YoutubeIcon, FacebookIcon } from '@/lib/icons';
 import { useTranslations, useLocale } from 'next-intl';
 
 // Footer sections now use translation keys - next-intl format
@@ -56,13 +56,18 @@ const getFooterSections = (t: any) => [
 const social = [
   {
     name: 'LinkedIn',
-    href: 'https://www.linkedin.com/company/bapi-building-automation-products-inc-/',
+    href: 'https://www.linkedin.com/company/bapi',
     icon: LinkedinIcon,
   },
   {
     name: 'YouTube',
-    href: 'https://www.youtube.com/@BAPIInc',
+    href: 'https://www.youtube.com/user/BAPIHVAC',
     icon: YoutubeIcon,
+  },
+  {
+    name: 'Facebook',
+    href: 'https://www.facebook.com/bapihvac',
+    icon: FacebookIcon,
   },
 ];
 

--- a/web/src/lib/icons.ts
+++ b/web/src/lib/icons.ts
@@ -137,27 +137,60 @@ const QrCode = createMaterialSymbolIcon('qr_code', 'QrCode');
 const Key = createMaterialSymbolIcon('key', 'Key');
 const Smartphone = createMaterialSymbolIcon('smartphone', 'Smartphone');
 
-// Social & Utility — LinkedIn and YouTube use official brand SVGs, not Material Symbols
-const YouTube = ({ className, ...props }: React.SVGProps<SVGSVGElement>) =>
+// Social & Utility — LinkedIn, YouTube, Facebook use official brand SVGs, not Material Symbols
+const YouTube = ({ className, 'aria-label': ariaLabel, ...props }: React.SVGProps<SVGSVGElement>) =>
   React.createElement(
     'svg',
-    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', className, ...props },
+    {
+      xmlns: 'http://www.w3.org/2000/svg',
+      viewBox: '0 0 24 24',
+      fill: 'currentColor',
+      width: '1em',
+      height: '1em',
+      'aria-hidden': ariaLabel ? undefined : true,
+      'aria-label': ariaLabel,
+      role: ariaLabel ? 'img' : undefined,
+      className,
+      ...props,
+    },
     React.createElement('path', {
       d: 'M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z',
     })
   );
-const LinkedIn = ({ className, ...props }: React.SVGProps<SVGSVGElement>) =>
+const LinkedIn = ({ className, 'aria-label': ariaLabel, ...props }: React.SVGProps<SVGSVGElement>) =>
   React.createElement(
     'svg',
-    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', className, ...props },
+    {
+      xmlns: 'http://www.w3.org/2000/svg',
+      viewBox: '0 0 24 24',
+      fill: 'currentColor',
+      width: '1em',
+      height: '1em',
+      'aria-hidden': ariaLabel ? undefined : true,
+      'aria-label': ariaLabel,
+      role: ariaLabel ? 'img' : undefined,
+      className,
+      ...props,
+    },
     React.createElement('path', {
       d: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
     })
   );
-const Facebook = ({ className, ...props }: React.SVGProps<SVGSVGElement>) =>
+const Facebook = ({ className, 'aria-label': ariaLabel, ...props }: React.SVGProps<SVGSVGElement>) =>
   React.createElement(
     'svg',
-    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', className, ...props },
+    {
+      xmlns: 'http://www.w3.org/2000/svg',
+      viewBox: '0 0 24 24',
+      fill: 'currentColor',
+      width: '1em',
+      height: '1em',
+      'aria-hidden': ariaLabel ? undefined : true,
+      'aria-label': ariaLabel,
+      role: ariaLabel ? 'img' : undefined,
+      className,
+      ...props,
+    },
     React.createElement('path', {
       d: 'M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z',
     })

--- a/web/src/lib/icons.ts
+++ b/web/src/lib/icons.ts
@@ -16,6 +16,7 @@
  * import { ShoppingCartIcon, CheckIcon } from '@/lib/icons';
  */
 
+import React from 'react';
 import { createMaterialSymbolIcon } from '@/components/icons/MaterialSymbol';
 
 // Create Material Symbol icon components using Google's snake_case naming
@@ -136,9 +137,31 @@ const QrCode = createMaterialSymbolIcon('qr_code', 'QrCode');
 const Key = createMaterialSymbolIcon('key', 'Key');
 const Smartphone = createMaterialSymbolIcon('smartphone', 'Smartphone');
 
-// Social & Utility
-const YouTube = createMaterialSymbolIcon('youtube_activity', 'YouTube');
-const LinkedIn = createMaterialSymbolIcon('linked_services', 'LinkedIn');
+// Social & Utility — LinkedIn and YouTube use official brand SVGs, not Material Symbols
+const YouTube = ({ className, ...props }: React.SVGProps<SVGSVGElement>) =>
+  React.createElement(
+    'svg',
+    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', className, ...props },
+    React.createElement('path', {
+      d: 'M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z',
+    })
+  );
+const LinkedIn = ({ className, ...props }: React.SVGProps<SVGSVGElement>) =>
+  React.createElement(
+    'svg',
+    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', className, ...props },
+    React.createElement('path', {
+      d: 'M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z',
+    })
+  );
+const Facebook = ({ className, ...props }: React.SVGProps<SVGSVGElement>) =>
+  React.createElement(
+    'svg',
+    { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 24 24', fill: 'currentColor', className, ...props },
+    React.createElement('path', {
+      d: 'M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z',
+    })
+  );
 const Language = createMaterialSymbolIcon('language', 'Language');
 const Public = createMaterialSymbolIcon('public', 'Public');
 const Logout = createMaterialSymbolIcon('logout', 'Logout');
@@ -336,6 +359,7 @@ export { Smartphone as SmartphoneIcon };
 // Social & Utility Icons
 export { YouTube as YoutubeIcon };
 export { LinkedIn as LinkedinIcon };
+export { Facebook as FacebookIcon };
 export { Language as LanguagesIcon };
 export { Public as GlobeIcon };
 export { Logout as LogOutIcon };

--- a/web/src/stories/DesignSystem/Icons.stories.tsx
+++ b/web/src/stories/DesignSystem/Icons.stories.tsx
@@ -105,6 +105,7 @@ import {
   ThumbsDownIcon,
   LinkedinIcon,
   YoutubeIcon,
+  FacebookIcon,
 } from '@/lib/icons';
 
 const meta: Meta = {
@@ -125,7 +126,7 @@ export default meta;
 type Story = StoryObj;
 
 // Icon registry organized by category
-const icons = {
+const icons: Record<string, Array<{ name: string; icon: React.ElementType; usage: string }>> = {
   Navigation: [
     { name: 'Menu', icon: MenuIcon, usage: 'Mobile menu toggle' },
     { name: 'X', icon: XIcon, usage: 'Close buttons, remove items' },
@@ -236,6 +237,7 @@ const icons = {
     { name: 'ThumbsDown', icon: ThumbsDownIcon, usage: 'Dislike/not helpful' },
     { name: 'Linkedin', icon: LinkedinIcon, usage: 'LinkedIn social link' },
     { name: 'Youtube', icon: YoutubeIcon, usage: 'YouTube social link' },
+    { name: 'Facebook', icon: FacebookIcon, usage: 'Facebook social link' },
   ],
 };
 


### PR DESCRIPTION
- Replace Material Symbol placeholder icons with official LinkedIn, YouTube, and Facebook brand SVGs
- Fix LinkedIn URL (bapi-building-automation-products-inc- → bapi)
- Fix YouTube URL (@BAPIInc → user/BAPIHVAC)
- Add Facebook link (facebook.com/bapihvac)
- Update Icons.stories.tsx with FacebookIcon and explicit React.ElementType typing


