### PR TITLE
fix: update footer brand copy below logo

### DIFF
--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -232,8 +232,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "حلول استشعار الدقة لأتمتة المباني",
-      "description": "يثق بها المهندسون في جميع أنحاء العالم للمرافق الحرجة منذ عام 1993"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -394,8 +394,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "Präzisionssensorlösungen für die Gebäudeautomation",
-      "description": "Seit 1993 weltweit von Ingenieuren für lebensnotwendige Einrichtungen vertraut"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -940,8 +940,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "Precision Sensor Solutions for Building Automation",
-      "description": "Trusted by engineers worldwide for mission-critical facilities since 1993"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -232,8 +232,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "Soluciones de sensores de precisión para la automatización de edificios",
-      "description": "Confiado por ingenieros de todo el mundo para instalaciones críticas desde 1993"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -232,8 +232,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "Solutions de capteurs de précision pour l'automatisation des bâtiments",
-      "description": "Approuvé par les ingénieurs du monde entier pour les installations critiques depuis 1993"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/hi.json
+++ b/web/messages/hi.json
@@ -433,8 +433,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "भवन स्वचालन के लिए सटीक सेंसर समाधान",
-      "description": "1993 से मिशन-महत्वपूर्ण सुविधाओं के लिए दुनिया भर के इंजीनियरों द्वारा विश्वसनीय"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -232,8 +232,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "建築オートメーションのための精密センサーソリューション",
-      "description": "1993年以来、世界中のエンジニアに信頼されている重要施設向け"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -433,8 +433,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "Precyzyjne rozwiązania sensorowe dla automatyki budynkowej",
-      "description": "Zaufane na całym świecie przez inżynierów obiektów o kluczowym znaczeniu od 1993 roku"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -433,8 +433,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "ระบบอัตโนมัติอาคารด้วยเซ็นเซอร์แม่นยำ",
-      "description": "เชื่อถือได้จากวิศวกรทั่วโลกสำหรับสิ่งอำนวยความสะดวกที่สำคัญมาตั้งแต่ปี 1993"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/vi.json
+++ b/web/messages/vi.json
@@ -439,8 +439,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "Các giải pháp cảm biến chính xác cho Tự động hóa Tòa nhà",
-      "description": "Được các kỹ sư trên toàn thế giới tin tưởng sử dụng cho các cơ sở quan trọng kể từ năm 1993"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -232,8 +232,8 @@
   },
   "footer": {
     "brand": {
-      "tagline": "建筑自动化精密传感器解决方案",
-      "description": "自1993年以来深受全球工程师信赖的关键设施"
+      "tagline": "Changing the way you think about sensors since 1993",
+      "description": "People. Building. Sensors"
     },
     "sections": {
       "products": {


### PR DESCRIPTION
- Tagline: 'Changing the way you think about sensors since 1993'
- Description: 'People. Building. Sensors'
- English brand phrases kept across all 11 locales (same pattern as 'Another BAPI Original' / 'BAPI-Backed' in the hero)

