### PR TITLE
fix: remove BACnet B-ASC from certifications

### DIFF
--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -289,7 +289,6 @@
     },
     "certifications": {
       "title": "الشهادات",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "قائمة UL",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -451,7 +451,6 @@
     },
     "certifications": {
       "title": "Zertifizierungen",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "UL aufgelistet",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1003,7 +1003,6 @@
     },
     "certifications": {
       "title": "Certifications",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "UL Listed",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -289,7 +289,6 @@
     },
     "certifications": {
       "title": "Certificaciones",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "Listado UL",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -289,7 +289,6 @@
     },
     "certifications": {
       "title": "Certifications",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "Répertorié UL",

--- a/web/messages/hi.json
+++ b/web/messages/hi.json
@@ -490,7 +490,6 @@
     },
     "certifications": {
       "title": "प्रमाणीकरण",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "UL सूचीबद्ध",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -289,7 +289,6 @@
     },
     "certifications": {
       "title": "認証",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "UL 認定",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -490,7 +490,6 @@
     },
     "certifications": {
       "title": "Certyfikaty",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "Lista UL",

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -490,7 +490,6 @@
     },
     "certifications": {
       "title": "การรับรอง",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "ได้รับการรับรอง UL",

--- a/web/messages/vi.json
+++ b/web/messages/vi.json
@@ -496,7 +496,6 @@
     },
     "certifications": {
       "title": "Chứng nhận",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "Đăng ký UL",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -289,7 +289,6 @@
     },
     "certifications": {
       "title": "认证",
-      "bacnet": "BACnet B-ASC",
       "iso": "ISO 9001:2015",
       "ce": "CE EN 61326-1:2013 EMC",
       "ul": "UL列表",

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -282,7 +282,6 @@ const Footer: React.FC = () => {
 
               {/* Text Certifications */}
               <div className="space-y-1.5 text-sm font-medium text-neutral-700">
-                <p className="font-semibold text-neutral-900">{t('certifications.bacnet')}</p>
                 <p className="font-semibold text-neutral-900">{t('certifications.iso')}</p>
                 <p className="font-semibold text-neutral-900">{t('certifications.ce')}</p>
               </div>


### PR DESCRIPTION
BAPI does not hold BACnet certifications. Removed the bacnet key from all locale message files and the Footer certification display.


